### PR TITLE
Expand link text so it looks like a link.

### DIFF
--- a/modules/howtos/pages/encrypting-using-sdk.adoc
+++ b/modules/howtos/pages/encrypting-using-sdk.adoc
@@ -57,7 +57,7 @@ HashiCorp Vault Transit integration requires https://docs.spring.io/spring-vault
 
 == Configuration
 
-To enable Field-Level Encryption, supply a `CryptoManager` when configuring the Java SDK's xref:managing-connections.adoc#cluster-environment[`ClusterEnvironment`].
+To enable Field-Level Encryption, supply a `CryptoManager` when xref:managing-connections.adoc#cluster-environment[configuring the Java SDK's `ClusterEnvironment`].
 
 [source,java]
 ----


### PR DESCRIPTION
Motivation
----------
If the link text consists only of literal monospace
(text enclosed in backticks), the docs styling doesn't
give any indivation it's a hyperlink unless you mouse
over it.

A better fix would be to change the docs site CSS,
but that's beyond my ken.

Modifications
-------------
Expand the link text from "`ClusterEnvironment`"
to "configuring the Java SDK's `ClusterEnvironment`".