### PR TITLE
Update FLE2 docs

### DIFF
--- a/modules/concept-docs/pages/encryption.adoc
+++ b/modules/concept-docs/pages/encryption.adoc
@@ -6,7 +6,7 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-Fields within a document can be securely encrypted by the SDK, to support FIPS-140-2 compliance.
+Fields within a document can be securely encrypted by the SDK, to support FIPS 140-2 compliance.
 
 
 CAUTION: This is a developer preview release of Field Level Encryption for the 3.0 API version of Couchbase Java SDK.
@@ -26,103 +26,44 @@ This is a client-side implementation, with key management and initialization of 
 == Algorithm and Key Store
 
 From Couchbase Server 5.5, AES-256, AES-128, and RSA were all supported in earlier versions of the SDK's Field Level Encryption library -- these encryption algorithms are now deprecated, but decryption of data encrypted under earlier versions continues to be supported.
-SDK 3 uses a new algorithm, AEAD_AES_256_CBC_HMAC_SHA_512, which bundles the auth key and the encryption key into a single 64-byte "fat key". 
+SDK 3 uses a new algorithm, AEAD_AES_256_CBC_HMAC_SHA_512, which bundles the auth key and the encryption key into a single 64-byte "fat key".
 The key materials used by the AES and HMAC algorithms are distinct, but the keys can be managed as a single unit.
-
 
 Native Keystores (including Java Key Store and Windows Certificate Store) are supported, as well as an in-memory keystore for development and testing.
 More options for key stores and encryption algorithms may appear in future SDK releases.
 
