### PR TITLE
Expanding Compatibility matrix for Java SDK

### DIFF
--- a/modules/project-docs/pages/compatibility.adoc
+++ b/modules/project-docs/pages/compatibility.adoc
@@ -28,11 +28,17 @@ It is best to upgrade either the SDK or the Couchbase version you are using.
 |===
 | | SDK 2.4, 2.5 | SDK 2.6 | SDK 2.7  | SDK 3.0 
 
-| *Server 5.0-5.5*
+| *Server 5.0*
 | *✔*
 | *✔*
 | *✔*
 | *◎*
+
+| *Server 5.5*
+| *✔*
+| *✔*
+| *✔*
+| *✔*
 
 | *Server 6.0*
 | ◎

--- a/modules/project-docs/pages/compatibility.adoc
+++ b/modules/project-docs/pages/compatibility.adoc
@@ -141,5 +141,4 @@ Please make sure that you are using a supported version of the Couchbase Java SD
 Using the latest Spring Data Couchbase should ensure that this is so.
 
 
-
 include::6.5@sdk:shared:partial$interface-stability-pars.adoc[tag=interface-stability-section]


### PR DESCRIPTION
Post eBay discussion it was decided to update the page to show 5.5 as a separate line item and compatible with SDK 3.x