### PR TITLE
Setup test automation for Java SDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Build Code Samples 
+
+on:
+  push:
+    branches: [release/3.1]
+    paths:
+      - 'modules/test/*'
+      - 'modules/Makefile'
+      - '**/*.java'
+      - '**/pom.xml'
+  pull_request:
+    branches: [release/3.1]
+    paths:
+      - 'modules/test/*'
+      - 'modules/Makefile'
+      - '**/*.java'
+      - '**/pom.xml'
+env:
+  JAVA_VERSION: 15
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      working-directory:
+        ./modules
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ env.JAVA_VERSION }} # The JDK version to make available on the path.
+          java-package: jdk # (jre, jdk, or jdk+fx) - defaults to jdk
+          architecture: x64 # (x64 or x86) - defaults to x64
+
+      - name: Build code samples
+        run: make build
+        working-directory: ${{ env.working-directory }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test Code Samples 
+name: Test Code Samples
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,44 @@
+name: Test Code Samples 
+
+on:
+  push:
+    branches: [release/3.1]
+    paths:
+      - 'modules/test/*'
+      - 'modules/Makefile'
+      - '**/*.java'
+      - '**/pom.xml'
+  pull_request:
+    branches: [release/3.1]
+    paths:
+      - 'modules/test/*'
+      - 'modules/Makefile'
+      - '**/*.java'
+      - '**/pom.xml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      working-directory:
+        ./modules
+
+    steps:
+      - name: Checkout actions
+        uses: actions/checkout@v2
+
+      - name: Build Couchbase Docker image
+        run: make cb-build
+        working-directory: ${{ env.working-directory }}
+
+      - name: Run Couchbase Server+SDK container
+        run: make cb-start
+        working-directory: ${{ env.working-directory }}
+
+      - name: Test code samples
+        run: make tests 
+        working-directory: ${{ env.working-directory }}
+      
+      - name: Cleanup
+        run: make cb-stop
+        working-directory: ${{ env.working-directory }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ public/
 target/
 .idea/
 *.iml
+node_modules/

--- a/README.adoc
+++ b/README.adoc
@@ -38,3 +38,83 @@ The documentation source files are marked up with AsciiDoc.
 Once merged into a version branch, the source files and their assets are aggregated, converted to HTML, and published by Antora to our staging and production sites.
 The docs components and {url-ui}[site UI] are orchestrated by the {url-playbook}[docs site playbook].
 See the contributing guide to learn more.
+
+== Documentation Code Sample Testing
+
+To ensure that the code samples included in the documentation are correct and produce the results we expect, we have setup scripts that build and test each example file.
+
+For testing we use the https://github.com/bats-core/bats-core[bats-core] automation framework to run the code and https://github.com/ztombol/bats-assert[bats-assert] assertion library to make assertions on the output where necessary.
+
+The tests run against the latest Couchbase Server docker image with the relevant SDK (Java in this case) provided alongside it.
+
+To facilitate running the tests there is a `Makefile` in the `/modules` directory of the project.
+
+There you will find all the relevant commands needed to execute the docker container and the test/build scripts.
+
+=== Running a test
+Before you can run the tests you will need to ensure you have Docker and npm available on your machine.
+
+To run the example tests you will need to build the testing Docker image, run the container and execute your tests.
+
+TIP: After your first build of the docker image you won't need to build it every time you want to run the tests.
+
+Here are the steps required to achieve this:
+
+- `cd` into the `/modules` directory and run `make cb-build` to build a local image of Couchbase Server + Java SDK.
+
+- Once that has completed succesfully you can run `make cb-start` to run the docker container.
+
+Note that this can take some time as it will configure couchbase server with all the required test data (e.g. travel-sample bucket) for the examples to run successfully.
+
+- If you run `docker ps` in a separate shell you should see a container called `cb-test` running.
+```
+CONTAINER ID   IMAGE                          COMMAND                  CREATED             STATUS             PORTS                                                                           NAMES
+6fe1830a205a   couchbase:cb7-sdk3-java-ub20   "/entrypoint.sh couc…"   About an hour ago   Up About an hour   11207/tcp, 11210-11211/tcp, 0.0.0.0:8091-8096->8091-8096/tcp, 18091-18096/tcp   cb-test
+```
+
+- Once the container is up you can run `make TEST_NAME="StartUsing" single-test` to run an individual test.
+
+- You should expect to see the following output in your shell:
+```
+ ✓ [hello-world] - StartUsing.java [13192]
+
+1 test, 0 failures in 13 seconds
+```
+
+- If you want to run all the code sample tests you can also execute `make tests`.
+
+- To stop the docker container you can simply run `make cb-stop`, this will stop and remove the docker container, but will keep the local image should you need to start it up again.
+
+TIP: Because we mount the `/modules` directory in the `cb-test` container, you will see your local code changes reflected in the container instantly, so there is no need to stop and start the container when debugging your code.
+
+=== Creating a new test
+If you look at the `/modules/test` directory you will find files with the *.bats* extension, which are essentially our test files.
+
+Depending on where your code sample is going to be located (e.g. `/modules/devguide`), you will see a corresponding test file in the test directory. 
+
+This is mainly to keep the tests organised and easy to find.
+
+Here is an example test case:
+```
+@test "[hello-world] - your-example-file.java" {
+    runExample <your-example-class-name>
+    assert_success
+    assert_output --partial "some assertion substring"
+} 
+```
+
+*runExample* is simply a helper function provided in `test_helper.bash`, which takes care of invoking your `mvn compile exec:java` command. The idea is that any generic test functions can be placed there to be used across any test.
+
+*assert_success* is a helper function provied by the `bats-assert` library and checks whether your command has successfully exited with a status of 0. 
+
+If not, it will fail the test.
+
+*assert_output --partial* is another bats-assert helper that checks if the output of your code sample contains the substring provided. 
+The assertion will fail if the string is not found.
+
+Note that it will not always be necessary to assert the output of your code sample, in those cases just using `assert_success` will be enough.
+
+=== CI - Github Actions
+When submitting a PR, the code sample tests will run against your changes in the same manner as your local machine using Github Actions. 
+
+You can see the workflow definitions in the `.github` folder.

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -1,0 +1,41 @@
+.PHONY: build
+
+CB_IMAGE=couchbase
+CB_VERSION=cb7-sdk3-java-ub20
+
+TEST_NAME=""
+
+# --------------------------
+# BUILD
+# --------------------------
+build:
+	$(info ************ BUILDING DOC EXAMPLES ************)
+	@mvn compile
+
+# -------------------------------------------
+# DOCKER
+# -------------------------------------------
+cb-build:
+	@docker build --network host -t ${CB_IMAGE}:${CB_VERSION} -f test/Dockerfile .
+
+# Run couchbase server+sdk container. Note that this runs with the `-rm` option, 
+# which will ensure the container is deleted when stopped.
+cb-start:
+	@docker run -t --rm -v ${PWD}:/modules -d --name cb-test -p 8091-8096:8091-8096 ${CB_IMAGE}:${CB_VERSION}
+	@docker exec -t cb-test bin/bash -c "/init-couchbase/init.sh"
+	@docker exec -t cb-test bin/bash -c "/init-couchbase/init-buckets.sh"
+
+# Run all tests
+tests:
+	@cd test && npm install
+	@docker exec -t cb-test bin/bash -c "cd modules && bats -T ./test"
+
+# Run a single test.
+# i.e make TEST_NAME="Analytics" single-test
+single-test:
+	@cd test && npm install
+	@docker exec -t cb-test bin/bash -c "cd modules && bats -T ./test -f ${TEST_NAME}"
+	
+# Stop the server container
+cb-stop:
+	@docker stop cb-test

--- a/modules/hello-world/examples/StartUsing.java
+++ b/modules/hello-world/examples/StartUsing.java
@@ -21,7 +21,7 @@ import com.couchbase.client.java.json.*;
 import com.couchbase.client.java.query.*;
 // end::imports[]
 
-class StartUsing {
+public class StartUsing {
 
   static String connectionString = "localhost";
   static String username = "Administrator";

--- a/modules/howtos/examples/Tracing.java
+++ b/modules/howtos/examples/Tracing.java
@@ -1,8 +1,11 @@
+import java.time.Duration;
+
 import com.couchbase.client.core.cnc.RequestTracer;
 import com.couchbase.client.core.env.CoreEnvironment;
 import com.couchbase.client.core.env.ThresholdRequestTracerConfig;
 import com.couchbase.client.java.env.ClusterEnvironment;
 import com.couchbase.client.tracing.opentelemetry.OpenTelemetryRequestTracer;
+
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.opentelemetry.api.OpenTelemetry;
@@ -10,58 +13,39 @@ import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 
-import java.time.Duration;
-
 public class Tracing {
 
   public static void main(String... args) throws Exception {
     {
       {
         // tag::tracing-configure[]
-        ThresholdRequestTracerConfig.Builder config = ThresholdRequestTracerConfig
-          .builder()
-          .emitInterval(Duration.ofMinutes(1))
-          .kvThreshold(Duration.ofSeconds(2));
+        ThresholdRequestTracerConfig.Builder config = ThresholdRequestTracerConfig.builder()
+            .emitInterval(Duration.ofMinutes(1)).kvThreshold(Duration.ofSeconds(2));
 
-        CoreEnvironment environment = CoreEnvironment
-          .builder()
-          .thresholdRequestTracerConfig(config)
-          .build();
+        CoreEnvironment environment = CoreEnvironment.builder().thresholdRequestTracerConfig(config).build();
         // end::tracing-configure[]
       }
 
       {
         // tag::otel-configure[]
         // Create a channel towards Jaeger end point
-        ManagedChannel jaegerChannel = ManagedChannelBuilder
-          .forAddress("localhost", 14250)
-          .usePlaintext()
-          .build();
+        ManagedChannel jaegerChannel = ManagedChannelBuilder.forAddress("localhost", 14250).usePlaintext().build();
 
         // Export traces to Jaeger
-        JaegerGrpcSpanExporter jaegerExporter = JaegerGrpcSpanExporter
-          .builder()
-          .setServiceName("otel-jaeger-example")
-          .setChannel(jaegerChannel)
-          .setDeadlineMs(30000)
-          .build();
+        JaegerGrpcSpanExporter jaegerExporter = JaegerGrpcSpanExporter.builder().setServiceName("otel-jaeger-example")
+            .setChannel(jaegerChannel).setDeadlineMs(30000).build();
 
         // Set to process the spans by the Jaeger Exporter
-        OpenTelemetrySdk
-          .getGlobalTracerManagement()
-          .addSpanProcessor(SimpleSpanProcessor.builder(jaegerExporter).build());
+        OpenTelemetrySdk.getGlobalTracerManagement()
+            .addSpanProcessor(SimpleSpanProcessor.builder(jaegerExporter).build());
         // end::otel-configure[]
 
         // tag::otel-configure-setup[]
         // Wrap Tracer
-        RequestTracer tracer = OpenTelemetryRequestTracer.wrap(
-          OpenTelemetry.getGlobalTracer("com.couchbase.OpenTelemetryTracingSample")
-        );
+        RequestTracer tracer = OpenTelemetryRequestTracer
+            .wrap(OpenTelemetry.getGlobalTracer("com.couchbase.OpenTelemetryTracingSample"));
 
-        ClusterEnvironment environment = ClusterEnvironment
-          .builder()
-          .requestTracer(tracer)
-          .build();
+        ClusterEnvironment environment = ClusterEnvironment.builder().requestTracer(tracer).build();
         // end::otel-configure-setup[]
       }
     }

--- a/modules/howtos/examples/Tracing.java
+++ b/modules/howtos/examples/Tracing.java
@@ -42,8 +42,7 @@ public class Tracing {
 
         // tag::otel-configure-setup[]
         // Wrap Tracer
-        RequestTracer tracer = OpenTelemetryRequestTracer
-            .wrap(OpenTelemetry.getGlobalTracer("com.couchbase.OpenTelemetryTracingSample"));
+        RequestTracer tracer = OpenTelemetryRequestTracer.wrap(OpenTelemetry.get());
 
         ClusterEnvironment environment = ClusterEnvironment.builder().requestTracer(tracer).build();
         // end::otel-configure-setup[]

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.couchbase.client</groupId>
@@ -116,9 +114,9 @@
 
     <repositories>
         <repository>
-        <id>couchbase</id>
-        <name>Couchbase Preview Repository</name>
-        <url>http://files.couchbase.com/maven2</url>
+            <id>couchbase</id>
+            <name>Couchbase Preview Repository</name>
+            <url>http://files.couchbase.com/maven2</url>
         </repository>
 
         <repository>
@@ -170,11 +168,11 @@
                         </goals>
                         <configuration>
                             <sources>
-                                <source>modules/howtos/examples/</source>
-                                <source>modules/hello-world/examples/</source>
-                                <source>modules/project-docs/examples/</source>
-                                <source>modules/ref/examples/</source>
-                                <source>modules/concept-docs/examples/</source>
+                                <source>howtos/examples/</source>
+                                <source>hello-world/examples/</source>
+                                <source>project-docs/examples/</source>
+                                <source>ref/examples/</source>
+                                <source>concept-docs/examples/</source>
                             </sources>
                         </configuration>
                     </execution>

--- a/modules/test/Dockerfile
+++ b/modules/test/Dockerfile
@@ -1,0 +1,64 @@
+ARG BASE_IMAGE=ubuntu:20.04
+
+ARG CB_EDITION=enterprise
+ARG CB_VERSION=7.0.0-beta
+ARG CB_IMAGE=couchbase:$CB_EDITION-$CB_VERSION
+
+ARG CB_CLIENT_OS=ubuntu2004
+ARG CB_CLIENT_OS_TYPE=focal
+
+# SDK related images...
+
+FROM adoptopenjdk AS adoptopenjdk
+
+FROM maven AS maven
+
+FROM $CB_IMAGE
+
+ARG CB_EDITION
+ARG CB_VERSION
+ARG CB_IMAGE
+
+ARG CB_CLIENT_OS
+ARG CB_CLIENT_OS_TYPE
+
+ENV TZ=America/Los_Angeles
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get update && \
+    apt-get install -y \
+	git curl wget jq unzip zip \
+	build-essential cmake libssl-dev \
+	atop htop psmisc strace time \
+	vim npm
+
+# ------------------------------------------------------
+
+COPY --from=adoptopenjdk /opt/java /opt/java
+
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH="$PATH:/opt/java/openjdk/bin"
+
+RUN javac --version && \
+    java --version
+
+# Copy init-couchbase files into image.
+
+RUN mkdir -p /init-couchbase
+COPY test/scripts/init-couchbase /init-couchbase
+RUN chmod +x /init-couchbase/*.sh
+
+# Append to /opt/couchbase/etc/couchbase/static_config...
+
+RUN if [ ! -d /opt/couchbase/etc/couchbase ]; then mkdir -p /opt/couchbase/etc/couchbase; fi \
+    && cat /init-couchbase/init-static-config.txt >> \
+        /opt/couchbase/etc/couchbase/static_config
+
+# ------------------------------------------------
+# SDK java.
+
+# Copy maven shared files.
+
+COPY --from=maven /usr/share/maven /usr/share/maven
+
+RUN ln -s /usr/share/maven/bin/mvn /usr/bin/mvn

--- a/modules/test/package-lock.json
+++ b/modules/test/package-lock.json
@@ -1,0 +1,33 @@
+{
+  "name": "test",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "bats-assert": "github:ztombol/bats-assert",
+        "bats-support": "github:ztombol/bats-support"
+      }
+    },
+    "node_modules/bats-assert": {
+      "resolved": "git+ssh://git@github.com/ztombol/bats-assert.git#9f88b4207da750093baabc4e3f41bf68f0dd3630",
+      "dev": true
+    },
+    "node_modules/bats-support": {
+      "resolved": "git+ssh://git@github.com/ztombol/bats-support.git#004e707638eedd62e0481e8cdc9223ad471f12ee",
+      "dev": true
+    }
+  },
+  "dependencies": {
+    "bats-assert": {
+      "version": "git+ssh://git@github.com/ztombol/bats-assert.git#9f88b4207da750093baabc4e3f41bf68f0dd3630",
+      "dev": true,
+      "from": "bats-assert@github:ztombol/bats-assert"
+    },
+    "bats-support": {
+      "version": "git+ssh://git@github.com/ztombol/bats-support.git#004e707638eedd62e0481e8cdc9223ad471f12ee",
+      "dev": true,
+      "from": "bats-support@github:ztombol/bats-support"
+    }
+  }
+}

--- a/modules/test/package.json
+++ b/modules/test/package.json
@@ -1,0 +1,6 @@
+{
+  "devDependencies": {
+    "bats-assert": "github:ztombol/bats-assert",
+    "bats-support": "github:ztombol/bats-support"
+  }
+}

--- a/modules/test/scripts/init-couchbase/init-buckets.sh
+++ b/modules/test/scripts/init-couchbase/init-buckets.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+# expand variables and print commands
+set -o xtrace
+
+# exit immediately if a command fails or if there are unset vars
+set -euo pipefail
+
+CB_USER="${CB_USER:-Administrator}"
+CB_PSWD="${CB_PSWD:-password}"
+
+CB_BUCKET_RAMSIZE="${CB_BUCKET_RAMSIZE:-128}"
+
+echo "couchbase-cli bucket-create travel-sample..."
+/opt/couchbase/bin/couchbase-cli bucket-create \
+-c localhost -u ${CB_USER} -p ${CB_PSWD} \
+--bucket travel-sample \
+--bucket-type couchbase \
+--bucket-ramsize ${CB_BUCKET_RAMSIZE} \
+--bucket-replica 0 \
+--bucket-priority low \
+--bucket-eviction-policy fullEviction \
+--enable-flush 1 \
+--enable-index-replica 0 \
+--wait
+
+sleep 5
+
+echo "cbimport travel-sample..."
+/opt/couchbase/bin/cbimport json --format sample --verbose \
+-c localhost -u ${CB_USER} -p ${CB_PSWD} \
+-b travel-sample \
+-d file:///opt/couchbase/samples/travel-sample.zip
+
+echo "create ariports dataset"
+curl --fail -v -u ${CB_USER}:${CB_PSWD} -H "Content-Type: application/json" -d '{
+    "statement": "CREATE DATASET airports ON `travel-sample` WHERE `type`=\"airport\";",
+    "pretty":true,
+    "client_context_id":"test"
+}' http://localhost:8095/analytics/service
+
+echo "sleep 10 to allow stabilization..."
+sleep 10
+
+echo "create travel-sample-index"
+curl --fail -v -u Administrator:password -X PUT \
+http://localhost:8094/api/index/travel-sample-index \
+-H 'cache-control: no-cache' \
+-H 'content-type: application/json' \
+-d '{
+        "name": "travel-sample-index",
+        "type": "fulltext-index",
+        "params": {
+            "doc_config": {
+                "docid_prefix_delim": "",
+                "docid_regexp": "",
+                "mode": "type_field",
+                "type_field": "type"
+            },
+            "mapping": {
+                "default_analyzer": "standard",
+                "default_datetime_parser": "dateTimeOptional",
+                "default_field": "_all",
+                "default_mapping": {
+                    "dynamic": false,
+                    "enabled": true,
+                    "properties": {
+                        "description": {
+                            "enabled": true,
+                            "dynamic": false,
+                            "fields": [
+                                {
+                                    "docvalues": true,
+                                    "include_in_all": true,
+                                    "include_term_vectors": true,
+                                    "index": true,
+                                    "name": "description",
+                                    "store": true,
+                                    "type": "text"
+                                }
+                            ]
+                        },
+                        "type": {
+                            "enabled": true,
+                            "dynamic": false,
+                            "fields": [
+                                {
+                                    "docvalues": true,
+                                    "include_in_all": true,
+                                    "include_term_vectors": true,
+                                    "index": true,
+                                    "name": "type",
+                                    "store": true,
+                                    "type": "text"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "default_type": "_default",
+                "docvalues_dynamic": true,
+                "index_dynamic": true,
+                "store_dynamic": false,
+                "type_field": "_type"
+            },
+            "store": {
+                "indexType": "scorch",
+                "segmentVersion": 15
+            }
+        },
+        "sourceType": "gocbcore",
+        "sourceName": "travel-sample",
+        "sourceParams": {},
+        "planParams": {
+            "maxPartitionsPerPIndex": 1024,
+            "indexPartitions": 1,
+            "numReplicas": 0
+        }
+}'
+
+echo "sleep 20 to allow search index to load..."
+sleep 20

--- a/modules/test/scripts/init-couchbase/init-indexer.json
+++ b/modules/test/scripts/init-couchbase/init-indexer.json
@@ -1,0 +1,7 @@
+{
+  "indexer.settings.inmemory_snapshot.fdb.interval": 3000,
+  "indexer.settings.inmemory_snapshot.interval": 3000,
+  "indexer.settings.inmemory_snapshot.moi.interval": 3000,
+  "indexer.stream_reader.fdb.syncBatchInterval": 20000,
+  "indexer.stream_reader.moi.syncBatchInterval": 20000
+}

--- a/modules/test/scripts/init-couchbase/init-static-config.txt
+++ b/modules/test/scripts/init-couchbase/init-static-config.txt
@@ -1,0 +1,1 @@
+{grab_stats_every_n_ticks, 2}.

--- a/modules/test/scripts/init-couchbase/init.sh
+++ b/modules/test/scripts/init-couchbase/init.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+CB_USER="${CB_USER:-Administrator}"
+CB_PSWD="${CB_PSWD:-password}"
+CB_HOST="${CB_HOST:-127.0.0.1}"
+CB_PORT="${CB_PORT:-8091}"
+CB_NAME="${CB_NAME:-docs-test}"
+
+CB_SERVICES="${CB_SERVICES:-data,query,index,fts,analytics}"
+
+CB_KV_RAMSIZE="${CB_KV_RAMSIZE:-1024}"
+CB_INDEX_RAMSIZE="${CB_INDEX_RAMSIZE:-256}"
+CB_FTS_RAMSIZE="${CB_FTS_RAMSIZE:-256}"
+CB_EVENTING_RAMSIZE="${CB_EVENTING_RAMSIZE:-0}"
+CB_ANALYTICS_RAMSIZE="${CB_ANALYTICS_RAMSIZE:-1024}"
+
+CB_INDEXER_PORT="${CB_INDEXER_PORT:-9102}"
+
+# exit immediately if a command fails or if there are unset vars
+set -euo pipefail
+
+# turn on bash's job control, used to bring couchbase-server
+# back to the foreground after the node is configured
+set -m
+
+echo "Starting couchbase-server..."
+/entrypoint.sh couchbase-server &
+
+sleep 5
+
+echo "Restarting couchbase-server..."
+/opt/couchbase/bin/couchbase-server -k
+
+sleep 5
+
+echo "Waiting for couchbase-server..."
+until curl -s http://${CB_HOST}:${CB_PORT}/pools > /dev/null; do
+    sleep 5
+    echo "Waiting for couchbase-server..."
+done
+
+echo "Waiting for couchbase-server... ready"
+
+if ! couchbase-cli server-list -c ${CB_HOST}:${CB_PORT} -u ${CB_USER} -p ${CB_PSWD} > /dev/null; then
+    echo "couchbase cluster-init..."
+    couchbase-cli cluster-init \
+    --services ${CB_SERVICES} \
+    --cluster-name ${CB_NAME} \
+    --cluster-username ${CB_USER} \
+    --cluster-password ${CB_PSWD} \
+    --cluster-ramsize ${CB_KV_RAMSIZE} \
+    --cluster-index-ramsize ${CB_INDEX_RAMSIZE} \
+    --cluster-fts-ramsize ${CB_FTS_RAMSIZE} \
+    --cluster-eventing-ramsize ${CB_EVENTING_RAMSIZE} \
+    --cluster-analytics-ramsize ${CB_ANALYTICS_RAMSIZE}
+fi
+
+sleep 3
+
+curl -v -X POST -d @/init-couchbase/init-indexer.json \
+http://${CB_USER}:${CB_PSWD}@${CB_HOST}:${CB_INDEXER_PORT}/internal/settings?internal=ok
+
+sleep 3
+
+killall indexer
+
+sleep 3
+
+curl http://${CB_USER}:${CB_PSWD}@${CB_HOST}:${CB_INDEXER_PORT}/internal/settings?internal=ok | jq .
+
+echo "Installing bats test framework..."
+npm install -g bats
+export TERM=xterm-256color
+echo

--- a/modules/test/test-hello-world.bats
+++ b/modules/test/test-hello-world.bats
@@ -1,0 +1,15 @@
+#!./test/libs/bats/bin/bats
+
+load 'test/test_helper.bash'
+
+@test "[hello-world] - DocParser.java" {
+    runExample DocParser 
+    assert_success
+}
+
+@test "[hello-world] - StartUsing.java" {
+    runExample StartUsing 
+    assert_success
+    assert_output --partial "mike"
+    assert_output --partial "[{\"greeting\":\"Hello World\"}]"
+}

--- a/modules/test/test_helper.bash
+++ b/modules/test/test_helper.bash
@@ -1,0 +1,8 @@
+setup() {
+    load 'node_modules/bats-support/load'
+    load 'node_modules/bats-assert/load'
+}
+
+function runExample() {
+    run mvn compile exec:java -Dexec.mainClass=$1 -Dexec.cleanupDaemonThreads=false
+}


### PR DESCRIPTION
This PR adds the test automation setup for the Java code samples, and adds 2 initial tests to ensure the setup works.
The changes are quite similar to the Go SDK [PR](https://github.com/couchbase/docs-sdk-go/pull/117).

Please note when we compile the example Java classes, I've excluded the ones in here for the moment as I am not sure why they have their own separate `pom.xml` file with version `3.0.10` of the couchbase client:
https://github.com/couchbase/docs-sdk-java/blob/release/3.1/modules/devguide/examples/java/pom.xml
Any historical reasons? I can't see many of them referenced in .adoc files, but let me know if I need to include them.

I am planning to add tests for all other remaining examples in a separate PR so that this changeset doesn't get too big.