### PR TITLE
Prepare for FLE release

### DIFF
--- a/modules/concept-docs/pages/encryption.adoc
+++ b/modules/concept-docs/pages/encryption.adoc
@@ -6,31 +6,32 @@
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
-Fields within a document can be securely encrypted by the SDK, to support FIPS 140-2 compliance.
-
-
-CAUTION: This is a developer preview release of Field Level Encryption for the 3.0 API version of Couchbase Java SDK.
-As such, it is unsupported, and this documentation may lag behind development changes.
-Refer to the https://github.com/couchbase/java-couchbase-encryption[GitHub repo^] for the latest updates.
+A high-level overview of Field-Level Encryption concepts.
+For a practical guide, see xref:howtos:encrypting-using-sdk.adoc[].
 
 [#architecture]
 == Overview
 
-.Actors & Responsibilities in Field Level Encryption
-[#field_level_encryption--architecture]
-image::{incimagesdir}/field_level_encryption-architecture.png[]
+Fields within a JSON document can be securely encrypted by the SDK to support FIPS 140-2 compliance.
 
-This is a client-side implementation, with key management and initialization of data encryption done during configuration of the SDK, which then exposes the API during runtime, for normal read/write operations.
+This is a client-side implementation, with encryption and decryption handled by the Couchbase client SDK.
 
 [#algorithm]
 == Algorithm and Key Store
 
-From Couchbase Server 5.5, AES-256, AES-128, and RSA were all supported in earlier versions of the SDK's Field Level Encryption library -- these encryption algorithms are now deprecated, but decryption of data encrypted under earlier versions continues to be supported.
-SDK 3 uses a new algorithm, AEAD_AES_256_CBC_HMAC_SHA_512, which bundles the auth key and the encryption key into a single 64-byte "fat key".
-The key materials used by the AES and HMAC algorithms are distinct, but the keys can be managed as a single unit.
+SDK 3 uses the `AEAD_AES_256_CBC_HMAC_SHA_512` algorithm to provide authenticated symmetric encryption of sensitive JSON fields.
+This algorithm uses a 64-byte key (known affectionately as a "fat key", since it's really two 32-byte keys joined together).
+The key materials for the AES and HMAC steps are distinct, but are managed as a single unit.
 
-Native Keystores (including Java Key Store and Windows Certificate Store) are supported, as well as an in-memory keystore for development and testing.
-More options for key stores and encryption algorithms may appear in future SDK releases.
+NOTE: Previous versions of the Field-Level Encryption library used a variation of this algorithm that managed the AES and HMAC keys separately.
+This was an obstacle to key rotation, so those algorithms are deprecated in SDK 3 and are no longer used for encryption.
+Existing data encrypted with the old algorithm can still be read by SDK 3, although additional configuration is required to enable backwards compatibility.
+
+Developers may also plug in custom encryption algorithms.
+
+A `Keyring` provides access to encryption keys.
+Implementations are provided for native key stores (including Java Key Store and Windows Certificate Store).
+Developers may provide custom implementations for integration with external key management systems, or to implement key rotation.
 
 [#format]
 == Field Encryption Format
@@ -66,4 +67,4 @@ This means you can install the relevant SDK without being dependant upon a suite
 [#fips-140-2]
 == FIPS 140-2
 
-The standard AEAD_AES_256_CBC_HMAC_SHA512 encryption algorithm is composed of FIPS 140-2 "Approved Security Functions."
+The standard `AEAD_AES_256_CBC_HMAC_SHA512` encryption algorithm is composed of FIPS 140-2 "Approved Security Functions."

--- a/modules/concept-docs/pages/encryption.adoc
+++ b/modules/concept-docs/pages/encryption.adoc
@@ -7,6 +7,7 @@ include::project-docs:partial$attributes.adoc[]
 
 [abstract]
 A high-level overview of Field-Level Encryption concepts.
+
 For a practical guide, see xref:howtos:encrypting-using-sdk.adoc[].
 
 [#architecture]

--- a/modules/howtos/pages/encrypting-using-sdk.adoc
+++ b/modules/howtos/pages/encrypting-using-sdk.adoc
@@ -6,6 +6,7 @@
 
 [abstract]
 A practical guide for getting started with Field-Level Encryption, showing how to encrypt and decrypt JSON fields using the Java SDK.
+
 For a high-level overview of this feature, see xref:concept-docs:encryption.adoc[].
 
 [#package]

--- a/modules/howtos/pages/encrypting-using-sdk.adoc
+++ b/modules/howtos/pages/encrypting-using-sdk.adoc
@@ -5,24 +5,23 @@
 // :page-aliases: ROOT:encrypting-using-sdk.adoc
 
 [abstract]
-The Field Level Encryption library enables encryption and decryption of JSON fields.
-
-CAUTION: The Field-Level Encryption library for Couchbase Java SDK is currently a _pre-release_.
-It is not supported, but is available for development and experiment.
-It is planned that a supported, full release version will be available later this year.
-Refer to the https://github.com/couchbase/java-couchbase-encryption[GitHub repo] for the latest updates.
+A practical guide for getting started with Field-Level Encryption, showing how to encrypt and decrypt JSON fields using the Java SDK.
+For a high-level overview of this feature, see xref:concept-docs:encryption.adoc[].
 
 [#package]
 == Packaging
 
-The Couchbase Java SDK uses the https://github.com/couchbase/java-couchbase-encryption[java-couchbase-encryption^] library to provide support for encryption and decryption of JSON fields.
-It includes cryptographic algorithms and keyrings you can use out of the box, and provides a framework for implementing your own crypto components.
+The Couchbase Java SDK works together with the https://github.com/couchbase/java-couchbase-encryption[Java Couchbase Encryption^] library to provide support for encryption and decryption of JSON fields.
+This library includes cryptographic algorithms and keyrings you can use out of the box, and provides a framework for implementing your own crypto components.
 
-NOTE: This separation of the encryption library ensures that the SDK does not have a dependency upon an encryption library in general use --
-but it does mean you have to explicitly include this external dependency in your project configuration.
+NOTE: The encryption code is packaged as an optional library because it is released under a https://github.com/couchbase/java-couchbase-encryption/blob/master/LICENSE.md[different license^] than the Couchbase Java SDK.
+To use the encryption library, you have to explicitly include this dependency in your project configuration.
 Refer to the xref:#maven-coordinates[dependencies section].
 
-Version `3.0.0-pre.1` of this library requires Couchbase Java SDK version `3.0.5` or later.
+[#requirements]
+== Requirements
+* Couchbase Java SDK version `3.0.5` or later.
+* Java Couchbase Encryption version `3.0.0` or later.
 
 [#maven-coordinates]
 == Maven Coordinates
@@ -35,6 +34,8 @@ Version `3.0.0-pre.1` of this library requires Couchbase Java SDK version `3.0.5
     <version>${version}</version>
 </dependency>
 ----
+
+See the https://github.com/couchbase/java-couchbase-encryption/tags[GitHub repository tags^] for the latest version.
 
 === Optional Dependencies
 
@@ -55,7 +56,7 @@ HashiCorp Vault Transit integration requires https://docs.spring.io/spring-vault
 
 == Configuration
 
-To enable Field-Level Encryption, supply a `CryptoManager` when configuring the Java SDK's `ClusterEnvironment`.
+To enable Field-Level Encryption, supply a `CryptoManager` when configuring the Java SDK's xref:managing-connections.adoc#cluster-environment[`ClusterEnvironment`].
 
 [source,java]
 ----


### PR DESCRIPTION
Remove "pre-release" warnings.

Remove dead link to a missing (obsolete) architecture image.

Add mutual links between the "concept" and "howto" doc abstracts.

Update the concept docs.

Mention that the encryption library is released under
a different license than the SDK.

Add "requirements" section with version compatibility info,
 and info on how to find the latest FLE library version.