### PR TITLE
JCBC-1714 - Fix migrating-sdk-code-to-3 includes

### DIFF
--- a/modules/howtos/examples/SubDocument.java
+++ b/modules/howtos/examples/SubDocument.java
@@ -268,16 +268,6 @@ class SubDocument {
 
   }
 
-    static void full_doc_replaceFunc() {
-// #tag::full_doc_replace[]
-    JsonObject docContent = JsonObject.create().put("body", "value");
-    collection.mutateIn("doc-id", Arrays.asList(
-        MutateInSpec.upsert("foo", "bar").xattr().createPath(),
-        MutateInSpec.replace("", docContent))
-     );
-// #end::full_doc_replace[]
-    }
-
     static void createAndPopulateArrays() {
     // #tag::array-create[]
     collection.upsert("my_array", JsonArray.create());
@@ -286,7 +276,7 @@ class SubDocument {
         arrayAppend("", Collections.singletonList("some element"))
     ));
     // the document my_array is now ["some element"]
-// #end::array-create[]
+    // #end::array-create[]
     System.out.println("createAndPopulateArrays: my_array some element");
 
   }

--- a/modules/project-docs/examples/MigratingSDKCodeTo3n.java
+++ b/modules/project-docs/examples/MigratingSDKCodeTo3n.java
@@ -51,13 +51,13 @@ public class MigratingSDKCodeTo3n {
   public void migrating_sdk_code_to_3_n_1() throws Exception { // file: project-docs/pages/migrating-sdk-code-to-3.n.adoc line: 23
     // #tag::migrating_sdk_code_to_3_n_1[]
     GetResult getResult = collection.get("key", getOptions().timeout(Duration.ofSeconds(3)));
-    // #end::migrating_sdk_code_to_3_n_1[];
+    // #end::migrating_sdk_code_to_3_n_1[]
   }
 
   public void migrating_sdk_code_to_3_n_2() throws Exception { // file: project-docs/pages/migrating-sdk-code-to-3.n.adoc line: 30
     // #tag::migrating_sdk_code_to_3_n_2[]
     QueryResult queryResult = cluster.query("select 1=1", queryOptions().timeout(Duration.ofSeconds(3)));
-    // #end::migrating_sdk_code_to_3_n_2[];
+    // #end::migrating_sdk_code_to_3_n_2[]
   }
 
   public void migrating_sdk_code_to_3_n_11() throws Exception { // file: project-docs/pages/migrating-sdk-code-to-3.n.adoc line: 160
@@ -69,7 +69,7 @@ public class MigratingSDKCodeTo3n {
     GetResult getResult = bucket.defaultCollection().get("airline_10");
 
     cluster.disconnect();
-    // #end::migrating_sdk_code_to_3_n_11[];
+    // #end::migrating_sdk_code_to_3_n_11[]
   }
 
   public void migrating_sdk_code_to_3_n_22() throws Exception { // file: project-docs/pages/migrating-sdk-code-to-3.n.adoc line: 492
@@ -78,7 +78,7 @@ public class MigratingSDKCodeTo3n {
     if (!queryResult.metaData().warnings().isEmpty()) {
       // errors contain [{"msg":"syntax error - at end of input","code":3000}]
     }
-    // #end::migrating_sdk_code_to_3_n_22[];
+    // #end::migrating_sdk_code_to_3_n_22[]
   }
 
 

--- a/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
+++ b/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
@@ -20,7 +20,7 @@ As an example here is a KeyValue document fetch:
 
 [source,java]
 ----
-include::example$MigratingSDKCodeTo3n.java[tag=migrating_sdk_code_to_3_n_1_1,indent=0]
+include::example$MigratingSDKCodeTo3n.java[tag=migrating_sdk_code_to_3_n_1,indent=0]
 ----
 
 Compare this to a N1QL query:


### PR DESCRIPTION
1) migrating-sdk-code-to-3.n.adoc references an incorrect tag name
2) MigratingSDKCodeTo3n.java has semi-colons at the end of the tags
   resulting in them not being found
3) SubDocument had a duplicate method