### PR TITLE
Remove recommendation to avoid duration > 30 days

### DIFF
--- a/modules/howtos/pages/kv-operations.adoc
+++ b/modules/howtos/pages/kv-operations.adoc
@@ -209,11 +209,9 @@ You can set an expiry value from a `Duration` when creating a document:
 include::example$KvOperations.java[tag=expiry-insert]
 ----
 
-We recommend using a relative duration only if the provided value is less than 30 days. 
-The reason is that the server will assume any value larger than that to be an absolute Unix timestamp. 
-The SDK tries its best to coerce it into sane values, but to avoid any unexpected behavior please stick with relative duration for durations of less than 30 days.
+We recommend using a `Duration` only if the provided value is less than 50 years.
 
-For longer expiry values, use an `Instant` instead:
+For expiration more than 50 years in the future, or if you have already calculated when a document should expire, you can specify the expiry as an `Instant`:
 
 [source,java]
 ----


### PR DESCRIPTION
Since Java SDK 3.0.6, it's safe to specify a duration longer than 30 days.