-Here is an example of an in-memory store for development and testing called the “InsecureKeyStore”, to reflect its lack of security:
-
-----
-public class InsecureKeyProvider : IKeyProvider
-{
-    private readonly Dictionary<string, string> _keys = new Dictionary<string, string>();
-
-    public string GetKey(string keyname)
-    {
-        return _keys[keyname];
-    }
-
-    public void StoreKey(string keyname, string key)
-    {
-        _keys[keyname] = key;
-    }
-}
-----
-
-The keys are stored by name in a dictionary and retrieved using the same name.
-See the xref:howtos:encrypting-using-sdk.adoc[sample code page] for more secure code.
-
 [#format]
 == Field Encryption Format
 
-Behind the API, the following format is used internally to encompass both the temporary field name used to hold the encrypted value, plus the additional metadata associated with the algorithm used and the public key:
+Here’s a document that illustrates how an encrypted field is stored in Couchbase.
+The document has a normal field called "foo", and an encrypted field called "bar".
+Note that the name of the "bar" field is mangled to indicate it holds an encrypted value:
 
 ----
-__[PREFIX]_[FIELDNAME]” : {
-	“kid” : “[KEY_IDENTIFIER]”,
-	“alg”: “[ALGORITHM”],
-	“ciphertext”: “[BASE64_ENCRYPTED_DATA]”,
-	“sig”: “[BASE64_HMAC_SIGNATURE]”,
-	“Iv” : [“INITIALIZATION_VECTOR”]
+{
+  "foo": "I am not a secret",
+  "encrypted$bar": {
+    "alg": "AEAD_AES_256_CBC_HMAC_SHA512",
+    "kid": "my-secret-key-name",
+    "ciphertext": "<base64-encoded-ciphertext>"
+  }
 }
 ----
 
-This is how Couchbase stores the JSON internally, but it is exposed to the developer as a public API.
-For your preferred SDK, an API reference is available, linked from xref:start-using-sdk.adoc[Install and Start Using the Java SDK with Couchbase Server] as well as xref:encrypting-using-sdk.adoc[sample code].
-
-[#field-types]
-== Field Types
-
-The encryption _payload_ can be any JSON type.
-
-.Supported Field Types
-[#sprtd-field-types,cols="1,4,3"]
-|===
-| Type | Example | Payload
-
-| _string_
-| `"magicWord":"xyzzy"`
-| `"xyzzy"`
-
-| _object_
-| `"score":{"dance":10,"presentation":3}`
-| `{"dance":10,"presentation":3}`
-
-| _numeric_
-| `"myint":10`
-| `10`
-
-| _null_
-| `"isnull":null`
-| `null`
-
-| _array_
-| `"myFruityArray":['Apple', 'Banana', 'Olive']`
-| `['Apple', 'Banana', 'Olive']`
-
-| _boolean_
-| `"dues_paid":true`
-| `true`
-|===
-
-[#auditing]
-== Auditing
-
-For auditing purposes, the encrypted fields must be discoverable, for example via N1QL.
+See the xref:howtos:encrypting-using-sdk.adoc[sample code page] for examples of reading & writing encrypted fields.
 
 [#error]
 == Data Safeguards
 
-Under error conditions, to prevent data loss, an error in decryption or encryption in any part of an operation will cause the whole operation to fail with an exception, to prevent unnoticed loss of data.
-
-It's important that encrypted fields be treated as “special” fields and not mutated by APIs other than through the Field Level Encryption (FLE) API.
-For example, for AES-HMAC-SHA256 the entire temporary field is signed; if any changes are made to any fields (“alg”, “kid”, “ciphertext”, “sig” or “iv”) then the decryption will fail because the signature has changed.
+To prevent data loss under error conditions, an error in decryption or encryption in any part of an operation will cause the whole operation to fail with an exception.
 
 [#packaging]
 == Packaging
 
 Field Level Encryption for all SDKs is a separate package from the Couchbase SDK itself; the APIs are extensions of the SDK, but the SDK does not have a dependency on FLE.
 This means you can install the relevant SDK without being dependant upon a suite of crypto libraries.
+
+[#fips-140-2]
+== FIPS 140-2
+
+The standard AEAD_AES_256_CBC_HMAC_SHA512 encryption algorithm is composed of FIPS 140-2 "Approved Security Functions."

--- a/modules/howtos/examples/EncryptingUsingSDK.java
+++ b/modules/howtos/examples/EncryptingUsingSDK.java
@@ -39,6 +39,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.security.KeyStore;
 import java.security.SecureRandom;
+import java.util.Collections;
 
 public class EncryptingUsingSDK {
 
@@ -132,6 +133,27 @@ public class EncryptingUsingSDK {
 
     System.out.println(readItBack.isReplicant());
     // #end::encrypting_using_sdk_5[]
+  }
+
+  public void legacy_decrypters() throws Exception {
+    Keyring keyring = Keyring.fromMap(Collections.emptyMap());
+
+    // #tag::legacy_decrypters[]
+    CryptoManager cryptoManager = DefaultCryptoManager.builder()
+        .legacyAesDecrypters(keyring, encryptionKeyName -> "MySigningKeyName")
+        .legacyRsaDecrypter(keyring, publicKeyName -> "MyPrivateKeyName")
+        // other config...
+        .build();
+    // #end::legacy_decrypters[]
+  }
+
+  public void legacy_field_name_prefix() throws Exception {
+    // #tag::legacy_field_name_prefix[]
+    CryptoManager cryptoManager = DefaultCryptoManager.builder()
+        .encryptedFieldNamePrefix("__crypt_")
+        // other config...
+        .build();
+    // #end::legacy_field_name_prefix[]
   }
 
   public void encrypting_using_sdk_6() throws Exception { // file: howtos/pages/encrypting-using-sdk.adoc line: 173

--- a/modules/howtos/pages/encrypting-using-sdk.adoc
+++ b/modules/howtos/pages/encrypting-using-sdk.adoc
@@ -7,7 +7,7 @@
 [abstract]
 The Field Level Encryption library enables encryption and decryption of JSON fields.
 
-CAUTION: The Field-Level Encryption library for Couchbase Java SDK is currently a _pre-release_. 
+CAUTION: The Field-Level Encryption library for Couchbase Java SDK is currently a _pre-release_.
 It is not supported, but is available for development and experiment.
 It is planned that a supported, full release version will be available later this year.
 Refer to the https://github.com/couchbase/java-couchbase-encryption[GitHub repo] for the latest updates.
@@ -18,15 +18,13 @@ Refer to the https://github.com/couchbase/java-couchbase-encryption[GitHub repo]
 The Couchbase Java SDK uses the https://github.com/couchbase/java-couchbase-encryption[java-couchbase-encryption^] library to provide support for encryption and decryption of JSON fields.
 It includes cryptographic algorithms and keyrings you can use out of the box, and provides a framework for implementing your own crypto components.
 
-NOTE: This separation of the encryption library ensures that the SDK does not have a dependency upon an encryption library in general use -- 
-but it does mean you have to explicitly include this external dependency in your project configuration. 
+NOTE: This separation of the encryption library ensures that the SDK does not have a dependency upon an encryption library in general use --
+but it does mean you have to explicitly include this external dependency in your project configuration.
 Refer to the xref:#maven-coordinates[dependencies section].
-
-The Couchbase Java Field Level Encryption (FLE) uses entity annotations/`JsonObject` methods to specify which field(s) to apply encryption and which algorithm to use.
 
 Version `3.0.0-pre.1` of this library requires Couchbase Java SDK version `3.0.5` or later.
 
-
+[#maven-coordinates]
 == Maven Coordinates
 
 [source,xml]
@@ -40,10 +38,10 @@ Version `3.0.0-pre.1` of this library requires Couchbase Java SDK version `3.0.5
 
 === Optional Dependencies
 
-To reduce the footprint of this library, some of its dependencies are optional. 
+To reduce the footprint of this library, some of its dependencies are optional.
 Using certain features requires adding additional dependencies to your project.
 
-HashiCorp Vault Transit integration requires [Spring Vault](https://docs.spring.io/spring-vault/docs/current/reference/html/):
+HashiCorp Vault Transit integration requires https://docs.spring.io/spring-vault/docs/current/reference/html/[Spring Vault]:
 
 [source,xml]
 ----
@@ -67,7 +65,7 @@ include::example$EncryptingUsingSDK.java[tag=encrypting_using_sdk_1,indent=0]
 
 == Usage
 
-Two modes of operation are available: 
+Two modes of operation are available:
 
 * Transparent encryption/decryption during Jackson data binding.
 * Manual field editing using `JsonObjectCrypto`.
@@ -120,10 +118,10 @@ This prints `true`.
 
 ==== Using a custom ObjectMapper
 
-The code that enables encryption/decryption during data binding is packaged as a Jackson module called `EncryptionModule`. 
+The code that enables encryption/decryption during data binding is packaged as a Jackson module called `EncryptionModule`.
 You can register this module with any Jackson `ObjectMapper`.
 
-You'll need to do this if you want to supply your own customized ObjectMapper for the Java SDK to use when serializing documents. 
+You'll need to do this if you want to supply your own customized ObjectMapper for the Java SDK to use when serializing documents.
 Here's how to configure the cluster environment to use a custom JSON serializer backed by your own ObjectMapper with support for Field-Level Encryption:
 
 [source,java]
@@ -133,7 +131,7 @@ include::example$EncryptingUsingSDK.java[tag=encrypting_using_sdk_6,indent=0]
 
 === JsonObjectCrypto
 
-If you need more control of which fields get decrypted, or if you prefer working with the Couchbase `JsonObject` tree model, 
+If you need more control of which fields get decrypted, or if you prefer working with the Couchbase `JsonObject` tree model,
 you can use a `JsonObjectCrypto` instance to read and write encrypted field values of a `JsonObject`.
 
 [source,java]
@@ -144,7 +142,7 @@ include::example$EncryptingUsingSDK.java[tag=encrypting_using_sdk_7,indent=0]
 
 == Creating Encryption Keys
 
-The AEAD_AES_256_CBC_HMAC_SHA512 algortihm included in this library uses encryption keys that are 64 bytes long.
+The AEAD_AES_256_CBC_HMAC_SHA512 algorithm included in this library uses encryption keys that are 64 bytes long.
 
 Here's an example that shows how to create a Java key store file containing a suitable encryption key:
 
@@ -159,3 +157,46 @@ And here's how to use that file to create a `Keyring` for use with Couchbase Fie
 ----
 include::example$EncryptingUsingSDK.java[tag=encrypting_using_sdk_9,indent=0]
 ----
+
+
+[#migration-from-sdk2]
+== Migrating from SDK 2
+
+If you were previously using Field-Level Encryption with Java SDK 2, a few extra configuration steps are required.
+
+
+[#configure-field-name-prefix]
+=== Changing the field name prefix
+
+In SDK 2, the default prefix for encrypted field names was `\__crypt_`.
+This caused problems for Couchbase Sync Gateway, which does not like field names to begin with an underscore.
+In SDK 3, the default prefix is `encrypted$`.
+
+In order to decrypt fields written by SDK 2, you can configure the `CryptoManager` to use the old `\__crypt_` prefix:
+
+[source,java]
+----
+include::example$EncryptingUsingSDK.java[tag=legacy_field_name_prefix,indent=0]
+----
+
+Alternatively, you can https://forums.couchbase.com/t/replacing-field-name-prefix/28786[rename the existing fields using a N1QL statement].
+
+WARNING: In SDK 2, only top-level fields could be encrypted.
+SDK 3 allows encrypting fields at any depth.
+If you decide to rename the existing fields, make sure to do so _before_ writing any encrypted fields below the top level, otherwise it may be difficult to rename the nested fields using a generic N1QL statement.
+
+
+[#configure-legacy-decrypters]
+=== Enabling decrypters for legacy algorithms
+
+The encryption algorithms used by SDK 2 are deprecated, and are no longer used for encrypting new data.
+To decrypt fields written by SDK 2, enable the legacy decrypters when configuring the `CryptoManager`:
+
+[source,java]
+----
+include::example$EncryptingUsingSDK.java[tag=legacy_decrypters,indent=0]
+----
+
+NOTE: The legacy decrypters require a mapping function.
+For AES, this function accepts an encryption key name and returns the corresponding signing key name.
+For RSA, this function accepts a public key name and returns the corresponding private key name.


### PR DESCRIPTION
Remove obsolete "IKeyProvider" example.

Remove "Supported Field Types" table, which isn't useful for end-users.

Update the encrypted field JSON format example.

Add a FIPS 140-2 statement.

Add a section on migrating from SDK 2.

Tidy whitespace and other minor issues.