### PR TITLE
Update pom.xml

### DIFF
--- a/modules/devguide/examples/java/pom.xml
+++ b/modules/devguide/examples/java/pom.xml
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
+      <version>2.13.3</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
CVE-2019-17571
moderate severity
Vulnerable versions: >= 1.2, <= 1.2.27
Patched version: No fix
Included in Log4j 1.2 is a SocketServer class that is vulnerable to deserialization of untrusted data which can be exploited to remotely execute arbitrary code when combined with a deserialization gadget when listening to untrusted network traffic for log data. This affects Log4j versions up to 1.2 up to 1.2.17.