### PR TITLE
DOC-8462 - Use internal build of Couchbase Server for tests

### DIFF
--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -1,4 +1,4 @@
-name: Test Code Samples
+name: Test Code Samples (Dev)
 
 on:
   push:
@@ -15,6 +15,10 @@ on:
       - 'modules/Makefile'
       - '**/*.java'
       - '**/pom.xml'
+env:
+  REGISTRY: registry.gitlab.com/cb-vanilla/server
+  CB_EDITION: 7.0.0
+  CB_BUILD: 5127
 
 jobs:
   test:
@@ -26,6 +30,13 @@ jobs:
     steps:
       - name: Checkout actions
         uses: actions/checkout@v2
+
+      - name: Docker Login
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PSWD }}
 
       - name: Build Couchbase Docker image
         run: make cb-build

--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -8,13 +8,7 @@ on:
       - 'modules/Makefile'
       - '**/*.java'
       - '**/pom.xml'
-  pull_request:
-    branches: [release/3.1]
-    paths:
-      - 'modules/test/*'
-      - 'modules/Makefile'
-      - '**/*.java'
-      - '**/pom.xml'
+      
 env:
   REGISTRY: registry.gitlab.com/cb-vanilla/server
   CB_EDITION: 7.0.0

--- a/.github/workflows/test-ga.yml
+++ b/.github/workflows/test-ga.yml
@@ -1,0 +1,44 @@
+name: Test Code Samples (GA)
+
+on:
+  push:
+    branches: [release/3.1]
+    paths:
+      - 'modules/test/*'
+      - 'modules/Makefile'
+      - '**/*.java'
+      - '**/pom.xml'
+  pull_request:
+    branches: [release/3.1]
+    paths:
+      - 'modules/test/*'
+      - 'modules/Makefile'
+      - '**/*.java'
+      - '**/pom.xml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      working-directory:
+        ./modules
+
+    steps:
+      - name: Checkout actions
+        uses: actions/checkout@v2
+
+      - name: Build Couchbase Docker image
+        run: make cb-build
+        working-directory: ${{ env.working-directory }}
+
+      - name: Run Couchbase Server+SDK container
+        run: make cb-start
+        working-directory: ${{ env.working-directory }}
+
+      - name: Test code samples
+        run: make tests 
+        working-directory: ${{ env.working-directory }}
+      
+      - name: Cleanup
+        run: make cb-stop
+        working-directory: ${{ env.working-directory }}

--- a/README.adoc
+++ b/README.adoc
@@ -1,3 +1,8 @@
+image:https://github.com/couchbase/docs-sdk-java/actions/workflows/build.yml/badge.svg[https://github.com/couchbase/docs-sdk-java/actions/workflows/build.yml] 
+image:https://github.com/couchbase/docs-sdk-java/actions/workflows/test-ga.yml/badge.svg[https://github.com/couchbase/docs-sdk-java/actions/workflows/test-ga.yml]
+image:https://github.com/couchbase/docs-sdk-java/actions/workflows/test-dev.yml/badge.svg[https://github.com/couchbase/docs-sdk-java/actions/workflows/test-dev.yml]
+
+
 = Couchbase Java SDK Documentation
 // Settings:
 ifdef::env-github[]

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -1,7 +1,8 @@
 .PHONY: build
 
-CB_IMAGE=couchbase
-CB_VERSION=cb7-sdk3-java-ub20
+CB_EDITION ?=couchbase/server:enterprise-7.0.0
+CB_BUILD ?=beta
+LOCAL_IMAGE_NAME=cb7-sdk3-java-ub20
 
 TEST_NAME=""
 
@@ -16,12 +17,12 @@ build:
 # DOCKER
 # -------------------------------------------
 cb-build:
-	@docker build --network host -t ${CB_IMAGE}:${CB_VERSION} -f test/Dockerfile .
+	@docker build --build-arg CB_EDITION=${CB_EDITION} --build-arg CB_BUILD=${CB_BUILD} -t ${LOCAL_IMAGE_NAME} -f test/Dockerfile .
 
 # Run couchbase server+sdk container. Note that this runs with the `-rm` option, 
 # which will ensure the container is deleted when stopped.
 cb-start:
-	@docker run -t --rm -v ${PWD}:/modules -d --name cb-test -p 8091-8096:8091-8096 ${CB_IMAGE}:${CB_VERSION}
+	@docker run -t --rm -v ${PWD}:/modules -d --name cb-test -p 8091-8096:8091-8096 ${LOCAL_IMAGE_NAME}}
 	@docker exec -t cb-test bin/bash -c "/init-couchbase/init.sh"
 	@docker exec -t cb-test bin/bash -c "/init-couchbase/init-buckets.sh"
 

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -22,7 +22,7 @@ cb-build:
 # Run couchbase server+sdk container. Note that this runs with the `-rm` option, 
 # which will ensure the container is deleted when stopped.
 cb-start:
-	@docker run -t --rm -v ${PWD}:/modules -d --name cb-test -p 8091-8096:8091-8096 ${LOCAL_IMAGE_NAME}}
+	@docker run -t --rm -v ${PWD}:/modules -d --name cb-test -p 8091-8096:8091-8096 ${LOCAL_IMAGE_NAME}
 	@docker exec -t cb-test bin/bash -c "/init-couchbase/init.sh"
 	@docker exec -t cb-test bin/bash -c "/init-couchbase/init-buckets.sh"
 

