### PR TITLE
provided link for MapReduce

### DIFF
--- a/modules/ROOT/pages/core-operations.adoc
+++ b/modules/ROOT/pages/core-operations.adoc
@@ -143,7 +143,7 @@ update `default` SET sale_price = msrp * 0.75 WHERE msrp < 19.95;
 == Retrieving Documents
 
 FASTPATH: This section discusses retrieving documents using their IDs, or primary keys.
-Documents can also be accessed using secondary lookups via xref:n1ql-query.adoc[N1QL queries] and MapReduce.
+Documents can also be accessed using secondary lookups via xref:n1ql-query.adoc[N1QL queries] and xref:view-queries-with-sdk.adoc[MapReduce].
 Primary key lookups are performed using the key-value API, which simplifies use and increases performance (as applications may interact with the KV store directly, rather than a secondary index or query processor).
 
 In Couchbase, documents are stored with their IDs.


### PR DESCRIPTION
Added link for MapReduce documentation at line 146 so that user can go to it directly to Map Reduce doc from here. I have added the hyper link in doc, please review it.
Below is the URL which it should open.
https://docs.couchbase.com/java-sdk/2.7/view-queries-with-sdk.html