### PR TITLE
Clean up Asciidoc comment tags

### DIFF
--- a/modules/concept-docs/examples/BucketsAndClustersExample.java
+++ b/modules/concept-docs/examples/BucketsAndClustersExample.java
@@ -46,11 +46,11 @@ public class BucketsAndClustersExample {
   }
 
   public void buckets_and_clusters_1() throws Exception {
-    // #tag::buckets_and_clusters_1[]
+    // tag::buckets_and_clusters_1[]
     BucketManager manager = cluster.buckets();
     bucketSettings = BucketSettings.create("myBucket");
     manager.createBucket(bucketSettings);
-    // #end::buckets_and_clusters_1[];
+    // end::buckets_and_clusters_1[];
   }
 
   public static void main(String[] args) throws Exception {

--- a/modules/concept-docs/examples/CompressionExample.java
+++ b/modules/concept-docs/examples/CompressionExample.java
@@ -44,13 +44,13 @@ public class CompressionExample {
   }
 
   public void compression_1() throws Exception {
-    // #tag::compression_1[]
+    // tag::compression_1[]
     ClusterEnvironment env = ClusterEnvironment
         .builder()
         // start compressing at 1024 bytes
         .compressionConfig(CompressionConfig.minSize(1024))
         .build();
-    // #end::compression_1[];
+    // end::compression_1[];
   }
 
   public static void main(String[] args) throws Exception {

--- a/modules/concept-docs/examples/DataModelExample.java
+++ b/modules/concept-docs/examples/DataModelExample.java
@@ -45,9 +45,9 @@ public class DataModelExample {
   }
 
   public void data_model_1() throws Exception {
-    // #tag::data_model_1[]
+    // tag::data_model_1[]
     Map<String, String> myMap = collection.map("name", String.class);
-    // #end::data_model_1[];
+    // end::data_model_1[];
   }
 
   public static void main(String[] args) throws Exception {

--- a/modules/concept-docs/examples/HealthCheckConcepts.java
+++ b/modules/concept-docs/examples/HealthCheckConcepts.java
@@ -40,7 +40,7 @@ public class HealthCheckConcepts {
     Collection collection = scope.collection("collection-name");
 
     {
-// #tag::ping-basic[]
+// tag::ping-basic[]
       PingResult pingResult = cluster.ping();
 
       for (Map.Entry<ServiceType, List<EndpointPingReport>> service : pingResult.endpoints().entrySet()) {
@@ -50,27 +50,27 @@ public class HealthCheckConcepts {
           );
         }
       }
-// #end::ping-basic[]
+// end::ping-basic[]
     }
 
     {
-// #tag::ping-json-export[]
+// tag::ping-json-export[]
       PingResult pingResult = cluster.ping();
 
       System.out.println(pingResult.exportToJson());
-// #end::ping-json-export[]
+// end::ping-json-export[]
     }
 
     {
-// #tag::ping-options[]
+// tag::ping-options[]
       PingResult pingResult = cluster.ping(pingOptions().serviceTypes(EnumSet.of(ServiceType.QUERY)));
 
       System.out.println(pingResult.exportToJson());
-// #end::ping-options[]
+// end::ping-options[]
     }
 
     {
-// #tag::diagnostics-basic[]
+// tag::diagnostics-basic[]
       DiagnosticsResult diagnosticsResult = cluster.diagnostics();
 
       for (Map.Entry<ServiceType, List<EndpointDiagnostics>> service : diagnosticsResult.endpoints().entrySet()) {
@@ -80,15 +80,15 @@ public class HealthCheckConcepts {
           );
         }
       }
-// #end::diagnostics-basic[]
+// end::diagnostics-basic[]
     }
 
     {
-// #tag::diagnostics-options[]
+// tag::diagnostics-options[]
       DiagnosticsResult diagnosticsResult = cluster.diagnostics();
 
       System.out.println(diagnosticsResult.exportToJson());
-// #end::diagnostics-options[]
+// end::diagnostics-options[]
     }
   }
 

--- a/modules/concept-docs/examples/N1qlQueryExample.java
+++ b/modules/concept-docs/examples/N1qlQueryExample.java
@@ -58,22 +58,22 @@ public class N1qlQueryExample {
   }
 
   public void n1ql_query_1() throws Exception {
-    // #tag::n1ql_query_1[]
+    // tag::n1ql_query_1[]
     QueryResult result = cluster.query(
         "select count(*) from `travel-sample` where type = \"airports\" and country = ?",
         QueryOptions.queryOptions().adhoc(false).parameters(JsonArray.from("France"))
     );
-    // #end::n1ql_query_1[];
+    // end::n1ql_query_1[];
   }
 
   public void n1ql_query_2() throws Exception {
     try {
-      // #tag::n1ql_query_2[]
+      // tag::n1ql_query_2[]
       QueryIndexManager indexManager = cluster.queryIndexes();
       indexManager.createPrimaryIndex(bucketName);
       indexManager.createIndex(bucketName, "ix_name", Collections.singletonList("name"));
       indexManager.createIndex(bucketName, "ix_email", Collections.singletonList("email"));
-      // #end::n1ql_query_2[];
+      // end::n1ql_query_2[];
     } catch (IndexExistsException e) {
       System.err.println(e);
     }
@@ -81,7 +81,7 @@ public class N1qlQueryExample {
 
   public void n1ql_query_3() throws Exception {
     try {
-      // #tag::n1ql_query_3[]
+      // tag::n1ql_query_3[]
       QueryIndexManager indexManager = cluster.queryIndexes();
       indexManager.createPrimaryIndex(bucketName,
           CreatePrimaryQueryIndexOptions.createPrimaryQueryIndexOptions().deferred(true));
@@ -91,14 +91,14 @@ public class N1qlQueryExample {
           CreateQueryIndexOptions.createQueryIndexOptions().deferred(true));
       indexManager.buildDeferredIndexes(bucketName);
       indexManager.watchIndexes(bucketName, Arrays.asList("ix_name", "ix_email"), Duration.ofMinutes(5));
-      // #end::n1ql_query_3[];
+      // end::n1ql_query_3[];
     } catch (IndexExistsException e) {
       System.err.println(e);
     }
   }
 
   public void n1ql_query_4() throws Exception {
-    // #tag::n1ql_query_4[]
+    // tag::n1ql_query_4[]
     String id = "user::" + UUID.randomUUID();
     collection.insert(
         id,
@@ -110,18 +110,18 @@ public class N1qlQueryExample {
         QueryOptions.queryOptions()
             .parameters(JsonObject.create().put("id", id))
     );
-    // #end::n1ql_query_4[];
+    // end::n1ql_query_4[];
   }
 
   public void n1ql_query_5() throws Exception {
-    // #tag::n1ql_query_5[]
+    // tag::n1ql_query_5[]
     cluster.query(
         "select * from `" + bucketName + "` where META().id = $id",
         QueryOptions.queryOptions()
             .parameters(JsonObject.create().put("id", id))
             .scanConsistency(QueryScanConsistency.REQUEST_PLUS)
     );
-    // #end::n1ql_query_5[];
+    // end::n1ql_query_5[];
   }
 
   public static void main(String[] args) throws Exception {

--- a/modules/concept-docs/examples/XattrExample.java
+++ b/modules/concept-docs/examples/XattrExample.java
@@ -47,13 +47,13 @@ public class XattrExample {
   }
 
   public void xattr_1() throws Exception {
-    // #tag::xattr_1[]
+    // tag::xattr_1[]
     collection.lookupIn(
         "airport_1254",
         Collections.singletonList(
             LookupInSpec.get(LookupInMacro.EXPIRY_TIME).xattr())
     );
-    // #end::xattr_1[];
+    // end::xattr_1[];
   }
 
   public static void main(String[] args) throws Exception {

--- a/modules/devguide/examples/java/src/main/java/com/couchbase/devguide/HealthCheck.java
+++ b/modules/devguide/examples/java/src/main/java/com/couchbase/devguide/HealthCheck.java
@@ -51,17 +51,17 @@ public class HealthCheck extends ConnectionBase {
 //                .put("baz", "qux");
 //
 //
-//// #tag::apis[]
+//// tag::apis[]
 //        AsyncCollection asyncCollection = collection.async();
 //        ReactiveCollection reactiveCollection = collection.reactive();
-//// #end::apis[]
+//// end::apis[]
 //
 //        JsonObject content = JsonObject.create().put("foo", "bar");
 ////        MutationResult result = collection.upsert("document-key", content);
 //
-//// #tag::apis[]
+//// tag::apis[]
 //        PingResult ping = bucket.ping();
-//// #end::apis[]
+//// end::apis[]
     @Override
     protected void doWork() {
 
@@ -73,7 +73,7 @@ public class HealthCheck extends ConnectionBase {
 
         MutationResult result = collection.upsert("document-key", content);
 
-// #tag::ping[]
+// tag::ping[]
         // Ping a specified bucket to look at the state of all associated endpoints
         PingResult pingResult = bucket.ping();
         // Look at the KV endpoints and warn if their state is not OK
@@ -87,9 +87,9 @@ public class HealthCheck extends ConnectionBase {
                 LOGGER.info(String.format("Node %s at remote %s is OK.", pingEndpoint.id(), pingEndpoint.remote()));
             }
         }
-// #end::ping[]
+// end::ping[]
 
-// #tag::diagnostics[]
+// tag::diagnostics[]
         // Get all diagnostics associated with a given cluster, passively
         DiagnosticsResult diagnosticsResult = cluster.diagnostics();
         Map<ServiceType, List<EndpointDiagnostics>> diagEndpoints = diagnosticsResult.endpoints();
@@ -106,7 +106,7 @@ public class HealthCheck extends ConnectionBase {
                 }
             }
         }
-// #end::diagnostics[]
+// end::diagnostics[]
     }
 
     public static void main(String[] args) {

--- a/modules/hello-world/examples/DocParser.java
+++ b/modules/hello-world/examples/DocParser.java
@@ -276,7 +276,7 @@ public class DocParser {
             } else {
               methodLines.add("    // file: " + fileName + " line: " + lineno);
             }
-            methodLines.add("    // #tag::" + javaName + "_" + sourceSection + "[]");
+            methodLines.add("    // tag::" + javaName + "_" + sourceSection + "[]");
             methodLines.add("    " + line); // first line
 
             // read in the method into
@@ -291,7 +291,7 @@ public class DocParser {
               methodLines.add("    " + line); // remaining lines
               continued = line.contains("// continued"); // don't close-out this method.
             } // while content between ---- and ---- of [source,java]
-            methodLines.add("    // #end::" + javaName + "_" + sourceSection + "[]");
+            methodLines.add("    // end::" + javaName + "_" + sourceSection + "[]");
             if (!dontEncapsulate && !continued) { // close off the method
               methodLines.add("  }\n");
             }

--- a/modules/hello-world/examples/StartUsing.java
+++ b/modules/hello-world/examples/StartUsing.java
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-// #tag::imports[]
+// tag::imports[]
 import com.couchbase.client.java.*;
 import com.couchbase.client.java.kv.*;
 import com.couchbase.client.java.json.*;
 import com.couchbase.client.java.query.*;
-// #end::imports[]
+// end::imports[]
 
 class StartUsing {
 
@@ -29,7 +29,7 @@ class StartUsing {
   static String bucketName = "travel-sample";
 
   public static void local(String... args) {
-    // #tag::connect_local[]
+    // tag::connect_local[]
     Cluster cluster = Cluster.connect(connectionString, username, password);
     Bucket bucket = cluster.bucket(bucketName);
     Collection collection = bucket.defaultCollection();
@@ -42,25 +42,25 @@ class StartUsing {
     System.out.println(name); // name == "mike"
     QueryResult result = cluster.query("select \"Hello World\" as greeting");
     System.out.println(result.rowsAsObject());
-    // #end::connect_local[]
+    // end::connect_local[]
   }
 
   public static void main(String... args) {
-    // #tag::connect[]
+    // tag::connect[]
     Cluster cluster = Cluster.connect(connectionString, username, password);
-    // #end::connect[]
+    // end::connect[]
 
-    // #tag::bucket[]
+    // tag::bucket[]
     // get a bucket reference
     Bucket bucket = cluster.bucket(bucketName);
-    // #end::bucket[]
+    // end::bucket[]
 
-    // #tag::collection[]
+    // tag::collection[]
     // get a collection reference
     Collection collection = bucket.defaultCollection();
-    // #end::collection[]
+    // end::collection[]
 
-    // #tag::upsert-get[]
+    // tag::upsert-get[]
     // Upsert Document
     MutationResult upsertResult = collection.upsert(
         "my-document",
@@ -71,12 +71,12 @@ class StartUsing {
     GetResult getResult = collection.get("my-document");
     String name = getResult.contentAsObject().getString("name");
     System.out.println(name); // name == "mike"
-    // #end::upsert-get[]
+    // end::upsert-get[]
 
-    // #tag::n1ql-query[]
+    // tag::n1ql-query[]
     QueryResult result = cluster.query("select \"Hello World\" as greeting");
     System.out.println(result.rowsAsObject());
-    // #end::n1ql-query[]
+    // end::n1ql-query[]
 
   }
 

--- a/modules/howtos/examples/Analytics.java
+++ b/modules/howtos/examples/Analytics.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-// #tag::imports[]
+// tag::imports[]
 import com.couchbase.client.core.error.CouchbaseException;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.analytics.AnalyticsResult;
@@ -30,7 +30,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.couchbase.client.java.analytics.AnalyticsOptions.analyticsOptions;
-// #end::imports[]
+// end::imports[]
 
 public class Analytics {
 
@@ -38,7 +38,7 @@ public class Analytics {
 
   public static void main(String... args) {
     {
-      // #tag::simple[]
+      // tag::simple[]
       try {
         final AnalyticsResult result = cluster
           .analyticsQuery("select \"hello\" as greeting");
@@ -52,86 +52,86 @@ public class Analytics {
       } catch (CouchbaseException ex) {
         ex.printStackTrace();
       }
-      // #end::simple[]
+      // end::simple[]
     }
 
     {
-      // #tag::named[]
+      // tag::named[]
       AnalyticsResult result = cluster.analyticsQuery(
         "select count(*) from airports where country = $country",
         analyticsOptions().parameters(JsonObject.create().put("country", "France"))
       );
-      // #end::named[]
+      // end::named[]
     }
 
 
     {
-      // #tag::positional[]
+      // tag::positional[]
       AnalyticsResult result = cluster.analyticsQuery(
         "select count(*) from airports where country = ?",
         analyticsOptions().parameters(JsonArray.from("France"))
       );
-      // #end::positional[]
+      // end::positional[]
     }
 
     {
-      // #tag::scanconsistency[]
+      // tag::scanconsistency[]
       AnalyticsResult result = cluster.analyticsQuery(
         "select ...",
         analyticsOptions().scanConsistency(AnalyticsScanConsistency.REQUEST_PLUS)
       );
-      // #end::scanconsistency[]
+      // end::scanconsistency[]
     }
 
     {
-      // #tag::clientcontextid[]
+      // tag::clientcontextid[]
       AnalyticsResult result = cluster.analyticsQuery(
         "select ...",
         analyticsOptions().clientContextId("user-44" + UUID.randomUUID())
       );
-      // #end::clientcontextid[]
+      // end::clientcontextid[]
     }
 
     {
-      // #tag::priority[]
+      // tag::priority[]
       AnalyticsResult result = cluster.analyticsQuery(
         "select ...",
         analyticsOptions().priority(true)
       );
-      // #end::priority[]
+      // end::priority[]
     }
 
     {
-      // #tag::readonly[]
+      // tag::readonly[]
       AnalyticsResult result = cluster.analyticsQuery(
         "select ...",
         analyticsOptions().readonly(true)
       );
-      // #end::readonly[]
+      // end::readonly[]
     }
 
     {
-      // #tag::printmetrics[]
+      // tag::printmetrics[]
       AnalyticsResult result = cluster.analyticsQuery("select 1=1");
       System.err.println(
         "Execution time: " + result.metaData().metrics().executionTime()
       );
-      // #end::printmetrics[]
+      // end::printmetrics[]
     }
 
     {
-      // #tag::rowsasobject[]
+      // tag::rowsasobject[]
       AnalyticsResult result = cluster.analyticsQuery(
         "select * from `travel-sample` limit 10"
       );
       for (JsonObject row : result.rowsAsObject()) {
         System.out.println("Found row: " + row);
       }
-      // #end::rowsasobject[]
+      // end::rowsasobject[]
     }
 
     {
-      // #tag::simplereactive[]
+      // tag::simplereactive[]
       Mono<ReactiveAnalyticsResult> result = cluster
         .reactive()
         .analyticsQuery("select 1=1");
@@ -139,11 +139,11 @@ public class Analytics {
       result
         .flatMapMany(ReactiveAnalyticsResult::rowsAsObject)
         .subscribe(row -> System.out.println("Found row: " + row));
-      // #end::simplereactive[]
+      // end::simplereactive[]
     }
 
     {
-      // #tag::backpressure[]
+      // tag::backpressure[]
       Mono<ReactiveAnalyticsResult> result = cluster
         .reactive()
         .analyticsQuery("select * from hugeDataset");
@@ -169,7 +169,7 @@ public class Analytics {
             }
           }
       });
-      // #end::backpressure[]
+      // end::backpressure[]
     }
 
   }

--- a/modules/howtos/examples/AsyncOperations.java
+++ b/modules/howtos/examples/AsyncOperations.java
@@ -43,7 +43,7 @@ public class AsyncOperations {
 
   public static void main(String... args) {
 
-// #tag::access[]
+// tag::access[]
 Cluster cluster = Cluster.connect("127.0.0.1", "Administrator", "password");
 ReactiveCluster reactiveCluster = cluster.reactive();
 
@@ -52,26 +52,26 @@ ReactiveBucket reactiveBucket = bucket.reactive();
 
 Collection collection = bucket.defaultCollection();
 ReactiveCollection reactiveCollection = collection.reactive();
-// #end::access[]
+// end::access[]
 
-// #tag::access-async[]
+// tag::access-async[]
 AsyncCluster asyncCluster = cluster.async();
 AsyncBucket asyncBucket = bucket.async();
 AsyncCollection asyncCollection = collection.async();
-// #end::access-async[]
+// end::access-async[]
 
 
-// #tag::simple-get[]
+// tag::simple-get[]
 reactiveCollection
   .get("my-doc")
   .subscribe(System.out::println, System.err::println);
-// #end::simple-get[]
+// end::simple-get[]
 
-// #tag::non-used-upsert[]
+// tag::non-used-upsert[]
 reactiveCollection.upsert("my-doc", JsonObject.create());
-// #end::non-used-upsert[]
+// end::non-used-upsert[]
 
-// #tag::verbose-query[]
+// tag::verbose-query[]
 reactiveCluster
   .query("select * from `travel-sample`")
   .flux()
@@ -81,33 +81,33 @@ reactiveCluster
   }).subscribe(row -> {
     System.out.println("Found row: " + row);
   });
-// #end::verbose-query[]
+// end::verbose-query[]
 
     {
-// #tag::simple-bulk[]
+// tag::simple-bulk[]
 List<String> docsToFetch = Arrays.asList("key1", "key2", "key3");
 List<GetResult> results = Flux
   .fromIterable(docsToFetch)
   .flatMap(reactiveCollection::get)
   .collectList()
   .block();
-// #end::simple-bulk[]
+// end::simple-bulk[]
     }
 
     {
-// #tag::ignore-bulk[]
+// tag::ignore-bulk[]
 List<String> docsToFetch = Arrays.asList("key1", "key2", "key3");
 List<GetResult> results = Flux
   .fromIterable(docsToFetch)
   .flatMap(key -> reactiveCollection.get(key).onErrorResume(e -> Mono.empty()))
   .collectList()
   .block();
-// #end::ignore-bulk[]
+// end::ignore-bulk[]
     }
 
 
     {
-// #tag::split-bulk[]
+// tag::split-bulk[]
 List<String> docsToFetch = Arrays.asList("key1", "key2", "key3");
 
 List<GetResult> successfulResults =
@@ -124,12 +124,12 @@ Flux
   .doOnNext(successfulResults::add)
   .last()
   .block();
-// #end::split-bulk[]
+// end::split-bulk[]
     }
 
 
     {
-// #tag::retry-bulk[]
+// tag::retry-bulk[]
 List<String> docsToFetch = Arrays.asList("key1", "key2", "key3");
 
 List<GetResult> results = Flux
@@ -139,12 +139,12 @@ List<GetResult> results = Flux
     .retryBackoff(10, Duration.ofMillis(10)))
   .collectList()
   .block();
-// #end::retry-bulk[]
+// end::retry-bulk[]
     }
 
-// #tag::rs-conversion[]
+// tag::rs-conversion[]
 Single<GetResult> rxSingleResult = monoToSingle(reactiveCollection.get("my-doc"));
-// #end::rs-conversion[]
+// end::rs-conversion[]
 
   }
 }

--- a/modules/howtos/examples/Auth.java
+++ b/modules/howtos/examples/Auth.java
@@ -30,19 +30,19 @@ public class Auth {
   public static void main(String... args) {
 
     {
-      // #tag::rbac-simple[]
+      // tag::rbac-simple[]
       Cluster cluster = Cluster.connect("127.0.0.1", "username", "password");
-      // #end::rbac-simple[]
+      // end::rbac-simple[]
     }
 
     {
-      // #tag::rbac-clusteroptions[]
+      // tag::rbac-clusteroptions[]
       Cluster cluster = Cluster.connect("127.0.0.1", clusterOptions("username", "password"));
-      // #end::rbac-clusteroptions[]
+      // end::rbac-clusteroptions[]
     }
 
     {
-      // #tag::rbac-pwd[]
+      // tag::rbac-pwd[]
       PasswordAuthenticator authenticator = PasswordAuthenticator
         .builder()
         .username("username")
@@ -52,17 +52,17 @@ public class Auth {
         .build();
 
       Cluster cluster = Cluster.connect("127.0.0.1", clusterOptions(authenticator));
-      // #end::rbac-pwd[]
+      // end::rbac-pwd[]
     }
 
     {
-      // #tag::certauth[]
+      // tag::certauth[]
       // should be replaced with your actual KeyStore
       KeyStore keyStore = loadKeyStore();
 
       CertificateAuthenticator authenticator = CertificateAuthenticator.fromKeyStore(keyStore, "keyStorePassword");
       Cluster cluster = Cluster.connect("127.0.0.1", clusterOptions(authenticator));
-      // #end::certauth[]
+      // end::certauth[]
     }
   }
 

--- a/modules/howtos/examples/Cas.java
+++ b/modules/howtos/examples/Cas.java
@@ -32,7 +32,7 @@ public class Cas {
     Collection collection = null;
 
     {
-      // #tag::handlingerrors[]
+      // tag::handlingerrors[]
       int maxRetries = 10;
 
       for (int i = 0; i < maxRetries; i++) {
@@ -52,11 +52,11 @@ public class Cas {
           // note that any other exception will be raised and break the loop as well
         }
       }
-      // #end::handlingerrors[]
+      // end::handlingerrors[]
     }
 
     {
-      // #tag::locking[]
+      // tag::locking[]
       GetResult getAndLockResult = collection.getAndLock("key", Duration.ofSeconds(2));
 
       long lockedCas = getAndLockResult.cas();
@@ -66,7 +66,7 @@ public class Cas {
        */
 
       collection.replace("key", "new value", replaceOptions().cas(lockedCas));
-      // #end::locking[]
+      // end::locking[]
     }
   }
 

--- a/modules/howtos/examples/CollectingInformationAndLogging.java
+++ b/modules/howtos/examples/CollectingInformationAndLogging.java
@@ -43,16 +43,16 @@ public class CollectingInformationAndLogging {
   Collection collection;
 
   private void init(){
-    // #tag::connection_1[];
+    // tag::connection_1[];
     ClusterEnvironment environment = ClusterEnvironment.builder().build();
     cluster = Cluster.connect(connectionString,      ClusterOptions.clusterOptions(username, password).environment(environment));
     bucket = cluster.bucket(bucketName);
     scope = bucket.defaultScope();
     collection = bucket.defaultCollection();
-    // #end::connection_1[];
+    // end::connection_1[];
   }
   public void collecting_information_and_logging_1() throws Exception { // file: howtos/pages/collecting-information-and-logging.adoc line: 114
-    // #tag::collecting_information_and_logging_1[]
+    // tag::collecting_information_and_logging_1[]
     Logger logger = Logger.getLogger("com.couchbase.client");
     logger.setLevel(Level.FINE);
     for(Handler h : logger.getParent().getHandlers()) {
@@ -60,11 +60,11 @@ public class CollectingInformationAndLogging {
         	h.setLevel(Level.FINE);
     	}
     }
-    // #end::collecting_information_and_logging_1[];
+    // end::collecting_information_and_logging_1[];
   }
 
   public void collecting_information_and_logging_2() throws Exception { // file: howtos/pages/collecting-information-and-logging.adoc line: 131
-    // #tag::collecting_information_and_logging_2[]
+    // tag::collecting_information_and_logging_2[]
     ClusterEnvironment environment = ClusterEnvironment
       .builder()
       .loggerConfig(LoggerConfig
@@ -72,33 +72,33 @@ public class CollectingInformationAndLogging {
         .disableSlf4J(true)
       )
       .build();
-    // #end::collecting_information_and_logging_2[];
+    // end::collecting_information_and_logging_2[];
   }
 
   public void collecting_information_and_logging_3() throws Exception { // file: howtos/pages/collecting-information-and-logging.adoc line: 163
-    // #tag::collecting_information_and_logging_3[]
+    // tag::collecting_information_and_logging_3[]
     ClusterEnvironment environment = ClusterEnvironment.builder().build();
-    
+
     environment.eventBus().subscribe(event -> {
       // handle events as they arrive
       if (event.severity() == Event.Severity.INFO || event.severity() == Event.Severity.WARN) {
         System.out.println(event);
       }
     });
-    
+
     Cluster cluster = Cluster.connect(
         connectionString,
         ClusterOptions.clusterOptions(username, password).environment(environment)
     );
-    
+
     Bucket bucket = cluster.bucket(bucketName);
-    // #end::collecting_information_and_logging_3[];
+    // end::collecting_information_and_logging_3[];
   }
 
   public void collecting_information_and_logging_4() throws Exception { // file: howtos/pages/collecting-information-and-logging.adoc line: 206
-    // #tag::collecting_information_and_logging_4[]
+    // tag::collecting_information_and_logging_4[]
     LogRedaction.setRedactionLevel(RedactionLevel.FULL);
-    // #end::collecting_information_and_logging_4[];
+    // end::collecting_information_and_logging_4[];
   }
 
   public static void main(String[] args) throws Exception{

--- a/modules/howtos/examples/EncryptingUsingSDK.java
+++ b/modules/howtos/examples/EncryptingUsingSDK.java
@@ -53,16 +53,16 @@ public class EncryptingUsingSDK {
   Collection collection;
 
   private void init() {
-    // #tag::connection_1[];
+    // tag::connection_1[];
     ClusterEnvironment environment = ClusterEnvironment.builder().build();
     cluster = Cluster.connect(connectionString, ClusterOptions.clusterOptions(username, password).environment(environment));
     bucket = cluster.bucket("travel-sample");
     scope = bucket.defaultScope();
-    collection = bucket.defaultCollection();    // #end::connection_1[];
+    collection = bucket.defaultCollection();    // end::connection_1[];
   }
 
   public void encrypting_using_sdk_1() throws Exception { // file: howtos/pages/encrypting-using-sdk.adoc line: 60
-    // #tag::encrypting_using_sdk_1[]
+    // tag::encrypting_using_sdk_1[]
     KeyStore javaKeyStore = KeyStore.getInstance("MyKeyStoreType");
     FileInputStream fis = new java.io.FileInputStream("keyStoreName");
     char[] password = {'a', 'b', 'c'};
@@ -86,11 +86,11 @@ public class EncryptingUsingSDK {
     Cluster cluster = Cluster.connect("localhost",
         ClusterOptions.clusterOptions("username", "password")
             .environment(env));
-    // #end::encrypting_using_sdk_1[]
+    // end::encrypting_using_sdk_1[]
   }
 
   // file: howtos/pages/encrypting-using-sdk.adoc line: 97
-  // #tag::encrypting_using_sdk_2[]
+  // tag::encrypting_using_sdk_2[]
   public class Employee {
     @Encrypted
     private boolean replicant;
@@ -105,59 +105,59 @@ public class EncryptingUsingSDK {
     }
   }
 
-  // #end::encrypting_using_sdk_2[]
+  // end::encrypting_using_sdk_2[]
   public void encrypting_using_sdk_3() throws Exception { // file: howtos/pages/encrypting-using-sdk.adoc line: 116
-    // #tag::encrypting_using_sdk_3[]
+    // tag::encrypting_using_sdk_3[]
     Collection collection = cluster.bucket("myBucket")
         .defaultCollection();
 
     Employee employee = new Employee();
     employee.setReplicant(true);
     collection.upsert("employee:1234", employee);
-    // #end::encrypting_using_sdk_3[]
+    // end::encrypting_using_sdk_3[]
   }
 
   public void encrypting_using_sdk_4() throws Exception { // file: howtos/pages/encrypting-using-sdk.adoc line: 128
-    // #tag::encrypting_using_sdk_4[]
+    // tag::encrypting_using_sdk_4[]
     JsonObject encrypted = collection.get("employee:1234")
         .contentAsObject();
 
     System.out.println(encrypted);
-    // #end::encrypting_using_sdk_4[]
+    // end::encrypting_using_sdk_4[]
   }
 
   public void encrypting_using_sdk_5() throws Exception { // file: howtos/pages/encrypting-using-sdk.adoc line: 152
-    // #tag::encrypting_using_sdk_5[]
+    // tag::encrypting_using_sdk_5[]
     Employee readItBack = collection.get("employee:1234")
         .contentAs(Employee.class);
 
     System.out.println(readItBack.isReplicant());
-    // #end::encrypting_using_sdk_5[]
+    // end::encrypting_using_sdk_5[]
   }
 
   public void legacy_decrypters() throws Exception {
     Keyring keyring = Keyring.fromMap(Collections.emptyMap());
 
-    // #tag::legacy_decrypters[]
+    // tag::legacy_decrypters[]
     CryptoManager cryptoManager = DefaultCryptoManager.builder()
         .legacyAesDecrypters(keyring, encryptionKeyName -> "MySigningKeyName")
         .legacyRsaDecrypter(keyring, publicKeyName -> "MyPrivateKeyName")
         // other config...
         .build();
-    // #end::legacy_decrypters[]
+    // end::legacy_decrypters[]
   }
 
   public void legacy_field_name_prefix() throws Exception {
-    // #tag::legacy_field_name_prefix[]
+    // tag::legacy_field_name_prefix[]
     CryptoManager cryptoManager = DefaultCryptoManager.builder()
         .encryptedFieldNamePrefix("__crypt_")
         // other config...
         .build();
-    // #end::legacy_field_name_prefix[]
+    // end::legacy_field_name_prefix[]
   }
 
   public void encrypting_using_sdk_6() throws Exception { // file: howtos/pages/encrypting-using-sdk.adoc line: 173
-    // #tag::encrypting_using_sdk_6[]
+    // tag::encrypting_using_sdk_6[]
     // CryptoManager cryptoManager = createMyCryptoManager();
     KeyStore javaKeyStore = KeyStore.getInstance("MyKeyStoreType");
     FileInputStream fis = new java.io.FileInputStream("keyStoreName");
@@ -188,11 +188,11 @@ public class EncryptingUsingSDK {
     Cluster cluster = Cluster.connect(connectionString,
         ClusterOptions.clusterOptions(username, password)
             .environment(env));
-    // #end::encrypting_using_sdk_6[]
+    // end::encrypting_using_sdk_6[]
   }
 
   public void encrypting_using_sdk_7() throws Exception { // file: howtos/pages/encrypting-using-sdk.adoc line: 204
-    // #tag::encrypting_using_sdk_7[]
+    // tag::encrypting_using_sdk_7[]
     Collection collection = cluster.bucket("myBucket").defaultCollection();
 
     JsonObject document = JsonObject.create();
@@ -208,11 +208,11 @@ public class EncryptingUsingSDK {
     JsonObject readItBack = collection.get("treasureMap").contentAsObject();
     JsonObjectCrypto readItBackCrypto = crypto.withObject(readItBack);
     System.out.println(readItBackCrypto.getString("locationOfBuriedTreasure"));
-    // #end::encrypting_using_sdk_7[]
+    // end::encrypting_using_sdk_7[]
   }
 
   public void encrypting_using_sdk_8() throws Exception { // file: howtos/pages/encrypting-using-sdk.adoc line: 231
-    // #tag::encrypting_using_sdk_8[]
+    // tag::encrypting_using_sdk_8[]
     KeyStore keyStore = KeyStore.getInstance("JCEKS");
     keyStore.load(null); // initialize new empty key store
 
@@ -229,11 +229,11 @@ public class EncryptingUsingSDK {
     try (OutputStream os = new FileOutputStream("MyKeystoreFile.jceks")) {
       keyStore.store(os, "integrity-password".toCharArray());
     }
-    // #end::encrypting_using_sdk_8[]
+    // end::encrypting_using_sdk_8[]
   }
 
   public void encrypting_using_sdk_9() throws Exception { // file: howtos/pages/encrypting-using-sdk.adoc line: 253
-    // #tag::encrypting_using_sdk_9[]
+    // tag::encrypting_using_sdk_9[]
     KeyStore keyStore = KeyStore.getInstance("JCEKS");
     try (InputStream is = new FileInputStream("MyKeystoreFile.jceks")) {
       keyStore.load(is, "integrity-password".toCharArray());
@@ -241,7 +241,7 @@ public class EncryptingUsingSDK {
 
     KeyStoreKeyring keyring = new KeyStoreKeyring(
         keyStore, keyName -> "protection-password");
-    // #end::encrypting_using_sdk_9[]
+    // end::encrypting_using_sdk_9[]
   }
 
   public static void main(String[] args) throws Exception {

--- a/modules/howtos/examples/ErrorHandling.java
+++ b/modules/howtos/examples/ErrorHandling.java
@@ -37,7 +37,7 @@ public class ErrorHandling {
     Collection collection = bucket.collection("travel-sample");
 
 
-    // #tag::readonly[]
+    // tag::readonly[]
     QueryResult queryResult = cluster.query(
       "SELECT * FROM bucket",
       queryOptions().readonly(true)
@@ -47,10 +47,10 @@ public class ErrorHandling {
       "SELECT * FROM dataset",
       analyticsOptions().readonly(true)
     );
-    // #end::readonly[]
+    // end::readonly[]
 
     {
-      // #tag::getfetch[]
+      // tag::getfetch[]
       // This will raise a `CouchbaseException` and propagate it
       GetResult result = collection.get("my-document-id");
 
@@ -60,11 +60,11 @@ public class ErrorHandling {
       } catch (CouchbaseException ex) {
         throw new DatabaseException("Couchbase lookup failed", ex);
       }
-      // #end::getfetch[]
+      // end::getfetch[]
     }
 
     {
-      // #tag::getcatch[]
+      // tag::getcatch[]
       try {
         collection.get("my-document-id");
       } catch (DocumentNotFoundException ex) {
@@ -72,11 +72,11 @@ public class ErrorHandling {
       } catch (CouchbaseException ex) {
         throw new DatabaseException("Couchbase lookup failed", ex);
       }
-      // #end::getcatch[]
+      // end::getcatch[]
     }
 
     {
-      // #tag::tryupsert[]
+      // tag::tryupsert[]
       for (int i = 0; i < 10; i++) {
         try {
           collection.upsert("docid", JsonObject.create().put("my", "value"));
@@ -89,29 +89,29 @@ public class ErrorHandling {
           // don't break, so retry
         }
       }
-      // #end::tryupsert[]
+      // end::tryupsert[]
     }
 
     {
       RetryStrategy myCustomStrategy = null;
-      // #tag::customglobal[]
+      // tag::customglobal[]
       ClusterEnvironment environment = ClusterEnvironment
         .builder()
         .retryStrategy(myCustomStrategy)
         .build();
-      // #end::customglobal[]
+      // end::customglobal[]
       environment.shutdown();
     }
 
     {
       RetryStrategy myCustomStrategy = null;
-      // #tag::customreq[]
+      // tag::customreq[]
       collection.get("doc-id", getOptions().retryStrategy(myCustomStrategy));
-      // #end::customreq[]
+      // end::customreq[]
     }
 
     {
-      // #tag::reactivesub[]
+      // tag::reactivesub[]
       collection.reactive()
         .get("this-doc-does-not-exist")
         .subscribe(new Subscriber<GetResult>() {
@@ -130,11 +130,11 @@ public class ErrorHandling {
           @Override
           public void onComplete() { }
         });
-      // #end::reactivesub[]
+      // end::reactivesub[]
     }
 
     {
-      // #tag::reactivefallback[]
+      // tag::reactivefallback[]
       Mono<JsonObject> documentContent = collection.reactive()
         .get("my-doc-id")
         .map(GetResult::contentAsObject)
@@ -142,17 +142,17 @@ public class ErrorHandling {
           DocumentNotFoundException.class,
           e -> createDocumentReactive("my-doc-id")
         );
-      // #end::reactivefallback[]
+      // end::reactivefallback[]
     }
 
     {
-      // #tag::reactiveretry[]
+      // tag::reactiveretry[]
       collection.reactive()
         .get("my-doc-id")
         .retryWhen(
           Retry.max(5).filter(t -> t instanceof DocumentNotFoundException)
         );
-      // #end::reactiveretry[]
+      // end::reactiveretry[]
     }
   }
 
@@ -164,7 +164,7 @@ public class ErrorHandling {
     return Mono.empty();
   }
 
-  // #tag::customclass[]
+  // tag::customclass[]
   class MyCustomRetryStrategy extends BestEffortRetryStrategy {
 
     @Override
@@ -177,9 +177,9 @@ public class ErrorHandling {
       return super.shouldRetry(request, reason);
     }
   }
-  // #end::customclass[]
+  // end::customclass[]
 
-  // #tag::failfastcircuit[]
+  // tag::failfastcircuit[]
   class MyCustomRetryStrategy2 extends BestEffortRetryStrategy {
     @Override
     public CompletableFuture<RetryAction> shouldRetry(Request<? extends Response> request, RetryReason reason) {
@@ -190,7 +190,7 @@ public class ErrorHandling {
       return super.shouldRetry(request, reason);
     }
   }
-  // #end::failfastcircuit[]
+  // end::failfastcircuit[]
 
   static class DatabaseException extends RuntimeException {
     public DatabaseException(String message, Throwable cause) {

--- a/modules/howtos/examples/HealthCheck.java
+++ b/modules/howtos/examples/HealthCheck.java
@@ -40,7 +40,7 @@ public class HealthCheck {
     Collection collection = scope.collection("collection-name");
 
     {
-// #tag::ping-basic[]
+// tag::ping-basic[]
 PingResult pingResult = cluster.ping();
 
 for (Map.Entry<ServiceType, List<EndpointPingReport>> service : pingResult.endpoints().entrySet()) {
@@ -50,27 +50,27 @@ for (Map.Entry<ServiceType, List<EndpointPingReport>> service : pingResult.endpo
     );
   }
 }
-// #end::ping-basic[]
+// end::ping-basic[]
     }
 
     {
-// #tag::ping-json-export[]
+// tag::ping-json-export[]
 PingResult pingResult = cluster.ping();
 
 System.out.println(pingResult.exportToJson());
-// #end::ping-json-export[]
+// end::ping-json-export[]
     }
 
     {
-// #tag::ping-options[]
+// tag::ping-options[]
 PingResult pingResult = cluster.ping(pingOptions().serviceTypes(EnumSet.of(ServiceType.QUERY)));
 
 System.out.println(pingResult.exportToJson());
-// #end::ping-options[]
+// end::ping-options[]
     }
 
     {
-// #tag::diagnostics-basic[]
+// tag::diagnostics-basic[]
 DiagnosticsResult diagnosticsResult = cluster.diagnostics();
 
 for (Map.Entry<ServiceType, List<EndpointDiagnostics>> service : diagnosticsResult.endpoints().entrySet()) {
@@ -80,15 +80,15 @@ for (Map.Entry<ServiceType, List<EndpointDiagnostics>> service : diagnosticsResu
     );
   }
 }
-// #end::diagnostics-basic[]
+// end::diagnostics-basic[]
     }
 
     {
-// #tag::diagnostics-options[]
+// tag::diagnostics-options[]
 DiagnosticsResult diagnosticsResult = cluster.diagnostics();
 
 System.out.println(diagnosticsResult.exportToJson());
-// #end::diagnostics-options[]
+// end::diagnostics-options[]
     }
   }
 

--- a/modules/howtos/examples/KvOperations.java
+++ b/modules/howtos/examples/KvOperations.java
@@ -75,7 +75,7 @@ try {
 {
 // tag::get-simple[]
 try {
-  GetResult getResult = collection.get("document-key"); 
+  GetResult getResult = collection.get("document-key");
   String title = getResult.contentAsObject().getString("title");
   System.out.println(title); // title == "My Blog Post"
 } catch (DocumentNotFoundException ex) {
@@ -93,7 +93,7 @@ if (content.getString("author").equals("mike")) {
 } else {
     // do something else
 }
-// #end::get[]
+// end::get[]
 }
 
 {

--- a/modules/howtos/examples/ManagingConnections.java
+++ b/modules/howtos/examples/ManagingConnections.java
@@ -35,7 +35,7 @@ public class ManagingConnections {
   public static void main(String... args) {
 
     {
-      // #tag::simpleconnect[]
+      // tag::simpleconnect[]
       Cluster cluster = Cluster.connect("127.0.0.1", "username", "password");
       Bucket bucket = cluster.bucket("travel-sample");
       Collection collection = bucket.defaultCollection();
@@ -50,18 +50,18 @@ public class ManagingConnections {
 
       // For a graceful shutdown, disconnect from the cluster when the program ends.
       cluster.disconnect();
-      // #end::simpleconnect[]
+      // end::simpleconnect[]
     }
 
     {
-      // #tag::multinodeconnect[]
+      // tag::multinodeconnect[]
       Cluster cluster = Cluster.connect("192.168.56.101,192.168.56.102", "username", "password");
-      // #end::multinodeconnect[]
+      // end::multinodeconnect[]
     }
 
 
     {
-      // #tag::customenv[]
+      // tag::customenv[]
       ClusterEnvironment env = ClusterEnvironment.builder()
           // Customize client settings by calling methods on the builder
           .build();
@@ -75,11 +75,11 @@ public class ManagingConnections {
       // after all associated clusters are disconnected.
       cluster.disconnect();
       env.shutdown();
-      // #end::customenv[]
+      // end::customenv[]
     }
 
     {
-      // #tag::shareclusterenvironment[]
+      // tag::shareclusterenvironment[]
       ClusterEnvironment env = ClusterEnvironment.builder()
           .timeoutConfig(TimeoutConfig.kvTimeout(Duration.ofSeconds(5)))
           .build();
@@ -101,12 +101,12 @@ public class ManagingConnections {
       clusterA.disconnect();
       clusterB.disconnect();
       env.shutdown();
-      // #end::shareclusterenvironment[]
+      // end::shareclusterenvironment[]
     }
 
     // todo use this example when beta 2 is released.
 //    {
-//      // #tag::seednodes[]
+//      // tag::seednodes[]
 //      int customKvPort = 12345;
 //      int customManagerPort = 23456;
 //      Set<SeedNode> seedNodes = new HashSet<>(Arrays.asList(
@@ -116,18 +116,18 @@ public class ManagingConnections {
 //
 
 //      Cluster cluster = Cluster.connect(seedNodes, "username", "password");
-//      // #end::customconnect[]
+//      // end::customconnect[]
 //    }
 
     {
-      // #tag::connectionstringparams[]
+      // tag::connectionstringparams[]
       Cluster cluster = Cluster.connect(
           "127.0.0.1?io.maxHttpConnections=23&io.networkResolution=external", "username", "password");
-      // #end::connectionstringparams[]
+      // end::connectionstringparams[]
     }
 
     {
-      // #tag::blockingtoasync[]
+      // tag::blockingtoasync[]
       Cluster cluster = Cluster.connect("127.0.0.1", "username", "password");
       Bucket bucket = cluster.bucket("travel-sample");
 
@@ -138,11 +138,11 @@ public class ManagingConnections {
       ReactiveBucket reactiveBucket = bucket.reactive();
 
       cluster.disconnect();
-      // #end::blockingtoasync[]
+      // end::blockingtoasync[]
     }
 
     {
-      // #tag::reactivecluster[]
+      // tag::reactivecluster[]
       ReactiveCluster cluster = ReactiveCluster.connect("127.0.0.1", "username", "password");
       ReactiveBucket bucket = cluster.bucket("travel-sample");
 
@@ -150,11 +150,11 @@ public class ManagingConnections {
       // Nothing actually happens until you subscribe to the Mono.
       // The simplest way to subscribe is to await completion by calling call `block()`.
       cluster.disconnect().block();
-      // #end::reactivecluster[]
+      // end::reactivecluster[]
     }
 
     {
-      // #tag::asynccluster[]
+      // tag::asynccluster[]
       AsyncCluster cluster = AsyncCluster.connect("127.0.0.1", "username", "password");
       AsyncBucket bucket = cluster.bucket("travel-sample");
 
@@ -162,25 +162,25 @@ public class ManagingConnections {
       // The disconnection starts as soon as you call disconnect().
       // The simplest way to wait for the disconnect to complete is to call `join()`.
       cluster.disconnect().join();
-      // #end::asynccluster[]
+      // end::asynccluster[]
     }
 
 
     {
-      // #tag::tls[]
+      // tag::tls[]
       ClusterEnvironment env = ClusterEnvironment.builder()
           .securityConfig(SecurityConfig.enableTls(true)
               .trustCertificate(Paths.get("/path/to/cluster.cert")))
           .build();
-      // #end::tls[]
+      // end::tls[]
     }
 
     {
-      // #tag::dnssrv[]
+      // tag::dnssrv[]
       ClusterEnvironment env = ClusterEnvironment.builder()
           .ioConfig(IoConfig.enableDnsSrv(true))
           .build();
-      // #end::dnssrv[]
+      // end::dnssrv[]
     }
   }
 }

--- a/modules/howtos/examples/Queries.java
+++ b/modules/howtos/examples/Queries.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-// #tag::imports[]
+// tag::imports[]
 import com.couchbase.client.core.error.CouchbaseException;
 import com.couchbase.client.java.*;
 import com.couchbase.client.java.json.*;
@@ -28,7 +28,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.couchbase.client.java.query.QueryOptions.queryOptions;
-// #end::imports[]
+// end::imports[]
 
 
 class Queries {
@@ -37,7 +37,7 @@ class Queries {
 
   public static void main(String... args) {
     {
-      // #tag::simple[]
+      // tag::simple[]
       try {
         final QueryResult result = cluster
           .query("select * from `travel-sample` limit 10", queryOptions().metrics(true));
@@ -51,91 +51,91 @@ class Queries {
       } catch (CouchbaseException ex) {
         ex.printStackTrace();
       }
-      // #end::simple[]
+      // end::simple[]
     }
 
     {
-      // #tag::named[]
+      // tag::named[]
       QueryResult result = cluster.query(
         "select count(*) from `travel-sample` where type = \"airport\" and country = $country",
         queryOptions().parameters(JsonObject.create().put("country", "France"))
       );
-      // #end::named[]
+      // end::named[]
     }
 
 
     {
-      // #tag::positional[]
+      // tag::positional[]
       QueryResult result = cluster.query(
         "select count(*) from `travel-sample` where type = \"airport\" and country = ?",
         queryOptions().parameters(JsonArray.from("France"))
       );
-      // #end::positional[]
+      // end::positional[]
     }
 
     {
-      // #tag::scanconsistency[]
+      // tag::scanconsistency[]
       QueryResult result = cluster.query(
         "select ...",
         queryOptions().scanConsistency(QueryScanConsistency.REQUEST_PLUS)
       );
-      // #end::scanconsistency[]
+      // end::scanconsistency[]
     }
 
     {
-      // #tag::scanconsistency_with[]
+      // tag::scanconsistency_with[]
       Bucket bucket = cluster.bucket("travel-sample");
       Collection collection = bucket.defaultCollection();
       MutationResult mr = collection.upsert("someDoc",JsonObject.create().put("name", "roi"));
       MutationState mutationState = MutationState.from(mr.mutationToken().get());
-    
-      QueryOptions qo = QueryOptions.queryOptions().consistentWith(mutationState); 
+
+      QueryOptions qo = QueryOptions.queryOptions().consistentWith(mutationState);
       QueryResult result = cluster.query(
         "select raw meta().id from `bucket1` limit 100;",qo
       );
-      // #end::scanconsistency_with[]
+      // end::scanconsistency_with[]
     }
 
     {
-      // #tag::clientcontextid[]
+      // tag::clientcontextid[]
       QueryResult result = cluster.query(
         "select ...",
         queryOptions().clientContextId("user-44" + UUID.randomUUID())
       );
-      // #end::clientcontextid[]
+      // end::clientcontextid[]
     }
 
     {
-      // #tag::readonly[]
+      // tag::readonly[]
       QueryResult result = cluster.query(
         "select ...",
         queryOptions().readonly(true)
       );
-      // #end::readonly[]
+      // end::readonly[]
     }
 
     {
-      // #tag::printmetrics[]
+      // tag::printmetrics[]
       QueryResult result = cluster.query("select 1=1", queryOptions().metrics(true));
       System.err.println(
         "Execution time: " + result.metaData().metrics().get().executionTime()
       );
-      // #end::printmetrics[]
+      // end::printmetrics[]
     }
 
     {
-      // #tag::rowsasobject[]
+      // tag::rowsasobject[]
       QueryResult result = cluster.query(
         "select * from `travel-sample` limit 10"
       );
       for (JsonObject row : result.rowsAsObject()) {
         System.out.println("Found row: " + row);
       }
-      // #end::rowsasobject[]
+      // end::rowsasobject[]
     }
 
     {
-      // #tag::simplereactive[]
+      // tag::simplereactive[]
       Mono<ReactiveQueryResult> result = cluster
         .reactive()
         .query("select 1=1");
@@ -143,11 +143,11 @@ class Queries {
       result
         .flatMapMany(ReactiveQueryResult::rowsAsObject)
         .subscribe(row -> System.out.println("Found row: " + row));
-      // #end::simplereactive[]
+      // end::simplereactive[]
     }
 
     {
-      // #tag::backpressure[]
+      // tag::backpressure[]
       Mono<ReactiveQueryResult> result = cluster
         .reactive()
         .query("select * from hugeBucket");
@@ -172,7 +172,7 @@ class Queries {
             }
           }
         });
-      // #end::backpressure[]
+      // end::backpressure[]
     }
 
   }

--- a/modules/howtos/examples/Search.java
+++ b/modules/howtos/examples/Search.java
@@ -49,7 +49,7 @@ public class Search {
   public static void main(String... args) {
 
     {
-      // #tag::simple[]
+      // tag::simple[]
       try {
         final SearchResult result = cluster
           .searchQuery("index", SearchQuery.queryString("query"));
@@ -63,11 +63,11 @@ public class Search {
       } catch (CouchbaseException ex) {
         ex.printStackTrace();
       }
-      // #end::simple[]
+      // end::simple[]
     }
 
     {
-      // #tag::squery[]
+      // tag::squery[]
       final SearchResult result = cluster
         .searchQuery("my-index-name", SearchQuery.prefix("airports-"), searchOptions().fields("field-1"));
 
@@ -78,21 +78,21 @@ public class Search {
         // Also print fields that are included in the query
         System.out.println(row.fieldsAs(JsonObject.class));
       }
-      // #end::squery[]
+      // end::squery[]
     }
 
     {
-      // #tag::limit[]
+      // tag::limit[]
       SearchResult result = cluster.searchQuery(
         "index",
         SearchQuery.queryString("query"),
         searchOptions().skip(3).limit(4)
       );
-      // #end::limit[]
+      // end::limit[]
     }
 
     {
-      // #tag::ryow[]
+      // tag::ryow[]
       MutationResult mutationResult = collection.upsert("key", JsonObject.create());
       MutationState mutationState = MutationState.from(mutationResult.mutationToken().get());
 
@@ -101,31 +101,31 @@ public class Search {
         SearchQuery.queryString("query"),
         searchOptions().consistentWith(mutationState)
       );
-      // #end::ryow[]
+      // end::ryow[]
     }
 
     {
-      // #tag::highlight[]
+      // tag::highlight[]
       SearchResult result = cluster.searchQuery(
         "index",
         SearchQuery.queryString("query"),
         searchOptions().highlight(HighlightStyle.HTML, "field1", "field2")
       );
-      // #end::highlight[]
+      // end::highlight[]
     }
 
     {
-      // #tag::sort[]
+      // tag::sort[]
       SearchResult result = cluster.searchQuery(
         "index",
         SearchQuery.queryString("query"),
         searchOptions().sort(SearchSort.byScore(), SearchSort.byField("field"))
       );
-      // #end::sort[]
+      // end::sort[]
     }
 
     {
-      // #tag::facets[]
+      // tag::facets[]
       Map<String, SearchFacet> facets = new HashMap<>();
       facets.put("categories", SearchFacet.term("category", 5));
 
@@ -134,21 +134,21 @@ public class Search {
         SearchQuery.queryString("query"),
         searchOptions().facets(facets)
       );
-      // #end::facets[]
+      // end::facets[]
     }
 
     {
-      // #tag::fields[]
+      // tag::fields[]
       SearchResult result = cluster.searchQuery(
         "index",
         SearchQuery.queryString("query"),
         searchOptions().fields("field1", "field2")
       );
-      // #end::fields[]
+      // end::fields[]
     }
 
     {
-      // #tag::simplereactive[]
+      // tag::simplereactive[]
       Mono<ReactiveSearchResult> result = cluster
         .reactive()
         .searchQuery("index", SearchQuery.queryString("query"));
@@ -156,11 +156,11 @@ public class Search {
       result
         .flatMapMany(ReactiveSearchResult::rows)
         .subscribe(row -> System.out.println("Found row: " + row));
-      // #end::simplereactive[]
+      // end::simplereactive[]
     }
 
     {
-      // #tag::backpressure[]
+      // tag::backpressure[]
       Mono<ReactiveSearchResult> result = cluster
         .reactive()
         .searchQuery("index", SearchQuery.queryString("query"));
@@ -185,7 +185,7 @@ public class Search {
             }
           }
         });
-      // #end::backpressure[]
+      // end::backpressure[]
     }
   }
 

--- a/modules/howtos/examples/SubDocument.java
+++ b/modules/howtos/examples/SubDocument.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-// #tag::imports[]
+// tag::imports[]
 
 import com.couchbase.client.core.error.CasMismatchException;
 import com.couchbase.client.core.error.DurabilityImpossibleException;
@@ -54,7 +54,7 @@ import static com.couchbase.client.java.kv.MutateInSpec.increment;
 import static com.couchbase.client.java.kv.MutateInSpec.insert;
 import static com.couchbase.client.java.kv.MutateInSpec.remove;
 import static com.couchbase.client.java.kv.MutateInSpec.upsert;
-// #end::imports[]
+// end::imports[]
 
 class SubDocument {
   static Collection collection;
@@ -95,7 +95,7 @@ class SubDocument {
   }
 
   static void getFunc() {
-    // #tag::get[]
+    // tag::get[]
     LookupInResult result = collection.lookupIn(
         "airport_1254",
         Collections.singletonList(get("geo.alt"))
@@ -103,12 +103,12 @@ class SubDocument {
 
     String str = result.contentAs(0, String.class);
     System.out.println("getFunc: Altitude = " + str);
-    // #end::get[]
+    // end::get[]
   }
 
   static void existsFunc() {
 
-    // #tag::exists[]
+    // tag::exists[]
     try {
       LookupInResult result = collection.lookupIn(
           "airport_1254",
@@ -117,11 +117,11 @@ class SubDocument {
     } catch (PathNotFoundException e) {
       System.out.println("existsFunc: " + e);
     }
-    // #end::exists[]
+    // end::exists[]
   }
 
   static void combine() {
-    // #tag::combine[]
+    // tag::combine[]
     try {
       LookupInResult result = collection.lookupIn(
           "airport_1254",
@@ -133,11 +133,11 @@ class SubDocument {
     } catch (PathNotFoundException e) {
       System.out.println("combine: " + e);
     }
-    // #end::combine[]
+    // end::combine[]
   }
 
   static void future() {
-    // #tag::get-future[]
+    // tag::get-future[]
     CompletableFuture<LookupInResult> future = collection.async().lookupIn(
         "airport_1254",
         Collections.singletonList(get("geo.alt"))
@@ -150,11 +150,11 @@ class SubDocument {
       e.printStackTrace();
     }
 
-    // #end::get-future[]
+    // end::get-future[]
   }
 
   static void reactive() {
-    // #tag::get-reactive[]
+    // tag::get-reactive[]
     Mono<LookupInResult> mono = collection.reactive().lookupIn(
         "airport_1254",
         Collections.singletonList(get("geo.alt"))
@@ -162,21 +162,21 @@ class SubDocument {
 
     // Just for example, block on the result - this is not best practice
     LookupInResult result = mono.block();
-    // #end::get-reactive[]
+    // end::get-reactive[]
     System.out.println("reactive: Altitude: " + result.contentAs(0, Number.class));
   }
 
   static void upsertFunc() {
-    // #tag::upsert[]
+    // tag::upsert[]
     collection.mutateIn("airport_1254", Arrays.asList(
         upsert("email", "dougr96@hotmail.com")
     ));
-    // #end::upsert[]
+    // end::upsert[]
     System.out.println("upsertFunc: airport_1254 email");
   }
 
   static void insertFunc() {
-    // #tag::insert[]
+    // tag::insert[]
     try {
       collection.mutateIn("airport_1254", Collections.singletonList(
           insert("email", "dougr96@hotmail.com")
@@ -184,7 +184,7 @@ class SubDocument {
     } catch (PathExistsException err) {
       System.out.println("insertFunc: exception caught, path already exists");
     }
-    // #end::insert[]
+    // end::insert[]
   }
 
   static void multiFunc() {
@@ -200,12 +200,12 @@ class SubDocument {
       ));
     } catch (PathNotFoundException e) {
     }
-    // #tag::multi[]
+    // tag::multi[]
     collection.mutateIn("airport_1254", Arrays.asList(
         remove("tz"),
         insert("email", "fredk84@hotmail.com")
     ));
-    // #end::multi[]
+    // end::multi[]
     System.out.println("upsertFunc: airport_1254 email");
   }
 
@@ -216,21 +216,21 @@ class SubDocument {
     docContent.put("flight", "DL999");
     docContent.put("utc", "11:59:59");
 
-    // #tag::array-appendobj[]
+    // tag::array-appendobj[]
     collection.mutateIn("route_21254", Collections.singletonList(
         arrayAppend("schedule", Collections.singletonList(docContent))
     ));
-    // #end::array-appendobj[]
+    // end::array-appendobj[]
     System.out.println("arrayAppendObjFunc: route_21254 schedule");
   }
 
   static void arrayAppendFunc() {
-    // #tag::array-append[]
+    // tag::array-append[]
     MutationResult result = collection.mutateIn("customer123", Collections.singletonList(
         arrayAppend("purchases.complete", Collections.singletonList(777))
     ));
     // purchases.complete is now [339, 976, 442, 666, 777]
-    // #end::array-append[]
+    // end::array-append[]
   }
 
   static void arrayPrependObjFunc() {
@@ -238,55 +238,55 @@ class SubDocument {
     docContent.put("day", 0);
     docContent.put("flight", "DL000");
     docContent.put("utc", "00:00:00");
-    // #tag::array-prependobj[]
+    // tag::array-prependobj[]
     collection.mutateIn("route_21254", Collections.singletonList(
         arrayPrepend("schedule", Collections.singletonList(docContent))
     ));
-    // #end::array-prependobj[]
+    // end::array-prependobj[]
     System.out.println("arrayAppendObjFunc: route_21254 schedule");
   }
 
   static void arrayPrependFunc() {
-    // #tag::array-prepend[]
+    // tag::array-prepend[]
     MutationResult result = collection.mutateIn("customer123", Collections.singletonList(
         arrayPrepend("purchases.abandoned", Collections.singletonList(18))
     ));
 
     // purchases.abandoned is now [18, 157, 49, 999]
-    // #end::array-prepend[]
+    // end::array-prepend[]
   }
 
   static void full_doc_replaceFunc() {
-    // #tag::full_doc_replace[]
+    // tag::full_doc_replace[]
     JsonObject docContent = JsonObject.create().put("body", "value");
     collection.mutateIn("airport_1255", Arrays.asList(
         MutateInSpec.upsert("foo", "bar").xattr().createPath(),
         MutateInSpec.replace("", docContent))
     );
-    // #end::full_doc_replace[]
+    // end::full_doc_replace[]
     System.out.println("full_doc_replaceFunc: airport_1255 foo");
 
   }
 
     static void createAndPopulateArrays() {
-    // #tag::array-create[]
+    // tag::array-create[]
     collection.upsert("my_array", JsonArray.create());
 
     collection.mutateIn("my_array", Collections.singletonList(
         arrayAppend("", Collections.singletonList("some element"))
     ));
     // the document my_array is now ["some element"]
-    // #end::array-create[]
+    // end::array-create[]
     System.out.println("createAndPopulateArrays: my_array some element");
 
   }
 
   static void arrayCreate() {
-    // #tag::array-upsert[]
+    // tag::array-upsert[]
     MutateInResult result = collection.mutateIn("airport_1256", Collections.singletonList(
         arrayAppend("some.array", Collections.singletonList("hello world")).createPath()
     ));
-    // #end::array-upsert[]
+    // end::array-upsert[]
     System.out.println("arrayCreate: airport_1256 some.array " + result);
 
   }
@@ -295,7 +295,7 @@ class SubDocument {
     collection.mutateIn("airport_1257", Arrays.asList(
         MutateInSpec.upsert("unique", Collections.singletonList(88))
     ));
-    // #tag::array-unique[]
+    // tag::array-unique[]
     collection.mutateIn("airport_1257", Collections.singletonList(
         arrayAddUnique("unique", 95)
     ));
@@ -308,18 +308,18 @@ class SubDocument {
     } catch (PathExistsException err) {
       System.out.println("arrayUnique: caught exception, path already exists");
     }
-    // #end::array-unique[]
+    // end::array-unique[]
   }
 
   static void arrayInsertFunc() {
     collection.mutateIn("airport_1258", Arrays.asList(
         MutateInSpec.upsert("foo", Collections.singletonList(88))
     ));
-    // #tag::array-insert[]
+    // tag::array-insert[]
     MutateInResult result = collection.mutateIn("airport_1258", Collections.singletonList(
         arrayInsert("foo[1]", Collections.singletonList("cruel"))
     ));
-    // #end::array-insert[]
+    // end::array-insert[]
     System.out.println("arrayInsertFunc: airport_1258 foo " + result);
 
   }
@@ -328,14 +328,14 @@ class SubDocument {
     collection.mutateIn("airport_1254", Arrays.asList(
         MutateInSpec.upsert("logins", 1)
     ));
-    // #tag::counter-inc[]
+    // tag::counter-inc[]
     MutateInResult result = collection.mutateIn("airport_1254", Collections.singletonList(
         increment("logins", 1)
     ));
 
     // Counter operations return the updated count
     Long count = result.contentAs(0, Long.class);
-    // #end::counter-inc[]
+    // end::counter-inc[]
     System.out.println("counterInc: airport_1254 logins " + count);
 
   }
@@ -344,20 +344,20 @@ class SubDocument {
     collection.mutateIn("airport_1254", Arrays.asList(
         MutateInSpec.upsert("logouts", 1000)
     ));
-    // #tag::counter-dec[]
+    // tag::counter-dec[]
 
     MutateInResult result = collection.mutateIn("airport_1254", Collections.singletonList(
         decrement("logouts", 150)
     ));
     // Counter operations return the updated count
     Long count = result.contentAs(0, Long.class);
-    // #end::counter-dec[]
+    // end::counter-dec[]
     System.out.println("counterDec: airport_1254 logouts " + count);
 
   }
 
   static void createPath() {
-    // #tag::create-path[]
+    // tag::create-path[]
     MutateInResult result = collection.mutateIn("airport_1254", Collections.singletonList(
         upsert("level_0.level_1.foo.bar.phone",
             JsonObject.create()
@@ -365,12 +365,12 @@ class SubDocument {
                 .put("ext", 16))
             .createPath()
     ));
-    // #end::create-path[]
+    // end::create-path[]
     System.out.println("createPath: airport_1254 " + result);
   }
 
   static void concurrent() {
-    // #tag::concurrent[]
+    // tag::concurrent[]
     Thread thread1 = new Thread() {
       public void run() {
         collection.mutateIn("airport_1258", Collections.singletonList(
@@ -388,7 +388,7 @@ class SubDocument {
     };
     thread1.start();
     thread2.start();
-    // #end::concurrent[]
+    // end::concurrent[]
     try {
       thread1.join();
     } catch (InterruptedException e) {
@@ -405,19 +405,19 @@ class SubDocument {
   }
 
   static void cas() {
-    // #tag::cas[]
+    // tag::cas[]
     GetResult doc = collection.get("airport_1254");
     MutationResult result = collection.mutateIn(
         "airport_1254",
         Collections.singletonList(decrement("logouts", 150)),
         mutateInOptions().cas(doc.cas())
     );
-    // #end::cas[]
+    // end::cas[]
     System.out.println("cas: airport_1258 " + doc);
   }
 
   static void cas_fail() {
-    // #tag::cas_fail[]
+    // tag::cas_fail[]
     GetResult doc = collection.get("airport_1254");
     try {
       MutationResult result = collection.mutateIn(
@@ -428,18 +428,18 @@ class SubDocument {
     } catch (CasMismatchException e) {
       System.out.println("cas_fail: " + e);
     }
-    // #end::cas_fail[]
+    // end::cas_fail[]
   }
 
   static void oldDurability() {
     try {
-      // #tag::old-durability[]
+      // tag::old-durability[]
       MutationResult result = collection.mutateIn(
           "airport_1254",
           Collections.singletonList(MutateInSpec.upsert("foo", "bar")),
           mutateInOptions().durability(PersistTo.ACTIVE, ReplicateTo.ONE)
       );
-      // #end::old-durability[]
+      // end::old-durability[]
       System.out.println("oldDurability: " + result);
     } catch (RuntimeException e) {
       System.out.println("oldDurability: replication not possible: " + e);
@@ -448,13 +448,13 @@ class SubDocument {
 
   static void newDurability() {
     try {
-      // #tag::new-durability[]
+      // tag::new-durability[]
       MutationResult result = collection.mutateIn(
           "airport_1254",
           Collections.singletonList(MutateInSpec.upsert("foo", "bar")),
           mutateInOptions().durability(DurabilityLevel.MAJORITY)
       );
-      // #end::new-durability[]
+      // end::new-durability[]
       System.out.println("newDurability: " + result);
     } catch (DurabilityImpossibleException e) {
       System.out.println("newDurability: replication not possible: " + e);

--- a/modules/howtos/examples/TransactionsExample.java
+++ b/modules/howtos/examples/TransactionsExample.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-// #tag::imports[]
+// tag::imports[]
 import com.couchbase.client.core.cnc.Event;
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
@@ -49,7 +49,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Logger;
 
 import static com.couchbase.client.java.query.QueryOptions.queryOptions;
-// #end::imports[]
+// end::imports[]
 
 public class TransactionsExample {
     static Cluster cluster;
@@ -57,7 +57,7 @@ public class TransactionsExample {
     static Transactions transactions;
 
     public static void main(String... args) {
-        // #tag::init[]
+        // tag::init[]
         // Initialize the Couchbase cluster
         Cluster cluster = Cluster.connect("localhost", "transactor", "mypass");
         Bucket bucket = cluster.bucket("transact");
@@ -65,7 +65,7 @@ public class TransactionsExample {
 
         // Create the single Transactions object
         Transactions transactions = Transactions.create(cluster);
-        // #end::init[]
+        // end::init[]
 
         TransactionsExample.cluster = cluster;
         TransactionsExample.collection = collection;
@@ -73,19 +73,19 @@ public class TransactionsExample {
     }
 
     static void config() {
-        // #tag::config[]
+        // tag::config[]
         Transactions transactions = Transactions.create(cluster,
                 TransactionConfigBuilder.create()
                         .durabilityLevel(TransactionDurabilityLevel.PERSIST_TO_MAJORITY)
-                        // #tag::config_warn[]
+                        // tag::config_warn[]
                         .logOnFailure(true, Event.Severity.WARN)
-                        // #end::config_warn[]
+                        // end::config_warn[]
                     .build());
-        // #end::config[]
+        // end::config[]
     }
 
     static void create() {
-        // #tag::create[]
+        // tag::create[]
         try {
             transactions.run((ctx) -> {
                 // 'ctx' is an AttemptContext, which permits getting, inserting,
@@ -98,7 +98,7 @@ public class TransactionsExample {
                 // will be committed anyway.
                 ctx.commit();
             });
-        // #tag::logging[]
+        // tag::logging[]
         } catch (TransactionCommitAmbiguous e) {
             // The application will of course want to use its own logging rather
             // than System.err
@@ -114,12 +114,12 @@ public class TransactionsExample {
                 System.err.println(err.toString());
             }
         }
-        // #end::logging[]
-        // #end::create[]
+        // end::logging[]
+        // end::create[]
     }
 
     static void createReactive() {
-        // #tag::createReactive[]
+        // tag::createReactive[]
         Mono<TransactionResult> result = transactions.reactive().run((ctx) -> {
             // 'ctx' is an AttemptContextReactive, providing asynchronous versions of the AttemptContext methods
 
@@ -132,7 +132,7 @@ public class TransactionsExample {
                             // The commit call is optional - if you leave it off,
                             // the transaction will be committed anyway.
                             .then(ctx.commit());
-        // #tag::async_logging[]
+        // tag::async_logging[]
         }).doOnError(err -> {
             if (err instanceof TransactionCommitAmbiguous) {
                 System.err.println("Transaction possibly committed: ");
@@ -146,17 +146,17 @@ public class TransactionsExample {
                 System.err.println(err.toString());
             }
         });
-        // #end::async_logging[]
+        // end::async_logging[]
 
 
         // Normally you will chain this result further and ultimately subscribe.  For simplicity, here we just block
         // on the result.
         TransactionResult finalResult = result.block();
-        // #end::createReactive[]
+        // end::createReactive[]
     }
 
     static void examples() {
-        // #tag::examples[]
+        // tag::examples[]
         try {
             TransactionResult result = transactions.run((ctx) -> {
                 // Inserting a doc:
@@ -196,11 +196,11 @@ public class TransactionsExample {
                 System.err.println(err.toString());
             }
         }
-        // #end::examples[]
+        // end::examples[]
     }
 
     static void examplesReactive() {
-        // #tag::examplesReactive[]
+        // tag::examplesReactive[]
         Mono<TransactionResult> result = transactions.reactive().run((ctx) -> {
             return
                     // Inserting a doc:
@@ -238,42 +238,42 @@ public class TransactionsExample {
         // Normally you will chain this result further and ultimately subscribe.
         // For simplicity, here we just block on the result.
         result.block();
-        // #end::examplesReactive[]
+        // end::examplesReactive[]
 
     }
 
     static void insert() {
-        // #tag::insert[]
+        // tag::insert[]
         transactions.reactive().run((ctx) -> {
             return ctx.insert(collection.reactive(), "docId", JsonObject.create()).then();
         }).block();
-        // #end::insert[]
+        // end::insert[]
     }
 
     static void insertReactive() {
-        // #tag::insertReactive[]
+        // tag::insertReactive[]
         transactions.run((ctx) -> {
             String docId = "docId";
 
             ctx.insert(collection, docId, JsonObject.create());
 
         });
-        // #end::insertReactive[]
+        // end::insertReactive[]
     }
 
     static void get() {
-        // #tag::get[]
+        // tag::get[]
         transactions.run((ctx) -> {
             String docId = "a-doc";
 
             Optional<TransactionGetResult> docOpt = ctx.getOptional(collection, docId);
             TransactionGetResult doc = ctx.get(collection, docId);
         });
-        // #end::get[]
+        // end::get[]
     }
 
     static void getReadOwnWrites() {
-        // #tag::getReadOwnWrites[]
+        // tag::getReadOwnWrites[]
         transactions.run((ctx) -> {
             String docId = "docId";
 
@@ -283,22 +283,22 @@ public class TransactionsExample {
 
             assert (doc.isPresent());
         });
-        // #end::getReadOwnWrites[]
+        // end::getReadOwnWrites[]
     }
 
     static void replace() {
-        // #tag::replace[]
+        // tag::replace[]
         transactions.run((ctx) -> {
             TransactionGetResult anotherDoc = ctx.get(collection, "anotherDoc");
             JsonObject content = anotherDoc.contentAs(JsonObject.class);
             content.put("transactions", "are awesome");
             ctx.replace(anotherDoc, content);
         });
-        // #end::replace[]
+        // end::replace[]
     }
 
     static void replaceReactive() {
-        // #tag::replaceReactive[]
+        // tag::replaceReactive[]
         transactions.reactive().run((ctx) -> {
             return ctx.get(collection.reactive(), "anotherDoc")
                     .flatMap(doc -> {
@@ -308,29 +308,29 @@ public class TransactionsExample {
                     })
                     .then(ctx.commit());
         });
-        // #end::replaceReactive[]
+        // end::replaceReactive[]
     }
 
     static void remove() {
-        // #tag::remove[]
+        // tag::remove[]
         transactions.run((ctx) -> {
             TransactionGetResult anotherDoc = ctx.get(collection, "anotherDoc");
             ctx.remove(anotherDoc);
         });
-        // #end::remove[]
+        // end::remove[]
     }
 
     static void removeReactive() {
-        // #tag::removeReactive[]
+        // tag::removeReactive[]
         transactions.reactive().run((ctx) -> {
             return ctx.get(collection.reactive(), "anotherDoc")
                     .flatMap(doc -> ctx.remove(doc));
         });
-        // #end::removeReactive[]
+        // end::removeReactive[]
     }
 
     static void commit() {
-        // #tag::commit[]
+        // tag::commit[]
         Mono<TransactionResult> result = transactions.reactive().run((ctx) -> {
             return ctx.get(collection.reactive(), "anotherDoc")
                     .flatMap(doc -> {
@@ -340,7 +340,7 @@ public class TransactionsExample {
                     })
                     .then();
         });
-        // #end::commit[]
+        // end::commit[]
     }
 
     static Transactions getTransactions() {
@@ -351,7 +351,7 @@ public class TransactionsExample {
         return experience / 10;
     }
 
-    // #tag::full[]
+    // tag::full[]
     public void playerHitsMonster(int damage, String playerId, String monsterId) {
         Transactions transactions = getTransactions();
 
@@ -398,33 +398,33 @@ public class TransactionsExample {
             // prolonged node failure.
         }
     }
-    // #end::full[]
+    // end::full[]
 
     static void concurrency() {
-        // #tag::concurrency[]
+        // tag::concurrency[]
         cluster.environment().eventBus().subscribe(event -> {
             if (event instanceof IllegalDocumentState) {
                 // log this event for review
             }
         });
-        // #end::concurrency[]
+        // end::concurrency[]
     }
 
     static void cleanupEvents() {
-        // #tag::cleanup-events[]
+        // tag::cleanup-events[]
         cluster.environment().eventBus().subscribe(event -> {
             if (event instanceof TransactionCleanupAttempt
                     || event instanceof TransactionCleanupEndRunEvent) {
                 // log this event
             }
         });
-        // #end::cleanup-events[]
+        // end::cleanup-events[]
     }
 
     static void rollback() {
         final int costOfItem = 10;
 
-        // #tag::rollback[]
+        // tag::rollback[]
         transactions.run((ctx) -> {
             TransactionGetResult customer = ctx.get(collection, "customer-name");
 
@@ -433,13 +433,13 @@ public class TransactionsExample {
             }
             // else continue transaction
         });
-        // #end::rollback[]
+        // end::rollback[]
     }
 
     static void rollbackCause() {
         final int costOfItem = 10;
 
-        // #tag::rollback-cause[]
+        // tag::rollback-cause[]
         class BalanceInsufficient extends RuntimeException {}
 
         try {
@@ -472,12 +472,12 @@ public class TransactionsExample {
                 }
             }
         }
-        // #end::rollback-cause[]
+        // end::rollback-cause[]
     }
 
     static void deferredCommit1() {
 
-        // #tag::defer1[]
+        // tag::defer1[]
         try {
             TransactionResult result = transactions.run((ctx) -> {
                 JsonObject initial = JsonObject.create().put("val", 1);
@@ -503,11 +503,11 @@ public class TransactionsExample {
                 System.err.println(err.toString());
             }
         }
-        // #end::defer1[]
+        // end::defer1[]
     }
 
     static void deferredCommit2(byte[] encoded) {
-        // #tag::defer2[]
+        // tag::defer2[]
         TransactionSerializedContext serialized = TransactionSerializedContext.createFrom(encoded);
 
         try {
@@ -521,11 +521,11 @@ public class TransactionsExample {
                 System.err.println(err.toString());
             }
         }
-        // #end::defer2[]
+        // end::defer2[]
     }
 
     static void deferredRollback(byte[] encoded) {
-        // #tag::defer3[]
+        // tag::defer3[]
         TransactionSerializedContext serialized = TransactionSerializedContext.createFrom(encoded);
 
         try {
@@ -539,29 +539,29 @@ public class TransactionsExample {
                 System.err.println(err.toString());
             }
         }
-        // #end::defer3[]
+        // end::defer3[]
     }
 
     static void configExpiration(byte[] encoded) {
-        // #tag::config-expiration[]
+        // tag::config-expiration[]
         Transactions transactions = Transactions.create(cluster, TransactionConfigBuilder.create()
                 .expirationTime(Duration.ofSeconds(120))
                 .build());
-        // #end::config-expiration[]
+        // end::config-expiration[]
     }
 
     static void configCleanup(byte[] encoded) {
-        // #tag::config-cleanup[]
+        // tag::config-cleanup[]
         Transactions transactions = Transactions.create(cluster, TransactionConfigBuilder.create()
                 .cleanupClientAttempts(false)
                 .cleanupLostAttempts(false)
                 .cleanupWindow(Duration.ofSeconds(120))
                 .build());
-        // #end::config-cleanup[]
+        // end::config-cleanup[]
     }
 
     static void concurrentOps() {
-        // #tag::concurrentOps[]
+        // tag::concurrentOps[]
         List<String> docIds = Arrays.asList("doc1", "doc2", "doc3", "doc4", "doc5");
 
         ReactiveCollection coll = collection.reactive();
@@ -609,11 +609,11 @@ public class TransactionsExample {
                         }
                     }));
         }).block();
-        // #end::concurrentOps[]
+        // end::concurrentOps[]
     }
 
     static void completeErrorHandling() {
-        // #tag::full-error-handling[]
+        // tag::full-error-handling[]
         try {
             TransactionResult result = transactions.run((ctx) -> {
                 // ... transactional code here ...
@@ -656,11 +656,11 @@ public class TransactionsExample {
             System.err.println("Transaction failed with TransactionFailed, logs:");
             err.result().log().logs().forEach(log -> System.err.println(log.toString()));
         }
-        // #end::full-error-handling[]
+        // end::full-error-handling[]
     }
 
     static void completeLogging() {
-        // #tag::full-logging[]
+        // tag::full-logging[]
         final Logger LOGGER = Logger.getLogger("transactions");
 
         try {
@@ -679,11 +679,11 @@ public class TransactionsExample {
             LOGGER.info("Transaction failed with TransactionFailed, logs:");
             err.result().log().logs().forEach(log -> LOGGER.info(log.toString()));
         }
-        // #end::full-logging[]
+        // end::full-logging[]
     }
 
     static void queryInsert() {
-        // #tag::queryInsert[]
+        // tag::queryInsert[]
         transactions.run((ctx) -> {
             ctx.query("INSERT INTO `default` VALUES ('doc', {'hello':'world'})");
 
@@ -693,11 +693,11 @@ public class TransactionsExample {
                 System.out.println(row);
             });
         });
-        // #end::queryInsert[]
+        // end::queryInsert[]
     }
 
     static void queryRyow() {
-        // #tag::queryRyow[]
+        // tag::queryRyow[]
         transactions.run((ctx) -> {
             ctx.insert(collection, "doc", JsonObject.create().put("hello", "world"));
 
@@ -707,26 +707,26 @@ public class TransactionsExample {
                 System.out.println(row);
             });
         });
-        // #end::queryRyow[]
+        // end::queryRyow[]
     }
 
     static void queryOptions() {
-        // #tag::queryOptions[]
+        // tag::queryOptions[]
         transactions.run((ctx) -> {
             ctx.query("INSERT INTO `default` VALUES ('doc', {'hello':'world'})",
                     TransactionQueryOptions.queryOptions().profile(QueryProfile.TIMINGS));
         });
-        // #end::queryOptions[]
+        // end::queryOptions[]
     }
 
     static void customMetadata() {
         Collection metadataCollection = null;
 
-        // #tag::custom-metadata[]
+        // tag::custom-metadata[]
         Transactions transactions = Transactions.create(cluster,
                 TransactionConfigBuilder.create()
                         .metadataCollection(metadataCollection));
-        // #end::custom-metadata[]
+        // end::custom-metadata[]
     }
 
 }

--- a/modules/howtos/examples/Transcoding.java
+++ b/modules/howtos/examples/Transcoding.java
@@ -54,7 +54,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 // TODO: remove TypeRef overload when JCBC-1588 done
-// #tag::gson-serializer[]
+// tag::gson-serializer[]
 class GsonSerializer implements JsonSerializer {
     private final Gson gson = new Gson();
 
@@ -76,10 +76,10 @@ class GsonSerializer implements JsonSerializer {
         return gson.fromJson(str, target.type());
     }
 }
-// #end::gson-serializer[]
+// end::gson-serializer[]
 
 // TODO: remove TypeRef overload when JCBC-1588 done
-// #tag::msgpack-serializer[]
+// tag::msgpack-serializer[]
 class MsgPackSerializer implements JsonSerializer {
     private final MessagePack msgpack = new MessagePack();
 
@@ -106,9 +106,9 @@ class MsgPackSerializer implements JsonSerializer {
         throw new DecodingFailureException("Does not support decoding via TypeRef.");
     }
 }
-// #end::msgpack-serializer[]
+// end::msgpack-serializer[]
 
-// #tag::msgpack-transcoder[]
+// tag::msgpack-transcoder[]
 class MsgPackTranscoder implements Transcoder {
     private final MsgPackSerializer serializer = new MsgPackSerializer();
 
@@ -123,7 +123,7 @@ class MsgPackTranscoder implements Transcoder {
         return serializer.deserialize(target, input);
     }
 }
-// #end::msgpack-transcoder[]
+// end::msgpack-transcoder[]
 
 class User {
     private final String name;
@@ -175,7 +175,7 @@ public class Transcoding {
 
     @Test
     void gson() {
-        // #tag::gson-encode[]
+        // tag::gson-encode[]
         // User is a simple POJO
         User user = new User("John Smith", 27);
 
@@ -184,15 +184,15 @@ public class Transcoding {
 
         collection.upsert("john-smith", json,
             UpsertOptions.upsertOptions().transcoder(RawJsonTranscoder.INSTANCE));
-        // #end::gson-encode[]
+        // end::gson-encode[]
 
-        // #tag::gson-decode[]
+        // tag::gson-decode[]
         GetResult result = collection.get("john-smith",
             GetOptions.getOptions().transcoder(RawJsonTranscoder.INSTANCE));
 
         String returnedJson = result.contentAs(String.class);
         User returnedUser = gson.fromJson(returnedJson, User.class);
-        // #end::gson-decode[]
+        // end::gson-decode[]
 
         assertEquals(json, returnedJson);
         assertEquals(user, returnedUser);
@@ -200,7 +200,7 @@ public class Transcoding {
 
     @Test
     void gsonCustom() {
-        // #tag::gson-custom-encode[]
+        // tag::gson-custom-encode[]
         GsonSerializer serializer = new GsonSerializer();
         JsonTranscoder transcoder = JsonTranscoder.create(serializer);
 
@@ -208,27 +208,27 @@ public class Transcoding {
 
         collection.upsert("john-smith", user,
             UpsertOptions.upsertOptions().transcoder(transcoder));
-        // #end::gson-custom-encode[]
+        // end::gson-custom-encode[]
 
-        // #tag::gson-custom-decode[]
+        // tag::gson-custom-decode[]
         GetResult result = collection.get("john-smith",
             GetOptions.getOptions().transcoder(transcoder));
 
         User returnedUser = result.contentAs(User.class);
 
         assertEquals(user, returnedUser);
-        // #end::gson-custom-decode[]
+        // end::gson-custom-decode[]
     }
 
     @Test
     void gsonRegister() {
-        // #tag::gson-register-1[]
+        // tag::gson-register-1[]
         GsonSerializer serializer = new GsonSerializer();
 
         ClusterEnvironment env = ClusterEnvironment.builder()
             .jsonSerializer(serializer)
             .build();
-        // #end::gson-register-1[]
+        // end::gson-register-1[]
 
         Cluster cluster = Cluster.connect("localhost",
             ClusterOptions.clusterOptions("Administrator", "password")
@@ -236,7 +236,7 @@ public class Transcoding {
 
         Collection coll = cluster.bucket("default").defaultCollection();
 
-        // #tag::gson-register-2[]
+        // tag::gson-register-2[]
         User user = new User("John Smith", 27);
 
         coll.upsert("john-smith", user);
@@ -244,7 +244,7 @@ public class Transcoding {
         GetResult result = coll.get("john-smith");
 
         User returnedUser = result.contentAs(User.class);
-        // #end::gson-register-2[]
+        // end::gson-register-2[]
 
         assertEquals(user, returnedUser);
 
@@ -264,7 +264,7 @@ public class Transcoding {
 
     @Test
     void msgpack() {
-        // #tag::msgpack-encode[]
+        // tag::msgpack-encode[]
         MsgPackTranscoder transcoder = new MsgPackTranscoder();
 
         String input = "hello world!";
@@ -276,7 +276,7 @@ public class Transcoding {
             GetOptions.getOptions().transcoder(transcoder));
 
         String output = result.contentAs(String.class);
-        // #end::msgpack-encode[]
+        // end::msgpack-encode[]
 
         assertEquals(input, output);
     }
@@ -284,7 +284,7 @@ public class Transcoding {
     @Test
     void string() {
         String docId = "doc";
-        // #tag::string[]
+        // tag::string[]
         collection.upsert(docId, "hello world",
             UpsertOptions.upsertOptions().transcoder(RawStringTranscoder.INSTANCE));
 
@@ -292,14 +292,14 @@ public class Transcoding {
             GetOptions.getOptions().transcoder(RawStringTranscoder.INSTANCE));
 
         String returned = result.contentAs(String.class);
-        // #end::string[]
+        // end::string[]
         assertEquals(returned, "hello world");
     }
 
     @Test
     void binary() {
         String docId = "doc";
-        // #tag::binary[]
+        // tag::binary[]
         String input = "hello world";
         byte[] bytes = input.getBytes(StandardCharsets.UTF_8);
 
@@ -310,9 +310,9 @@ public class Transcoding {
             GetOptions.getOptions().transcoder(RawBinaryTranscoder.INSTANCE));
 
         byte[] returned = result.contentAs(byte[].class);
-        // #end::binary[]
+        // end::binary[]
         assertTrue(Arrays.equals(returned, bytes));
     }
 }
 
-  
+

--- a/modules/howtos/examples/Views.java
+++ b/modules/howtos/examples/Views.java
@@ -33,7 +33,7 @@ public class Views {
   public static void main(String... args) {
 
     {
-      // #tag::views-simple[]
+      // tag::views-simple[]
       Cluster cluster = Cluster.connect("127.0.0.1", "username", "password");
       Bucket bucket = cluster.bucket("bucket-name");
 
@@ -41,24 +41,24 @@ public class Views {
       for (ViewRow row : viewResult.rows()) {
         System.out.println("Found row: " + row);
       }
-      // #end::views-simple[]
+      // end::views-simple[]
     }
 
     Cluster cluster = Cluster.connect("127.0.0.1", "username", "password");
     Bucket bucket = cluster.bucket("bucket-name");
 
     {
-      // #tag::views-dev[]
+      // tag::views-dev[]
       ViewResult viewResult = bucket.viewQuery(
         "ddoc",
         "view",
         viewOptions().namespace(DesignDocumentNamespace.DEVELOPMENT)
       );
-      // #end::views-dev[]
+      // end::views-dev[]
     }
 
     {
-      // #tag::views-opts[]
+      // tag::views-opts[]
       ViewResult viewResult = bucket.viewQuery(
         "ddoc",
         "view",
@@ -67,17 +67,17 @@ public class Views {
           .limit(5)
           .inclusiveEnd(true)
       );
-      // #end::views-opts[]
+      // end::views-opts[]
     }
 
     {
-      // #tag::views-meta[]
+      // tag::views-meta[]
       ViewResult viewResult = bucket.viewQuery("ddoc", "view", viewOptions().debug(true));
 
       ViewMetaData viewMeta = viewResult.metaData();
       System.out.println("Got total rows: " + viewMeta.totalRows());
       viewMeta.debug().ifPresent(debug -> System.out.println("Got debug info as well: " + debug));
-      // #end::views-meta[]
+      // end::views-meta[]
     }
 
   }

--- a/modules/howtos/examples/managing_connections.java
+++ b/modules/howtos/examples/managing_connections.java
@@ -42,16 +42,16 @@ public class managing_connections {
 	Collection collection;
 
 	private void init() {
-		// #tag::connection_1[];
+		// tag::connection_1[];
 		ClusterEnvironment environment = ClusterEnvironment.builder().build();
 		cluster = Cluster.connect(connectionString, ClusterOptions.clusterOptions(username, password).environment(environment));
 		bucket = cluster.bucket("travel-sample");
 		scope = bucket.defaultScope();
-		collection = bucket.defaultCollection();    // #end::connection_1[];
+		collection = bucket.defaultCollection();    // end::connection_1[];
 	}
 
 	public void managing_connections_5() throws Exception { // file: howtos/pages/managing-connections.adoc line: 125
-		// #tag::managing_connections_5[]
+		// tag::managing_connections_5[]
 		int customKvPort = 1234;
 		int customManagerPort = 2345;
 		Set<SeedNode> seedNodes = new HashSet<>(Arrays.asList(
@@ -62,25 +62,25 @@ public class managing_connections {
 		Authenticator authenticator = PasswordAuthenticator.create(username, password);
 		ClusterOptions options = ClusterOptions.clusterOptions(authenticator);
 		Cluster cluster = Cluster.connect(seedNodes, options);
-		// #end::managing_connections_5[];
+		// end::managing_connections_5[];
 	}
 
 	public void managing_connections_8() throws Exception { // file: howtos/pages/managing-connections.adoc line: 242
-		// #tag::managing_connections_8[]
+		// tag::managing_connections_8[]
 		Cluster cluster = Cluster.connect("127.0.0.1", "username", "password");
 		cluster.waitUntilReady(Duration.ofSeconds(10));
 		Bucket bucket = cluster.bucket("travel-sample");
 		Collection collection = bucket.defaultCollection();
-		// #end::managing_connections_8[];
+		// end::managing_connections_8[];
 	}
 
 	public void managing_connections_9() throws Exception { // file: howtos/pages/managing-connections.adoc line: 252
-		// #tag::managing_connections_9[]
+		// tag::managing_connections_9[]
 		Cluster cluster = Cluster.connect("127.0.0.1", "username", "password");
 		cluster.waitUntilReady(Duration.ofSeconds(10));
 		Bucket bucket = cluster.bucket("travel-sample");
 		Collection collection = bucket.defaultCollection();
-		// #end::managing_connections_9[];
+		// end::managing_connections_9[];
 	}
 
 	public static void main(String[] args) throws Exception {

--- a/modules/project-docs/examples/Migrating.java
+++ b/modules/project-docs/examples/Migrating.java
@@ -57,17 +57,17 @@ import static com.couchbase.client.java.view.ViewOptions.viewOptions;
 public class Migrating {
   public static void main(String... args) {
     {
-      // #tag::timeoutbuilder[]
+      // tag::timeoutbuilder[]
       // SDK 3 equivalent
       ClusterEnvironment env = ClusterEnvironment
         .builder()
         .timeoutConfig(TimeoutConfig.kvTimeout(Duration.ofSeconds(5)))
         .build();
-      // #end::timeoutbuilder[]
+      // end::timeoutbuilder[]
     }
 
     {
-      // #tag::shutdown[]
+      // tag::shutdown[]
       ClusterEnvironment env = ClusterEnvironment.create();
       Cluster cluster = Cluster.connect(
         "127.0.0.1",
@@ -78,11 +78,11 @@ public class Migrating {
       // first disconnect, then shutdown the environment
       cluster.disconnect();
       env.shutdown();
-      // #end::shutdown[]
+      // end::shutdown[]
     }
 
     {
-      // #tag::sysprops[]
+      // tag::sysprops[]
       // Will set the max http connections to 23
       System.setProperty("com.couchbase.env.io.maxHttpConnections", "23");
       Cluster.connect("127.0.0.1", "user", "pass");
@@ -92,11 +92,11 @@ public class Migrating {
         .builder()
         .ioConfig(IoConfig.maxHttpConnections(23))
         .build();
-      // #end::sysprops[]
+      // end::sysprops[]
     }
 
     {
-      // #tag::connstr[]
+      // tag::connstr[]
       // Will set the max http connections to 23
       Cluster.connect(
         "127.0.0.1?com.couchbase.env.io.maxHttpConnections=23",
@@ -109,35 +109,35 @@ public class Migrating {
         .builder()
         .ioConfig(IoConfig.maxHttpConnections(23))
         .build();
-      // #end::connstr[]
+      // end::connstr[]
     }
 
     {
-      // #tag::rbac[]
+      // tag::rbac[]
       Cluster.connect("127.0.0.1", "username", "password");
-      // #end::rbac[]
+      // end::rbac[]
     }
 
     {
-      // #tag::rbac-full[]
+      // tag::rbac-full[]
       Cluster.connect(
         "127.0.0.1",
         clusterOptions(PasswordAuthenticator.create("username", "password"))
       );
-      // #end::rbac-full[]
+      // end::rbac-full[]
     }
 
     {
-      // #tag::certauth[]
+      // tag::certauth[]
       KeyManagerFactory keyManagerFactory = null;  // configure certificates per documentation
       Cluster.connect("127.0.0.1", clusterOptions(
         CertificateAuthenticator.fromKeyManagerFactory(() -> keyManagerFactory)
       ));
-      // #end::certauth[]
+      // end::certauth[]
     }
 
     {
-      // #tag::simpleget[]
+      // tag::simpleget[]
       Cluster cluster = Cluster.connect("127.0.0.1", "user", "pass");
       Bucket bucket = cluster.bucket("travel-sample");
       Collection collection = bucket.defaultCollection();
@@ -145,7 +145,7 @@ public class Migrating {
       GetResult getResult = collection.get("airline_10");
 
       cluster.disconnect();
-      // #end::simpleget[]
+      // end::simpleget[]
     }
 
     Cluster cluster = Cluster.connect("127.0.0.1", "user", "pass");
@@ -153,45 +153,45 @@ public class Migrating {
     Collection collection = bucket.defaultCollection();
 
     {
-      // #tag::upsertandget[]
+      // tag::upsertandget[]
       MutationResult upsertResult = collection.upsert("mydoc-id", JsonObject.create());
       GetResult getResult = collection.get("mydoc-id");
-      // #end::upsertandget[]
+      // end::upsertandget[]
     }
 
     {
-      // #tag::rawjson[]
+      // tag::rawjson[]
       byte[] content = "{}".getBytes(StandardCharsets.UTF_8);
       MutationResult upsertResult = collection.upsert(
         "mydoc-id",
         content,
         upsertOptions().transcoder(RawJsonTranscoder.INSTANCE)
       );
-      // #end::rawjson[]
+      // end::rawjson[]
     }
 
     {
-      // #tag::customtimeout[]
+      // tag::customtimeout[]
       // SDK 3 custom timeout
       GetResult getResult = collection.get(
         "mydoc-id",
         getOptions().timeout(Duration.ofSeconds(5))
       );
-      // #end::customtimeout[]
+      // end::customtimeout[]
     }
 
     {
-      // #tag::querysimple[]
+      // tag::querysimple[]
       // SDK 3 simple query
       QueryResult queryResult = cluster.query("select * from `travel-sample` limit 10");
       for (JsonObject value : queryResult.rowsAsObject()) {
         // ...
       }
-      // #end::querysimple[]
+      // end::querysimple[]
     }
 
     {
-      // #tag::queryparameterized[]
+      // tag::queryparameterized[]
       // SDK 3 named parameters
       cluster.query(
         "select * from bucket where type = $type",
@@ -203,21 +203,21 @@ public class Migrating {
         "select * from bucket where type = $1",
         queryOptions().parameters(JsonArray.from("airport"))
       );
-      // #end::queryparameterized[]
+      // end::queryparameterized[]
     }
 
     {
-      // #tag::analyticssimple[]
+      // tag::analyticssimple[]
       // SDK 3 simple analytics query
       AnalyticsResult analyticsResult = cluster.analyticsQuery("select * from dataset");
       for (JsonObject value : analyticsResult.rowsAsObject()) {
         // ...
       }
-      // #end::analyticssimple[]
+      // end::analyticssimple[]
     }
 
     {
-      // #tag::analyticsparameterized[]
+      // tag::analyticsparameterized[]
       // SDK 3 named parameters for analytics
       cluster.analyticsQuery(
         "select * from dataset where type = $type",
@@ -229,11 +229,11 @@ public class Migrating {
         "select * from dataset where type = $1",
         analyticsOptions().parameters(JsonArray.from("airport"))
       );
-      // #end::analyticsparameterized[]
+      // end::analyticsparameterized[]
     }
 
     {
-      // #tag::searchsimple[]
+      // tag::searchsimple[]
       // SDK 3 search query
       SearchResult searchResult = cluster.searchQuery(
         "indexname",
@@ -246,11 +246,11 @@ public class Migrating {
       for (SearchRow row : searchResult.rows()) {
         // ...
       }
-      // #end::searchsimple[]
+      // end::searchsimple[]
     }
 
     {
-      // #tag::searchcheck[]
+      // tag::searchcheck[]
       SearchResult searchResult = cluster.searchQuery(
         "myindex",
         SearchQuery.queryString("searchstring")
@@ -258,11 +258,11 @@ public class Migrating {
       if (searchResult.metaData().errors().isEmpty()) {
         // no errors present, so full data got returned
       }
-      // #end::searchcheck[]
+      // end::searchcheck[]
     }
 
     {
-      // #tag::viewquery[]
+      // tag::viewquery[]
       // SDK 3 view query
       ViewResult viewResult = bucket.viewQuery(
         "design",
@@ -272,7 +272,7 @@ public class Migrating {
       for (ViewRow row : viewResult.rows()) {
         // ...
       }
-      // #end::viewquery[]
+      // end::viewquery[]
     }
   }
 }

--- a/modules/project-docs/examples/MigratingSDKCodeTo3n.java
+++ b/modules/project-docs/examples/MigratingSDKCodeTo3n.java
@@ -49,19 +49,19 @@ public class MigratingSDKCodeTo3n {
   }
 
   public void migrating_sdk_code_to_3_n_1() throws Exception { // file: project-docs/pages/migrating-sdk-code-to-3.n.adoc line: 23
-    // #tag::migrating_sdk_code_to_3_n_1[]
+    // tag::migrating_sdk_code_to_3_n_1[]
     GetResult getResult = collection.get("key", getOptions().timeout(Duration.ofSeconds(3)));
-    // #end::migrating_sdk_code_to_3_n_1[]
+    // end::migrating_sdk_code_to_3_n_1[]
   }
 
   public void migrating_sdk_code_to_3_n_2() throws Exception { // file: project-docs/pages/migrating-sdk-code-to-3.n.adoc line: 30
-    // #tag::migrating_sdk_code_to_3_n_2[]
+    // tag::migrating_sdk_code_to_3_n_2[]
     QueryResult queryResult = cluster.query("select 1=1", queryOptions().timeout(Duration.ofSeconds(3)));
-    // #end::migrating_sdk_code_to_3_n_2[]
+    // end::migrating_sdk_code_to_3_n_2[]
   }
 
   public void migrating_sdk_code_to_3_n_11() throws Exception { // file: project-docs/pages/migrating-sdk-code-to-3.n.adoc line: 160
-    // #tag::migrating_sdk_code_to_3_n_11[]
+    // tag::migrating_sdk_code_to_3_n_11[]
     Cluster cluster = Cluster.connect(connectionString, username, password);
 
     Bucket bucket = cluster.bucket(bucketName);
@@ -69,16 +69,16 @@ public class MigratingSDKCodeTo3n {
     GetResult getResult = bucket.defaultCollection().get("airline_10");
 
     cluster.disconnect();
-    // #end::migrating_sdk_code_to_3_n_11[]
+    // end::migrating_sdk_code_to_3_n_11[]
   }
 
   public void migrating_sdk_code_to_3_n_22() throws Exception { // file: project-docs/pages/migrating-sdk-code-to-3.n.adoc line: 492
-    // #tag::migrating_sdk_code_to_3_n_22[]
+    // tag::migrating_sdk_code_to_3_n_22[]
     QueryResult queryResult = cluster.query("select 1=");
     if (!queryResult.metaData().warnings().isEmpty()) {
       // errors contain [{"msg":"syntax error - at end of input","code":3000}]
     }
-    // #end::migrating_sdk_code_to_3_n_22[]
+    // end::migrating_sdk_code_to_3_n_22[]
   }
 
 

--- a/modules/project-docs/examples/Transactions.java
+++ b/modules/project-docs/examples/Transactions.java
@@ -18,7 +18,7 @@ import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.Collection;
 
-// #tag::imports[]
+// tag::imports[]
 // Imports required by this sample
 import com.couchbase.client.java.json.JsonObject;
 import com.couchbase.client.java.kv.GetResult;
@@ -31,7 +31,7 @@ import com.couchbase.transactions.error.TransactionFailed;
 import java.util.logging.Logger;
 
 import static com.couchbase.client.java.query.QueryOptions.queryOptions;
-// #end::imports[]
+// end::imports[]
 
 class TransactionsDemo {
     private static final Cluster cluster = Cluster.connect("localhost", "Administrator", "password");
@@ -40,7 +40,7 @@ class TransactionsDemo {
     private static final Transactions transactions = Transactions.create(cluster);
 
     void demo_1_0_1_changes() {
-        // #tag::demo_1_0_1[]
+        // tag::demo_1_0_1[]
         try {
             TransactionResult result = transactions.run((ctx) -> {
                 // ... transactional code here ...
@@ -81,7 +81,7 @@ class TransactionsDemo {
             System.err.println("Transaction failed with TransactionFailed, logs:");
             err.result().log().logs().forEach(log -> System.err.println(log.toString()));
         }
-        // #end::demo_1_0_1[]
+        // end::demo_1_0_1[]
 
 
         cluster.disconnect();
@@ -93,22 +93,22 @@ class TransactionsDemo {
         JsonObject cContent = JsonObject.create();
         final Logger LOGGER = Logger.getLogger("transactions");
 
-        // #tag::query-basic[]
+        // tag::query-basic[]
         TransactionResult result = transactions.run((ctx) -> {
             ctx.insert(collection, "doc-a", aContent);
             ctx.query("INSERT INTO `default` VALUES ('doc-b', " + bContent + ")");
             ctx.insert(collection, "doc-c", cContent);
         });
-        // #end::query-basic[]
+        // end::query-basic[]
     }
 
     static void customMetadata() {
         Collection metadataCollection = null;
 
-        // #tag::custom-metadata[]
+        // tag::custom-metadata[]
         Transactions transactions = Transactions.create(cluster,
                 TransactionConfigBuilder.create()
                         .metadataCollection(metadataCollection));
-        // #end::custom-metadata[]
+        // end::custom-metadata[]
     }
 }

--- a/modules/ref/examples/DataStructuresExample.java
+++ b/modules/ref/examples/DataStructuresExample.java
@@ -58,106 +58,106 @@ public class DataStructuresExample {
     bucket = cluster.bucket(bucketName);
     scope = bucket.defaultScope();
     collection = bucket.defaultCollection();
-    // #tag::data_structures_0[]
+    // tag::data_structures_0[]
     map = new CouchbaseMap("mapId", collection, String.class, MapOptions.mapOptions());
     arrayList = new CouchbaseArrayList("arrayListId", collection, String.class, ArrayListOptions.arrayListOptions());
     arraySet = new CouchbaseArraySet("arraySetId", collection, String.class, ArraySetOptions.arraySetOptions());
     queue = new CouchbaseQueue("queueId", collection, String.class, QueueOptions.queueOptions());
-    // #end::data_structures_0[];
+    // end::data_structures_0[];
   }
 
   public void data_structures_1() throws Exception {
-    // #tag::data_structures_1[]
+    // tag::data_structures_1[]
     map.put("some_key", "value");
-    // #end::data_structures_1[];
+    // end::data_structures_1[];
   }
 
   public void data_structures_2() throws Exception {
-    // #tag::data_structures_2[]
+    // tag::data_structures_2[]
     map.remove("some_key");
-    // #end::data_structures_2[];
+    // end::data_structures_2[];
   }
 
   public void data_structures_3() throws Exception {
-    // #tag::data_structures_3[]
+    // tag::data_structures_3[]
     map.get("some_key"); //=> value
-    // #end::data_structures_3[];
+    // end::data_structures_3[];
   }
 
   public void data_structures_4() throws Exception {
-    // #tag::data_structures_4[]
+    // tag::data_structures_4[]
     arrayList.add(1234);
-    // #end::data_structures_4[];
+    // end::data_structures_4[];
   }
 
   public void data_structures_5() throws Exception {
-    // #tag::data_structures_5[]
+    // tag::data_structures_5[]
     arrayList.add(0, "hello world");
-    // #end::data_structures_5[];
+    // end::data_structures_5[];
   }
 
   public void data_structures_6() throws Exception {
-    // #tag::data_structures_6[]
+    // tag::data_structures_6[]
     arrayList.remove(1);
-    // #end::data_structures_6[];
+    // end::data_structures_6[];
   }
 
   public void data_structures_7() throws Exception {
-    // #tag::data_structures_7[]
+    // tag::data_structures_7[]
     arrayList.set(0, "first value");
-    // #end::data_structures_7[];
+    // end::data_structures_7[];
   }
 
   public void data_structures_8() throws Exception {
-    // #tag::data_structures_8[]
+    // tag::data_structures_8[]
     arrayList.get(0);
-    // #end::data_structures_8[];
+    // end::data_structures_8[];
   }
 
   public void data_structures_9() throws Exception {
-    // #tag::data_structures_9[]
+    // tag::data_structures_9[]
     arraySet.add("some_value");
-    // #end::data_structures_9[];
+    // end::data_structures_9[];
   }
 
   public void data_structures_10() throws Exception {
-    // #tag::data_structures_10[]
+    // tag::data_structures_10[]
     Set set = arraySet;
-    // #end::data_structures_10[];
+    // end::data_structures_10[];
   }
 
   public void data_structures_11() throws Exception {
-    // #tag::data_structures_11[]
+    // tag::data_structures_11[]
     arraySet.contains("value");
-    // #end::data_structures_11[];
+    // end::data_structures_11[];
   }
 
   public void data_structures_12() throws Exception {
-    // #tag::data_structures_12[]
+    // tag::data_structures_12[]
     arraySet.remove("some_value");
-    // #end::data_structures_12[];
+    // end::data_structures_12[];
   }
 
   public void data_structures_13() throws Exception {
-    // #tag::data_structures_13[]
+    // tag::data_structures_13[]
     queue.add("job123");
-    // #end::data_structures_13[];
+    // end::data_structures_13[];
   }
 
   public void data_structures_14() throws Exception {
-    // #tag::data_structures_14[]
+    // tag::data_structures_14[]
     Object item = queue.poll(); //=> "job123"
-    // #end::data_structures_14[];
+    // end::data_structures_14[];
   }
 
   public void data_structures_15() throws Exception {
-    // #tag::data_structures_15[]
+    // tag::data_structures_15[]
     int len = arrayList.size(); //=> 42
-    // #end::data_structures_15[];
+    // end::data_structures_15[];
   }
 
   public void data_structures_16() throws Exception {
-    // #tag::data_structures_16[]
+    // tag::data_structures_16[]
     Map<String, String> favorites = new CouchbaseMap<String>("mapDocId", collection, String.class, MapOptions.mapOptions());
     favorites.put("color", "Blue");
     favorites.put("flavor", "Chocolate");
@@ -167,11 +167,11 @@ public class DataStructuresExample {
     // What does the JSON document look like?
     System.out.println(collection.get("mapDocId").contentAsObject());
     //=> {"flavor":"Chocolate","color":"Blue"}
-    // #end::data_structures_16[];
+    // end::data_structures_16[];
   }
 
   public void data_structures_17() throws Exception {
-    // #tag::data_structures_17[]
+    // tag::data_structures_17[]
     List<String> names = new CouchbaseArrayList<String>("listDocId", collection, String.class, ArrayListOptions.arrayListOptions());
     names.add("Alice");
     names.add("Bob");
@@ -182,11 +182,11 @@ public class DataStructuresExample {
     // What does the JSON document look like?
     System.out.println(collection.get("listDocId").contentAsArray());
     //=> ["Alice","Bob","Alice"]
-    // #end::data_structures_17[];
+    // end::data_structures_17[];
   }
 
   public void data_structures_18() throws Exception {
-    // #tag::data_structures_18[]
+    // tag::data_structures_18[]
     Set<String> uniqueNames = new CouchbaseArraySet<String>("setDocId", collection, String.class, ArraySetOptions.arraySetOptions());
     uniqueNames.add("Alice");
     uniqueNames.add("Bob");
@@ -197,11 +197,11 @@ public class DataStructuresExample {
     // What does the JSON document look like?
     System.out.println(collection.get("setDocId").contentAsArray());
     //=> ["Alice","Bob"]
-    // #end::data_structures_18[];
+    // end::data_structures_18[];
   }
 
   public void data_structures_19() throws Exception {
-    // #tag::data_structures_19[]
+    // tag::data_structures_19[]
     Queue<String> shoppingList = new CouchbaseQueue<String>("queueDocId", collection, String.class, QueueOptions.queueOptions());
     shoppingList.add("loaf of bread");
     shoppingList.add("container of milk");
@@ -222,7 +222,7 @@ public class DataStructuresExample {
     // What does the JSON document look like after draining the queue?
     System.out.println(collection.get("queueDocId").contentAsArray());
     //=> []
-    // #end::data_structures_19[];
+    // end::data_structures_19[];
   }
 
   public static void main(String[] args) throws Exception {


### PR DESCRIPTION
Replace "// #tag::" -> "// tag::" (remove unnecessary #)
since Asciidoc honors the comment syntax of the source language.

No functional impact.