### PR TITLE
DOC-7628 correct Analytics dataset prerequisites

### DIFF
--- a/modules/howtos/examples/Analytics.java
+++ b/modules/howtos/examples/Analytics.java
@@ -17,11 +17,10 @@
  /*
   * You need the following datasets created:
   *
-  *  CREATE DATASET `airports` ON `travel-sample` where type = "airport";
+  *  CREATE DATASET `airports` ON `travel-sample` where `type` = "airport";
   *  CREATE DATASET `huge-dataset` ON `travel-sample`;
-  *  CREATE DATAVERSE `travel-sample.inventory`;
-  *  USE `travel-sample.inventory`;
-  *  CREATE DATASET `airports-collection` ON `travel-sample`.inventory.airport;
+  *  ALTER COLLECTION `travel-sample`.`inventory`.`airport` ENABLE ANALYTICS;
+  *  CONNECT LINK Local;
   */
 
 // tag::imports[]
@@ -167,20 +166,20 @@ public class Analytics {
     {
       // tag::handle-collection[]
       AnalyticsResult result = cluster.analyticsQuery(
-        "SELECT airportname, country FROM `airports-collection` WHERE country='France' LIMIT 3");
+        "SELECT airportname, country FROM `travel-sample`.inventory.airport WHERE country='France' LIMIT 3");
       // end::handle-collection[]
       show("handle-collection", result);
     }
 
-    {
-      // tag::handle-scope[]
-      Bucket bucket = cluster.bucket("travel-sample");
-      Scope scope = bucket.scope("inventory");
-      AnalyticsResult result = scope.analyticsQuery(
-        "SELECT airportname, country FROM `airports-collection` WHERE country='France' LIMIT 4");
-      // end::handle-scope[]
-      show("handle-scope", result);
-    }
+    // {
+    //   // tag::handle-scope[]
+    //   Bucket bucket = cluster.bucket("travel-sample");
+    //   Scope scope = bucket.scope("inventory");
+    //   AnalyticsResult result = scope.analyticsQuery(
+    //     "SELECT airportname, country FROM `airport` WHERE country='France' LIMIT 4");
+    //   // end::handle-scope[]
+    //   show("handle-scope", result);
+    // }
 
     System.out.println("Disconnecting...");
     cluster.disconnect();

--- a/modules/howtos/examples/Analytics.java
+++ b/modules/howtos/examples/Analytics.java
@@ -171,15 +171,15 @@ public class Analytics {
       show("handle-collection", result);
     }
 
-    // {
-    //   // tag::handle-scope[]
-    //   Bucket bucket = cluster.bucket("travel-sample");
-    //   Scope scope = bucket.scope("inventory");
-    //   AnalyticsResult result = scope.analyticsQuery(
-    //     "SELECT airportname, country FROM `airport` WHERE country='France' LIMIT 4");
-    //   // end::handle-scope[]
-    //   show("handle-scope", result);
-    // }
+    {
+      // tag::handle-scope[]
+      Bucket bucket = cluster.bucket("travel-sample");
+      Scope scope = bucket.scope("inventory");
+      AnalyticsResult result = scope.analyticsQuery(
+        "SELECT airportname, country FROM `airport` WHERE country='France' LIMIT 4");
+      // end::handle-scope[]
+      show("handle-scope", result);
+    }
 
     System.out.println("Disconnecting...");
     cluster.disconnect();

--- a/modules/howtos/pages/analytics-using-sdk.adoc
+++ b/modules/howtos/pages/analytics-using-sdk.adoc
@@ -219,7 +219,6 @@ We can then query the Dataset as normal, using the fully qualified keyspace:
 include::../examples/Analytics.java[tag=handle-collection,indent=0]
 ----
 
-////
 Note that using the `CREATE DATASET` syntax we could choose any Dataset name in any Dataverse, including the default.
 However the SDK supports this standard convention, allowing us to query from the Scope object:
 
@@ -227,4 +226,3 @@ However the SDK supports this standard convention, allowing us to query from the
 ----
 include::../examples/Analytics.java[tag=handle-scope,indent=0]
 ----
-////

--- a/modules/howtos/pages/analytics-using-sdk.adoc
+++ b/modules/howtos/pages/analytics-using-sdk.adoc
@@ -205,31 +205,26 @@ In addition to creating a dataset with a WHERE clause to filter the results to d
 
 [source,n1ql]
 ----
-CREATE DATASET `airports-collection` ON `travel-sample`.inventory.airport;
--- compare with:
--- CREATE DATASET airports ON `travel-sample` WHERE `type` = "airport";
+ALTER COLLECTION `travel-sample`.inventory.airport ENABLE ANALYTICS;
+
+-- NB: this is more or less equivalent to:
+CREATE DATAVERSE `travel-sample`.inventory;
+CREATE DATASET `travel-sample`.inventory.airport ON `travel-sample`.inventory.airport;
 ----
 
-You run the query in exactly the same way as usual:
+We can then query the Dataset as normal, using the fully qualified keyspace:
 
 [source,java]
 ----
 include::../examples/Analytics.java[tag=handle-collection,indent=0]
 ----
 
-Analytics supports Scopes too, by looking for a Dataverse with the name `bucket.scope`
-For example:
-
-[source,n1ql]
-----
-CREATE DATAVERSE `travel-sample.inventory`;
-USE `travel-sample.inventory`;
-CREATE DATASET `airports-collection` ON `travel-sample`.inventory.airport;
-----
-
-Once we have an appropriately named Dataverse and a Dataset created inside it, we can query it as follows:
+////
+Note that using the `CREATE DATASET` syntax we could choose any Dataset name in any Dataverse, including the default.
+However the SDK supports this standard convention, allowing us to query from the Scope object:
 
 [source,java]
 ----
 include::../examples/Analytics.java[tag=handle-scope,indent=0]
 ----
+////


### PR DESCRIPTION
 * update creation of dataset as per
   https://blog.couchbase.com/collections-simplify-your-analysis-with-couchbase-analytics/

 ** this now creates the dataset as "`bucket`.`scope`" instead of "`bucket.scope`"
 ** as the convenience scope.analyticsQuery call seemed to work previously in the
    Java SDK, this suggests the previous behaviour was incorrect?
    Now, the handle-scope example (which previously ran) gives the error:
       `com.couchbase.client.core.error.DataverseNotFoundException: The analytics dataverse is not found`

 ** Commented out that section of code and accompanying documentation for now.
 ** will also raise a bug/clarification ticket with sdk team