--- a/modules/howtos/examples/AsyncOperations.java
+++ b/modules/howtos/examples/AsyncOperations.java
@@ -39,6 +39,7 @@ import com.couchbase.client.java.kv.GetResult;
 import io.reactivex.Single;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
 
 public class AsyncOperations {
 
@@ -112,7 +113,8 @@ public class AsyncOperations {
       List<String> docsToFetch = Arrays.asList("airline_1316", "airline_13391", "airline_1355");
 
       List<GetResult> results = Flux.fromIterable(docsToFetch)
-          .flatMap(key -> reactiveCollection.get(key).retryBackoff(10, Duration.ofMillis(10))).collectList().block();
+          .flatMap(key -> reactiveCollection.get(key).retryWhen(Retry.backoff(10, Duration.ofMillis(10)))).collectList()
+          .block();
       // end::retry-bulk[]
     }
 

--- a/modules/test/Dockerfile
+++ b/modules/test/Dockerfile
@@ -1,8 +1,8 @@
 ARG BASE_IMAGE=ubuntu:20.04
 
-ARG CB_EDITION=enterprise
-ARG CB_VERSION=7.0.0-beta
-ARG CB_IMAGE=couchbase:$CB_EDITION-$CB_VERSION
+ARG CB_EDITION=couchbase/server:enterprise-7.0.0
+ARG CB_BUILD=beta
+ARG CB_IMAGE=$CB_EDITION-$CB_BUILD
 
 ARG CB_CLIENT_OS=ubuntu2004
 ARG CB_CLIENT_OS_TYPE=focal
@@ -27,10 +27,10 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update && \
     apt-get install -y \
-	git curl wget jq unzip zip \
-	build-essential cmake libssl-dev \
-	atop htop psmisc strace time \
-	vim npm
+    git curl wget jq unzip zip \
+    build-essential cmake libssl-dev \
+    atop htop psmisc strace time \
+    vim npm
 
 # ------------------------------------------------------
 
@@ -52,7 +52,7 @@ RUN chmod +x /init-couchbase/*.sh
 
 RUN if [ ! -d /opt/couchbase/etc/couchbase ]; then mkdir -p /opt/couchbase/etc/couchbase; fi \
     && cat /init-couchbase/init-static-config.txt >> \
-        /opt/couchbase/etc/couchbase/static_config
+    /opt/couchbase/etc/couchbase/static_config
 
 # ------------------------------------------------
 # SDK java.

--- a/modules/test/scripts/init-couchbase/travel-sample-index.json
+++ b/modules/test/scripts/init-couchbase/travel-sample-index.json
@@ -1,0 +1,70 @@
+{
+  "name": "travel-sample-index",
+  "type": "fulltext-index",
+  "params": {
+    "doc_config": {
+      "docid_prefix_delim": "",
+      "docid_regexp": "",
+      "mode": "type_field",
+      "type_field": "type"
+    },
+    "mapping": {
+      "default_analyzer": "standard",
+      "default_datetime_parser": "dateTimeOptional",
+      "default_field": "_all",
+      "default_mapping": {
+        "dynamic": false,
+        "enabled": true,
+        "properties": {
+          "description": {
+            "enabled": true,
+            "dynamic": false,
+            "fields": [
+              {
+                "docvalues": true,
+                "include_in_all": true,
+                "include_term_vectors": true,
+                "index": true,
+                "name": "description",
+                "store": true,
+                "type": "text"
+              }
+            ]
+          },
+          "type": {
+            "enabled": true,
+            "dynamic": false,
+            "fields": [
+              {
+                "docvalues": true,
+                "include_in_all": true,
+                "include_term_vectors": true,
+                "index": true,
+                "name": "type",
+                "store": true,
+                "type": "text"
+              }
+            ]
+          }
+        }
+      },
+      "default_type": "_default",
+      "docvalues_dynamic": true,
+      "index_dynamic": true,
+      "store_dynamic": false,
+      "type_field": "_type"
+    },
+    "store": {
+      "indexType": "scorch",
+      "segmentVersion": 15
+    }
+  },
+  "sourceType": "gocbcore",
+  "sourceName": "travel-sample",
+  "sourceParams": {},
+  "planParams": {
+    "maxPartitionsPerPIndex": 1024,
+    "indexPartitions": 1,
+    "numReplicas": 0
+  }
+}

--- a/modules/test/test-howtos.bats
+++ b/modules/test/test-howtos.bats
@@ -52,15 +52,6 @@ load 'test/test_helper.bash'
 }
 
 @test "[howtos] - KvOperations.java" {
-    # The example with tag `named-collection-upsert` fails when running against Couchbase Server 7.0.0-beta(4602) docker
-    # image with the following error:
-    #
-    # com.couchbase.client.core.error.AmbiguousTimeoutException: UpsertRequest, Reason: TIMEOUT
-
-    # Seems to be fixed when testing against Couchbase Server build `4933` locally(using vagrant), 
-    # but we have no way of running against internal builds at this point in time. 
-    skip "TODO: Example requires latest build of Couchbase Server 7.0"
-
     runExample KvOperations 
     assert_success
 }


### PR DESCRIPTION
This applies the same changes made in this PR: https://github.com/couchbase/docs-sdk-go/pull/129

I've also included a fix for the failing compilation of `AsyncOperations.java`, this was causing the `Build Code Samples` check to fail. Looks like this commit might have triggered that failure: https://github.com/couchbase/docs-sdk-java/commit/f682a63245dc5f24ebe7d392653c60730cecf769