### PR TITLE
DOC-8030 Field Level Encryption v2 migration limitations and details

### DIFF
--- a/modules/howtos/examples/EncryptingUsingSDK.java
+++ b/modules/howtos/examples/EncryptingUsingSDK.java
@@ -113,14 +113,14 @@ public class EncryptingUsingSDK {
 
     Employee employee = new Employee();
     employee.setReplicant(true);
-    collection.upsert("employee:1234", employee);
+    collection.upsert("employee:1234", employee); // encrypts the "replicant" field
     // #end::encrypting_using_sdk_3[]
   }
 
   public void encrypting_using_sdk_4() throws Exception { // file: howtos/pages/encrypting-using-sdk.adoc line: 128
     // #tag::encrypting_using_sdk_4[]
     JsonObject encrypted = collection.get("employee:1234")
-        .contentAsObject();
+        .contentAsObject(); // does not decrypt anything
 
     System.out.println(encrypted);
     // #end::encrypting_using_sdk_4[]
@@ -129,7 +129,7 @@ public class EncryptingUsingSDK {
   public void encrypting_using_sdk_5() throws Exception { // file: howtos/pages/encrypting-using-sdk.adoc line: 152
     // #tag::encrypting_using_sdk_5[]
     Employee readItBack = collection.get("employee:1234")
-        .contentAs(Employee.class);
+        .contentAs(Employee.class); // decrypts the "replicant" field
 
     System.out.println(readItBack.isReplicant());
     // #end::encrypting_using_sdk_5[]

--- a/modules/howtos/pages/encrypting-using-sdk.adoc
+++ b/modules/howtos/pages/encrypting-using-sdk.adoc
@@ -72,7 +72,7 @@ Two modes of operation are available:
 
 === Data Binding Example
 
-Sensitive fields of your POJOs can be annotated with `@Encrypted`.
+Sensitive fields of your data classes can be annotated with `@Encrypted`.
 Let's use this class as an example:
 
 [source,java]
@@ -80,7 +80,7 @@ Let's use this class as an example:
 include::example$EncryptingUsingSDK.java[tag=encrypting_using_sdk_2,indent=0]
 ----
 
-Now let's create an employee record:
+Now let's create an employee record and save it to Couchbase:
 
 [source,java]
 ----
@@ -162,8 +162,14 @@ include::example$EncryptingUsingSDK.java[tag=encrypting_using_sdk_9,indent=0]
 [#migration-from-sdk2]
 == Migrating from SDK 2
 
-If you were previously using Field-Level Encryption with Java SDK 2, a few extra configuration steps are required.
+WARNING: SDK 2 cannot read fields encrypted by SDK 3.
 
+It's inadvisable to have both the old and new versions of your application active at the same time.
+The simplest way to migrate is to do an offline upgrade during a scheduled a maintenance window.
+For an online upgrade without downtime, consider a https://en.wikipedia.org/wiki/Blue-green_deployment[blue-green deployment].
+
+SDK 3 requires additional configuration to read fields encrypted by SDK 2.
+The rest of this section describes how to configure Field-Level Encryption in SDK 3 for backwards compatibility with SDK 2.
 
 [#configure-field-name-prefix]
 === Changing the field name prefix
@@ -172,7 +178,7 @@ In SDK 2, the default prefix for encrypted field names was `\__crypt_`.
 This caused problems for Couchbase Sync Gateway, which does not like field names to begin with an underscore.
 In SDK 3, the default prefix is `encrypted$`.
 
-In order to decrypt fields written by SDK 2, you can configure the `CryptoManager` to use the old `\__crypt_` prefix:
+For compatibility with SDK 2, you can configure the `CryptoManager` to use the old `\__crypt_` prefix:
 
 [source,java]
 ----
@@ -190,7 +196,7 @@ If you decide to rename the existing fields, make sure to do so _before_ writing
 === Enabling decrypters for legacy algorithms
 
 The encryption algorithms used by SDK 2 are deprecated, and are no longer used for encrypting new data.
-To decrypt fields written by SDK 2, enable the legacy decrypters when configuring the `CryptoManager`:
+To enable decrypting fields written by SDK 2, register the legacy decrypters when configuring the `CryptoManager`:
 
 [source,java]
 ----

--- a/modules/howtos/pages/encrypting-using-sdk.adoc
+++ b/modules/howtos/pages/encrypting-using-sdk.adoc
@@ -166,7 +166,7 @@ WARNING: SDK 2 cannot read fields encrypted by SDK 3.
 
 It's inadvisable to have both the old and new versions of your application active at the same time.
 The simplest way to migrate is to do an offline upgrade during a scheduled a maintenance window.
-For an online upgrade without downtime, consider a https://en.wikipedia.org/wiki/Blue-green_deployment[blue-green deployment].
+For an online upgrade without downtime, consider a https://en.wikipedia.org/wiki/Blue-green_deployment[blue-green deployment^].
 
 SDK 3 requires additional configuration to read fields encrypted by SDK 2.
 The rest of this section describes how to configure Field-Level Encryption in SDK 3 for backwards compatibility with SDK 2.


### PR DESCRIPTION
Update the FLE migration docs to emphasize SDK 2 cannot
read fields encrypted by SDK 3.

Recommend an offline migration, or migration using a blue-green
deployment.

Plus a few minor edits.