### PR TITLE
1.0.1 release.

### DIFF
--- a/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
+++ b/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
@@ -47,7 +47,7 @@ With gradle this can be accomplished by modifying these sections of your build.g
 [source,gradle]
 ----
 dependencies {
-    compile group: 'com.couchbase.client', name: 'couchbase-transactions', version: '1.0.0'
+    compile group: 'com.couchbase.client', name: 'couchbase-transactions', version: '1.0.1'
 }
 ----
 

--- a/modules/project-docs/examples/Transactions.java
+++ b/modules/project-docs/examples/Transactions.java
@@ -1,0 +1,70 @@
+
+import com.couchbase.client.java.Bucket;
+import com.couchbase.client.java.Cluster;
+import com.couchbase.client.java.Collection;
+
+// #tag::imports[]
+// Imports required by this sample
+import com.couchbase.client.java.kv.GetResult;
+import com.couchbase.transactions.TransactionResult;
+import com.couchbase.transactions.Transactions;
+import com.couchbase.transactions.error.TransactionCommitAmbiguous;
+import com.couchbase.transactions.error.TransactionFailed;
+
+import static com.couchbase.client.java.query.QueryOptions.queryOptions;
+// #end::imports[]
+
+class TransactionsDemo {
+    void demo_1_0_1_changes() {
+        Cluster cluster = Cluster.connect("localhost", "Administrator", "password");
+        Bucket bucket = cluster.bucket("default");
+        Collection collection = bucket.defaultCollection();
+        Transactions transactions = Transactions.create(cluster);
+
+        // #tag::demo_1_0_1[]
+        try {
+            TransactionResult result = transactions.run((ctx) -> {
+                // ... transactional code here ...
+            });
+
+            // The transaction definitely reached the commit point. Unstaging
+            // the individual documents may or may not have completed
+
+            if (result.unstagingComplete()) {
+                // Operations with non-transactional actors will want
+                // unstagingComplete() to be true.
+                cluster.query(" ... N1QL ... ",
+                        queryOptions()
+                                .consistentWith(result.mutationState()));
+
+                String documentKey = "a document key involved in the transaction";
+                GetResult getResult = collection.get(documentKey);
+            }
+            else {
+                // This step is completely application-dependent.  It may
+                // need to throw its own exception, if it is crucial that
+                // result.unstagingComplete() is true at this point.
+                // (Recall that the asynchronous cleanup process will
+                // complete the unstaging later on).
+            }
+        }
+        catch (TransactionCommitAmbiguous err) {
+            // The transaction may or may not have reached commit point
+            System.err.println("Transaction returned TransactionCommitAmbiguous and" +
+                    " may have succeeded, logs:");
+
+            // Of course, the application will want to use its own logging rather
+            // than System.err
+            err.result().log().logs().forEach(log -> System.err.println(log.toString()));
+        }
+        catch (TransactionFailed err) {
+            // The transaction definitely did not reach commit point
+            System.err.println("Transaction failed with TransactionFailed, logs:");
+            err.result().log().logs().forEach(log -> System.err.println(log.toString()));
+        }
+        // #end::demo_1_0_1[]
+
+
+        cluster.disconnect();
+    }
+}

--- a/modules/project-docs/pages/distributed-transactions-java-release-notes.adoc
+++ b/modules/project-docs/pages/distributed-transactions-java-release-notes.adoc
@@ -11,6 +11,99 @@ This page features the release notes for that library -- for release notes, down
 See the xref:6.5@server:learn:data/transactions.adoc[Distributed ACID Transactions concept doc] in the server documentation for details of how Couchbase implements transactions.
 The xref:howtos:distributed-acid-transactions-from-the-sdk.adoc[Distributed Transactions HOWTO doc] walks you through all aspects of working with Distributed Transactions.
 
