### PR TITLE
DOC-4603: Update JDK and OpenJDK Compatibility

### DIFF
--- a/modules/ROOT/pages/compatibility-versions-features.adoc
+++ b/modules/ROOT/pages/compatibility-versions-features.adoc
@@ -137,14 +137,22 @@ IMPORTANT: With xref:sdk-authentication-overview.adoc[RBAC], in Couchbase Server
 [#jdk-compat]
 == JDK Version Compatibility
 
-The Java SDK is tested with the Oracle JDK which should be used for best experience and supportability.
-Other JDK implementations might work but are  not tested and are unsupported.
+The Java SDK is tested with Oracle JDK and OpenJDK.  Other JDK implementations might work but are not tested and are unsupported.
 
-The following Oracle JDKs are supported for *Java SDK 1.4 and 2.0 - 2.7*:
+Starting with Java SDK release 2.7.2, the following JDK releases are supported:
 
-* Oracle JDK 1.6
+* OpenJDK 11 with HotSpot JVM (recommended)
+* Oracle JDK 11 (recommended)
+* OpenJDK 1.8 with HotSpot JVM
+* Oracle JDK 1.8
 * Oracle JDK 1.7
-* Oracle JDK 1.8 (recommended)
+* Oracle JDK 1.6 (Extended Support from Oracle https://www.oracle.com/technetwork/java/java-se-support-roadmap.html[ended December 2018])
+
+The following Oracle JDK releases are supported for Java SDK 1.4 and 2.0 through 2.7.1 inclusive:
+
+* Oracle JDK 1.8
+* Oracle JDK 1.7
+* Oracle JDK 1.6 (Extended Support from Oracle https://www.oracle.com/technetwork/java/java-se-support-roadmap.html[ended December 2018])
 
 Please make sure you run on one of the latest patch releases, since they provide stability improvements and security fixes in general.
 

--- a/modules/ROOT/pages/compatibility-versions-features.adoc
+++ b/modules/ROOT/pages/compatibility-versions-features.adoc
@@ -137,7 +137,8 @@ IMPORTANT: With xref:sdk-authentication-overview.adoc[RBAC], in Couchbase Server
 [#jdk-compat]
 == JDK Version Compatibility
 
-The Java SDK is tested with Oracle JDK and OpenJDK.  Other JDK implementations might work but are not tested and are unsupported.
+The Java SDK is tested with Oracle JDK and OpenJDK.
+Other JDK implementations might work but are not tested and are unsupported.
 
 Starting with Java SDK release 2.7.2, the following JDK releases are supported:
 
@@ -146,13 +147,18 @@ Starting with Java SDK release 2.7.2, the following JDK releases are supported:
 * OpenJDK 1.8 with HotSpot JVM
 * Oracle JDK 1.8
 * Oracle JDK 1.7
-* Oracle JDK 1.6 (Extended Support from Oracle https://www.oracle.com/technetwork/java/java-se-support-roadmap.html[ended December 2018])
 
-The following Oracle JDK releases are supported for Java SDK 1.4 and 2.0 through 2.7.1 inclusive:
+The following Oracle JDK releases are supported for Java SDK 2.7.1:
+
+* Oracle JDK 1.8
+* Oracle JDK 1.7
+
+The following Oracle JDK releases are supported for Java SDK 1.4 and 2.0 through 2.7.0 inclusive:
 
 * Oracle JDK 1.8
 * Oracle JDK 1.7
 * Oracle JDK 1.6 (Extended Support from Oracle https://www.oracle.com/technetwork/java/java-se-support-roadmap.html[ended December 2018])
+
 
 Please make sure you run on one of the latest patch releases, since they provide stability improvements and security fixes in general.
 


### PR DESCRIPTION
Changed docs to reflect JDK 11 as recommendation and support of OpenJDK
both 8 and 11.  Constrained it to HotSpot, since we do not test J9.