+== Distributed Transactions Java 1.0.1 (19th June 2020)
+This is the second release of Couchbase Distributed ACID Transactions.
+
+It is built on Couchbase java-client version 3.0.5, and requires Couchbase Server 6.5 or above.
+
+It is strongly recommended that all users read the "API Changes" section, as they may desire to make application changes in order to use this newly exposed information.
+
+https://docs.couchbase.com/sdk-api/couchbase-transactions-java-1.0.1/[JavaDocs]
+
+=== API Changes
+
+==== TransactionCommitAmbiguous
+*Summary:* A TransactionCommitAmbiguous exception has been added, and applications may wish to handle it (https://issues.couchbase.com/browse/TXNJ-205[TXNJ-205])
+
+Ambiguity is inevitable in any system, especially a distributed one.
+
+Each transaction has a 'single point of truth' that is updated atomically to reflect whether it is committed.
+
+However, it is not always possible for the protocol to become 100% certain that the operation was successful, before the transaction expires.
+This is important as the transaction may or may not have successfully committed, and in the previous release this was not reported to the application.
+
+The library will now raise a new error, TransactionCommitAmbiguous, to indicate this state.
+TransactionCommitAmbiguous derives from the existing TransactionFailed that applications will already be handling.
+
+On TransactionCommitAmbiguous, the transaction may or may not have reached the commit point.
+If it has reached it, then the transaction will be fully completed ("unstaged") by the asynchronous cleanup process at some point in the future.
+With default settings this will usually be within a minute, but whatever underlying fault has caused the TransactionCommitAmbiguous may lead to it taking longer.
+
+*Handling:* This error can be challenging for an application to handle.
+One simple approach is to retry the transaction at some point in the future.
+Alternatively, if transaction completion time is not a priority, then transaction expiration times can be extended across the board through `TransactionConfigBuilder`.
+This will allow the protocol more time to resolve the ambiguity, if possible.
+
+==== TransactionResult.unstagingComplete()
+*Summary:* Failures during the post-commit unstaging phase can now result in the transaction successfully returning.  A new `TransactionResult.unstagingComplete()` method has been added (https://issues.couchbase.com/browse/TXNJ-209[TXNJ-209]).
+
+As above, there is a 'single point of truth' for a transaction.
+After this atomic commit point is reached, the documents themselves still need to be committed (we also call this "unstaging").
+However, transactionally-aware actors will now be returning the post-transaction versions of the documents, and the transaction is effectively fully committed to those actors.
+
+So if the application is solely working with transaction-aware actors, then the unstaging process is optional.
+The previous release would retry any failures during the unstaging process until the transaction expires, but this unnecessarily penalises applications that do not require unstaging to be completed.
+
+So, many errors during unstaging will now cause the transaction to immediately return success.
+The asynchronous cleanup process will still complete the unstaging process at a later point.
+
+A new `unstagingComplete()` call is added to `TransactionResult` to indicate whether the unstaging process completed successfully or not.
+This should be used any time that the application needs all results of the transaction to be immediately available to non-transactional actors (which currently includes N1QL and non-transactional Key-Value reads).
+
+Putting two API changes above together, the recommendation for error handling of a typical transaction is now this:
+
+[source,java]
+----
+include::example$Transactions.java[tag=imports,indent=0]
+----
+
+[source,java]
+----
+include::example$Transactions.java[tag=demo_1_0_1,indent=0]
+----
+
+=== Bug Fixes and Stability
+* https://issues.couchbase.com/browse/TXNJ-184[TXNJ-184]:
+If doc is found to be removed while committing it, create it.
+* https://issues.couchbase.com/browse/TXNJ-187[TXNJ-187]:
+Errors raised while setting ATR state to Committed are now regarded as pre-commit errors, e.g. they can cause the transaction to fail or retry
+* https://issues.couchbase.com/browse/TXNJ-188[TXNJ-188], https://issues.couchbase.com/browse/TXNJ-192[TXNJ-192]:
+The TransactionResult.attempts() field now always correctly reflects all attempts made
+* https://issues.couchbase.com/browse/TXNJ-196[TXNJ-196]:
+Pre-commit expiry now always triggers rollback
+* https://issues.couchbase.com/browse/TXNJ-197[TXNJ-197]:
+Expiry during app-rollback now enters expiry-overtime-mode and has one more attempt at completing rollback
+* https://issues.couchbase.com/browse/TXNJ-202[TXNJ-202], https://issues.couchbase.com/browse/TXNJ-200[TXNJ-200]:
+FAIL_ATR_FULL now handled consistently throughout protocol
+* https://issues.couchbase.com/browse/TXNJ-210[TXNJ-210]:
+If anything goes wrong during app-rollback, return success. Rollback will be completed by the asynchronous cleanup process, and unrolled-back metadata is handled by the protocol anyway.
+* https://issues.couchbase.com/browse/TXNJ-211[TXNJ-211]:
+If rollback fails, the original error that caused the rollback is the one raised as the `getCause()` of any final exception raised to the application
+* https://issues.couchbase.com/browse/TXNJ-218[TXNJ-218]:
+Inserting the same document in the same transaction is now caught as an application bug, and will fail the transaction
+
+=== Improvements
+* https://issues.couchbase.com/browse/TXNJ-189[TXNJ-189]:
+Adds a transactionId field throughout the metadata, to assist with debugging
+* https://issues.couchbase.com/browse/TXNJ-190[TXNJ-190]:
+Write elided stacktraces in the logs to improve readability
+* https://issues.couchbase.com/browse/TXNJ-191[TXNJ-191], https://issues.couchbase.com/browse/TXNJ-199[TXNJ-199]:
+Performance improvement so that transactions are only rolled back and/or cleaned up if they reached the point of creating an ATR entry (e.g. if there is anything to cleanup)
+* https://issues.couchbase.com/browse/TXNJ-204[TXNJ-204]:
+All context methods, such as ctx.insert and ctx.replace, will now consistently only raise `ErrorWrapper` exceptions.  Applications should not be catching any exceptions from these methods so this is not expected to be impacting.
+* https://issues.couchbase.com/browse/TXNJ-215[TXNJ-215]:
+Adjust exponential backoff retry parameter from 250msecs down to 100msecs
+
 == Distributed Transactions Java 1.0.0 (17th January 2020)
 This is the first General Availability (GA) release of Distributed ACID Transactions 1.0.0 for Couchbase Server 6.5.
 

--- a/modules/project-docs/pages/distributed-transactions-java-release-notes.adoc
+++ b/modules/project-docs/pages/distributed-transactions-java-release-notes.adoc
@@ -11,7 +11,7 @@ This page features the release notes for that library -- for release notes, down
 See the xref:6.5@server:learn:data/transactions.adoc[Distributed ACID Transactions concept doc] in the server documentation for details of how Couchbase implements transactions.
 The xref:howtos:distributed-acid-transactions-from-the-sdk.adoc[Distributed Transactions HOWTO doc] walks you through all aspects of working with Distributed Transactions.
 
-== Distributed Transactions Java 1.0.1 (19th June 2020)
+== Distributed Transactions Java 1.0.1 (19 June 2020)
 This is the second release of Couchbase Distributed ACID Transactions.
 
 It is built on Couchbase java-client version 3.0.5, and requires Couchbase Server 6.5 or above.
@@ -23,7 +23,7 @@ https://docs.couchbase.com/sdk-api/couchbase-transactions-java-1.0.1/[JavaDocs]
 === API Changes
 
 ==== TransactionCommitAmbiguous
-*Summary:* A TransactionCommitAmbiguous exception has been added, and applications may wish to handle it (https://issues.couchbase.com/browse/TXNJ-205[TXNJ-205])
+*Summary:* A TransactionCommitAmbiguous exception has been added, and applications may wish to handle it (https://issues.couchbase.com/browse/TXNJ-205[TXNJ-205]).
 
 Ambiguity is inevitable in any system, especially a distributed one.
 
@@ -76,35 +76,37 @@ include::example$Transactions.java[tag=demo_1_0_1,indent=0]
 * https://issues.couchbase.com/browse/TXNJ-184[TXNJ-184]:
 If doc is found to be removed while committing it, create it.
 * https://issues.couchbase.com/browse/TXNJ-187[TXNJ-187]:
-Errors raised while setting ATR state to Committed are now regarded as pre-commit errors, e.g. they can cause the transaction to fail or retry
+Errors raised while setting ATR state to Committed are now regarded as pre-commit errors, e.g. they can cause the transaction to fail or retry.
 * https://issues.couchbase.com/browse/TXNJ-188[TXNJ-188], https://issues.couchbase.com/browse/TXNJ-192[TXNJ-192]:
-The TransactionResult.attempts() field now always correctly reflects all attempts made
+The TransactionResult.attempts() field now always correctly reflects all attempts made.
 * https://issues.couchbase.com/browse/TXNJ-196[TXNJ-196]:
-Pre-commit expiry now always triggers rollback
+Pre-commit expiry now always triggers rollback.
 * https://issues.couchbase.com/browse/TXNJ-197[TXNJ-197]:
-Expiry during app-rollback now enters expiry-overtime-mode and has one more attempt at completing rollback
+Expiry during app-rollback now enters expiry-overtime-mode and has one more attempt at completing rollback.
 * https://issues.couchbase.com/browse/TXNJ-202[TXNJ-202], https://issues.couchbase.com/browse/TXNJ-200[TXNJ-200]:
-FAIL_ATR_FULL now handled consistently throughout protocol
+FAIL_ATR_FULL now handled consistently throughout protocol.
 * https://issues.couchbase.com/browse/TXNJ-210[TXNJ-210]:
-If anything goes wrong during app-rollback, return success. Rollback will be completed by the asynchronous cleanup process, and unrolled-back metadata is handled by the protocol anyway.
+If anything goes wrong during app-rollback, return success. 
+Rollback will be completed by the asynchronous cleanup process, and unrolled-back metadata is handled by the protocol anyway.
 * https://issues.couchbase.com/browse/TXNJ-211[TXNJ-211]:
-If rollback fails, the original error that caused the rollback is the one raised as the `getCause()` of any final exception raised to the application
+If rollback fails, the original error that caused the rollback is the one raised as the `getCause()` of any final exception raised to the application.
 * https://issues.couchbase.com/browse/TXNJ-218[TXNJ-218]:
-Inserting the same document in the same transaction is now caught as an application bug, and will fail the transaction
+Inserting the same document in the same transaction is now caught as an application bug, and will fail the transaction.
 
 === Improvements
 * https://issues.couchbase.com/browse/TXNJ-189[TXNJ-189]:
-Adds a transactionId field throughout the metadata, to assist with debugging
+Adds a transactionId field throughout the metadata, to assist with debugging.
 * https://issues.couchbase.com/browse/TXNJ-190[TXNJ-190]:
-Write elided stacktraces in the logs to improve readability
+Write elided stacktraces in the logs to improve readability.
 * https://issues.couchbase.com/browse/TXNJ-191[TXNJ-191], https://issues.couchbase.com/browse/TXNJ-199[TXNJ-199]:
-Performance improvement so that transactions are only rolled back and/or cleaned up if they reached the point of creating an ATR entry (e.g. if there is anything to cleanup)
+Performance improvement so that transactions are only rolled back and/or cleaned up if they reached the point of creating an ATR entry (e.g. if there is anything to cleanup).
 * https://issues.couchbase.com/browse/TXNJ-204[TXNJ-204]:
-All context methods, such as ctx.insert and ctx.replace, will now consistently only raise `ErrorWrapper` exceptions.  Applications should not be catching any exceptions from these methods so this is not expected to be impacting.
+All context methods, such as ctx.insert and ctx.replace, will now consistently only raise `ErrorWrapper` exceptions. 
+Applications should not be catching any exceptions from these methods so this is not expected to be impacting.
 * https://issues.couchbase.com/browse/TXNJ-215[TXNJ-215]:
-Adjust exponential backoff retry parameter from 250msecs down to 100msecs
+Adjust exponential backoff retry parameter from 250msecs down to 100msecs.
 
-== Distributed Transactions Java 1.0.0 (17th January 2020)
+== Distributed Transactions Java 1.0.0 (17 January 2020)
 This is the first General Availability (GA) release of Distributed ACID Transactions 1.0.0 for Couchbase Server 6.5.
 
 Built on Couchbase java-client version 3.0.0 (GA).

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>com.couchbase.client</groupId>
             <artifactId>couchbase-transactions</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
         </dependency>
         <dependency>
             <groupId>io.projectreactor.addons</groupId>


### PR DESCRIPTION
Note that the documentation really needs updating to reflect the new additions to the API.
I have this work underway but it's turned into a larger rework than anticipated.  I don't want to block the 1.0.1 release any longer, so those changes will be delivered separately.