### PR TITLE
DOC-7867 - SDK 3.2 Collections-first examples

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,14 +2,14 @@ name: Build Code Samples
 
 on:
   push:
-    branches: [release/3.1]
+    branches: [release/3.2]
     paths:
       - 'modules/test/*'
       - 'modules/Makefile'
       - '**/*.java'
       - '**/pom.xml'
   pull_request:
-    branches: [release/3.1]
+    branches: [release/3.2]
     paths:
       - 'modules/test/*'
       - 'modules/Makefile'

--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -2,7 +2,7 @@ name: Test Code Samples (Dev)
 
 on:
   push:
-    branches: [release/3.1]
+    branches: [release/3.2]
     paths:
       - 'modules/test/*'
       - 'modules/Makefile'
@@ -12,7 +12,7 @@ on:
 env:
   REGISTRY: registry.gitlab.com/cb-vanilla/server
   CB_EDITION: 7.0.0
-  CB_BUILD: 5127
+  CB_BUILD: 5295
 
 jobs:
   test:

--- a/.github/workflows/test-ga.yml
+++ b/.github/workflows/test-ga.yml
@@ -2,14 +2,14 @@ name: Test Code Samples (GA)
 
 on:
   push:
-    branches: [release/3.1]
+    branches: [release/3.2]
     paths:
       - 'modules/test/*'
       - 'modules/Makefile'
       - '**/*.java'
       - '**/pom.xml'
   pull_request:
-    branches: [release/3.1]
+    branches: [release/3.2]
     paths:
       - 'modules/test/*'
       - 'modules/Makefile'

--- a/modules/concept-docs/examples/BucketsAndClustersExample.java
+++ b/modules/concept-docs/examples/BucketsAndClustersExample.java
@@ -32,8 +32,6 @@ public class BucketsAndClustersExample {
 
   Cluster cluster;
   Bucket bucket;
-  Scope scope;
-  Collection collection;
   BucketSettings bucketSettings;
 
   private void init() {
@@ -41,8 +39,6 @@ public class BucketsAndClustersExample {
     cluster = Cluster.connect(connectionString,
         ClusterOptions.clusterOptions(username, password).environment(environment));
     bucket = cluster.bucket(bucketName);
-    scope = bucket.defaultScope();
-    collection = bucket.defaultCollection();
   }
 
   public void buckets_and_clusters_1() throws Exception {

--- a/modules/concept-docs/examples/CollectionsExample.java
+++ b/modules/concept-docs/examples/CollectionsExample.java
@@ -18,8 +18,9 @@ import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.ClusterOptions;
 import com.couchbase.client.java.Collection;
-import com.couchbase.client.java.Scope;
 import com.couchbase.client.java.env.ClusterEnvironment;
+import com.couchbase.client.java.manager.collection.CollectionManager;
+import com.couchbase.client.java.manager.collection.CollectionSpec;
 
 public class CollectionsExample {
 
@@ -30,29 +31,37 @@ public class CollectionsExample {
 
   Cluster cluster;
   Bucket bucket;
-  Scope scope;
   Collection collection;
+  CollectionManager collectionMgr;
 
   private void init() {
     ClusterEnvironment environment = ClusterEnvironment.builder().build();
     cluster = Cluster.connect(connectionString,
         ClusterOptions.clusterOptions(username, password).environment(environment));
     bucket = cluster.bucket(bucketName);
-    scope = bucket.defaultScope();
-    collection = bucket.defaultCollection();
+
+    createCollection("bookings");
   }
 
-    // tag::collections_1[]
+  private void createCollection(String name) {
+    collectionMgr = bucket.collections();
+
+    // create flights collection in default scope
+    CollectionSpec spec1 = CollectionSpec.create(name, "_default");
+    collectionMgr.createCollection(spec1);
+  }
+
   public void collections_1() throws Exception {
-    collection = bucket.collection("flights"); // in default scope
-  }
+    // tag::collections_1[]
+    collection = bucket.collection("bookings"); // in default scope
     // end::collections_1[]
-
-    // tag::collections_2[]
-  public void collections_2() throws Exception {
-    collection = bucket.scope("marlowe_agency").collection("flights");
   }
+
+  public void collections_2() throws Exception {
+    // tag::collections_2[]
+    collection = bucket.scope("tenant_agent_00").collection("bookings");
     // end::collections_2[]
+  }
 
   public static void main(String[] args) throws Exception {
     CollectionsExample obj = new CollectionsExample();

--- a/modules/concept-docs/examples/CollectionsExample.java
+++ b/modules/concept-docs/examples/CollectionsExample.java
@@ -47,8 +47,8 @@ public class CollectionsExample {
     collectionMgr = bucket.collections();
 
     // create flights collection in default scope
-    CollectionSpec spec1 = CollectionSpec.create(name, "_default");
-    collectionMgr.createCollection(spec1);
+    CollectionSpec spec = CollectionSpec.create(name, "_default");
+    collectionMgr.createCollection(spec);
   }
 
   public void collections_1() throws Exception {

--- a/modules/concept-docs/examples/CompressionExample.java
+++ b/modules/concept-docs/examples/CompressionExample.java
@@ -27,20 +27,13 @@ public class CompressionExample {
   String connectionString = "localhost";
   String username = "Administrator";
   String password = "password";
-  String bucketName = "travel-sample";
 
   Cluster cluster;
-  Bucket bucket;
-  Scope scope;
-  Collection collection;
 
   private void init() {
     ClusterEnvironment environment = ClusterEnvironment.builder().build();
     cluster = Cluster.connect(connectionString,
         ClusterOptions.clusterOptions(username, password).environment(environment));
-    bucket = cluster.bucket(bucketName);
-    scope = bucket.defaultScope();
-    collection = bucket.defaultCollection();
   }
 
   public void compression_1() throws Exception {

--- a/modules/concept-docs/examples/DataModelExample.java
+++ b/modules/concept-docs/examples/DataModelExample.java
@@ -40,8 +40,8 @@ public class DataModelExample {
     cluster = Cluster.connect(connectionString,
         ClusterOptions.clusterOptions(username, password).environment(environment));
     bucket = cluster.bucket(bucketName);
-    scope = bucket.defaultScope();
-    collection = bucket.defaultCollection();
+    scope = bucket.scope("tenant_agent_00");
+    collection = scope.collection("users");
   }
 
   public void data_model_1() throws Exception {

--- a/modules/concept-docs/examples/HealthCheckConcepts.java
+++ b/modules/concept-docs/examples/HealthCheckConcepts.java
@@ -35,12 +35,12 @@ public class HealthCheckConcepts {
   public static void main(String... args) {
     Cluster cluster = Cluster.connect("127.0.0.1", "Administrator", "password");
 
-    Bucket bucket = cluster.bucket("bucket-name");
-    Scope scope = bucket.scope("scope-name");
-    Collection collection = scope.collection("collection-name");
+    Bucket bucket = cluster.bucket("travel-sample");
+    Scope scope = bucket.scope("tenant_agent_00");
+    Collection collection = scope.collection("users");
 
     {
-// tag::ping-basic[]
+      // tag::ping-basic[]
       PingResult pingResult = cluster.ping();
 
       for (Map.Entry<ServiceType, List<EndpointPingReport>> service : pingResult.endpoints().entrySet()) {
@@ -50,27 +50,27 @@ public class HealthCheckConcepts {
           );
         }
       }
-// end::ping-basic[]
+      // end::ping-basic[]
     }
 
     {
-// tag::ping-json-export[]
+      // tag::ping-json-export[]
       PingResult pingResult = cluster.ping();
 
       System.out.println(pingResult.exportToJson());
-// end::ping-json-export[]
+      // end::ping-json-export[]
     }
 
     {
-// tag::ping-options[]
+      // tag::ping-options[]
       PingResult pingResult = cluster.ping(pingOptions().serviceTypes(EnumSet.of(ServiceType.QUERY)));
 
       System.out.println(pingResult.exportToJson());
-// end::ping-options[]
+      // end::ping-options[]
     }
 
     {
-// tag::diagnostics-basic[]
+      // tag::diagnostics-basic[]
       DiagnosticsResult diagnosticsResult = cluster.diagnostics();
 
       for (Map.Entry<ServiceType, List<EndpointDiagnostics>> service : diagnosticsResult.endpoints().entrySet()) {
@@ -80,15 +80,15 @@ public class HealthCheckConcepts {
           );
         }
       }
-// end::diagnostics-basic[]
+      // end::diagnostics-basic[]
     }
 
     {
-// tag::diagnostics-options[]
+      // tag::diagnostics-options[]
       DiagnosticsResult diagnosticsResult = cluster.diagnostics();
 
       System.out.println(diagnosticsResult.exportToJson());
-// end::diagnostics-options[]
+      // end::diagnostics-options[]
     }
   }
 

--- a/modules/concept-docs/examples/XattrExample.java
+++ b/modules/concept-docs/examples/XattrExample.java
@@ -42,8 +42,8 @@ public class XattrExample {
     cluster = Cluster.connect(connectionString,
         ClusterOptions.clusterOptions(username, password).environment(environment));
     bucket = cluster.bucket(bucketName);
-    scope = bucket.defaultScope();
-    collection = bucket.defaultCollection();
+    scope = bucket.scope("inventory");
+    collection = scope.collection("airport");
   }
 
   public void xattr_1() throws Exception {

--- a/modules/concept-docs/pages/analytics-for-sdk-users.adoc
+++ b/modules/concept-docs/pages/analytics-for-sdk-users.adoc
@@ -21,5 +21,5 @@ For complex and long-running queries, involving large ad hoc join, set, aggregat
 
 == Additional Resources
 
-* Start with our  xref:6.5@server:analytics:primer-beer.adoc[introductory primer].
+* Start with our  xref:7.0@server:analytics:primer-beer.adoc[introductory primer].
 * Read the practical introduction xref:howtos:analytics-using-sdk.adoc[using analytics from the SDK].

--- a/modules/concept-docs/pages/buckets-and-clusters.adoc
+++ b/modules/concept-docs/pages/buckets-and-clusters.adoc
@@ -7,7 +7,7 @@
 [abstract]
 {description}
 
-include::6.5@sdk:shared:partial$clusters-buckets.adoc[tag=management]
+include::7.0@sdk:shared:partial$clusters-buckets.adoc[tag=management]
 
 Management operations in the Java SDK may be performed through several interfaces depending on the object:
 

--- a/modules/concept-docs/pages/certificate-based-authentication.adoc
+++ b/modules/concept-docs/pages/certificate-based-authentication.adoc
@@ -1,1 +1,1 @@
-include::6.5@sdk:pages:partial$certificates.adoc[]
+include::7.0@sdk:pages:partial$certificates.adoc[]

--- a/modules/concept-docs/pages/collections.adoc
+++ b/modules/concept-docs/pages/collections.adoc
@@ -1,5 +1,5 @@
-= Collections & Scope
-:description: pass:q[Available as a _Developer Preview_ in Couchbase Server 6.5.]
+= Collections & Scopes
+:description: pass:q[Fully supported in Couchbase Server 7.0.]
 :page-topic-type: concept
 :nav-title: Collections
 :page-status: Developer Preview
@@ -8,10 +8,10 @@
 [abstract]
 {description}
 
-The Developer Preview of the upcoming Collections feature in Couchbase Server is fully implemented in the 3.0 API versions of the Couchbase SDKs. 
-Information on the Developer Preview (DP) of _Collections_ can be found in the xref:6.5@server:developer-preview:collections/collections-overview.adoc[server docs].
+The Collections feature in Couchbase Server is fully implemented in the 3.2 API version of the Couchbase SDK.
+Information on _Collections_ can be found in the xref:7.0@server:developer-preview:collections/collections-overview.adoc[server docs].
 
-== Using Collections & Scope DP
+== Using Collections & Scope
 
 Access a non-default collection, in the default scope, with:
 
@@ -20,7 +20,7 @@ Access a non-default collection, in the default scope, with:
 include::example$CollectionsExample.java[tag=collections_1,indent=0]
 ----
 
-And for  a non-default scope:
+And for a non-default scope:
 [source,java]
 ----
 include::example$CollectionsExample.java[tag=collections_2,indent=0]
@@ -29,5 +29,5 @@ include::example$CollectionsExample.java[tag=collections_2,indent=0]
 
 == Further Reading  
 
-* Please see the xref:6.5@server:developer-preview:collections/collections-overview.adoc[Collections Overview documents] in the Server docs.
+* Please see the xref:7.0@server:learn:data:scopes-and-collections.adoc[Collections Overview documents] in the Server docs.
 * To see Collections in action, take a look at our xref:howtos:working-with-collections.adoc[Collections-enabled Travel Sample page].

--- a/modules/concept-docs/pages/collections.adoc
+++ b/modules/concept-docs/pages/collections.adoc
@@ -2,8 +2,6 @@
 :description: pass:q[Fully supported in Couchbase Server 7.0.]
 :page-topic-type: concept
 :nav-title: Collections
-:page-status: Developer Preview
-
 
 [abstract]
 {description}
@@ -11,7 +9,7 @@
 The Collections feature in Couchbase Server is fully implemented in the 3.2 API version of the Couchbase SDK.
 Information on _Collections_ can be found in the xref:7.0@server:developer-preview:collections/collections-overview.adoc[server docs].
 
-== Using Collections & Scope
+== Using Collections & Scopes
 
 Access a non-default collection, in the default scope, with:
 

--- a/modules/concept-docs/pages/compression.adoc
+++ b/modules/concept-docs/pages/compression.adoc
@@ -14,7 +14,7 @@ Documents may already be stored compressed with Snappy on the server.
 New documents may be passed from client applications to the server in compressed form, saving around 40% in bandwidth (depending on the document content and size), and also transmission time.
 These operations take place automatically, after the SDK negotiates the capability with the server, and do not require any changes on the client side.
 
-For SDKs with Snappy compression enabled, documents will be automatically compressed if the xref:6.5@server:learn:buckets-memory-and-storage/compression.adoc#compression-modes[Couchbase Server] is not set to `Off` for Compression see xref:#minimum-size[see below].
+For SDKs with Snappy compression enabled, documents will be automatically compressed if the xref:7.0@server:learn:buckets-memory-and-storage/compression.adoc#compression-modes[Couchbase Server] is not set to `Off` for Compression see xref:#minimum-size[see below].
 Instructions to disable compression can be found at xref:#threshold[the bottom of the page].
 
 == Limits
@@ -24,7 +24,7 @@ Compression is only available in the Enterprise Edition of Couchbase Data Platfo
 
 [TIP]
 ====
-This size limit is enforced by Couchbase Server (6.5 and earlier); in practice it will affect very few users, as most JSON documents are considerably smaller.
+This size limit is enforced by Couchbase Server (7.0 and earlier); in practice it will affect very few users, as most JSON documents are considerably smaller.
 A compressed doument of just under 20MB, which is greater than 20,971,520 bytes (20 MiB) when uncompressed, will be rejected by the server as follows:
 
 * Couchbase Server decompresses the document to check that it is valid JSON, and is correctly compressed with _Snappy_, and at this point measures it against `max data size` (20 MiB).

--- a/modules/concept-docs/pages/concepts.adoc
+++ b/modules/concept-docs/pages/concepts.adoc
@@ -6,5 +6,5 @@
 [abstract]
 {description}
 
-include::6.5@sdk:shared:partial$concepts.adoc[tag=concepts]
+include::7.0@sdk:shared:partial$concepts.adoc[tag=concepts]
 

--- a/modules/concept-docs/pages/data-model.adoc
+++ b/modules/concept-docs/pages/data-model.adoc
@@ -30,9 +30,9 @@ Only the relevant data is exchanged between client and server, allowing for less
 
 
 
-// include::6.5@sdk:shared:partial$data-model.adoc[tag=intro]
+// include::7.0@sdk:shared:partial$data-model.adoc[tag=intro]
 
-// include::6.5@sdk:shared:partial$data-model.adoc[tag=structures]
+// include::7.0@sdk:shared:partial$data-model.adoc[tag=structures]
 
 // == Creating a Data Structure
 

--- a/modules/concept-docs/pages/data-services.adoc
+++ b/modules/concept-docs/pages/data-services.adoc
@@ -1,1 +1,1 @@
-include::6.5@sdk:pages:partial$data-services.adoc[]
+include::7.0@sdk:pages:partial$data-services.adoc[]

--- a/modules/concept-docs/pages/documents.adoc
+++ b/modules/concept-docs/pages/documents.adoc
@@ -30,7 +30,7 @@ Although query and path-based (Sub-Document) services are available, the simplic
 
 
 
-include::6.5@sdk:shared:partial$documents.adoc[tag=document]
+include::7.0@sdk:shared:partial$documents.adoc[tag=document]
 
 == Primitive Key-Value Operations
 
@@ -43,9 +43,9 @@ get(docid)
 remove(docid)
 ----
 
-include::6.5@sdk:shared:partial$documents.adoc[tag=crud-overview]
+include::7.0@sdk:shared:partial$documents.adoc[tag=crud-overview]
 
-include::6.5@sdk:shared:partial$documents.adoc[tag=store-update]
+include::7.0@sdk:shared:partial$documents.adoc[tag=store-update]
 
 [NOTE]
 ====
@@ -56,7 +56,7 @@ If you wish to only modify certain parts of a document, you can use xref:subdocu
 collection.mutate_in("customer123", [SD.upsert("fax", "311-555-0151")])
 ----
 
-or xref:6.0@server:n1ql:n1ql-language-reference/update.adoc[N1QL UPDATE] to update documents based on specific query criteria:
+or xref:7.0@server:n1ql:n1ql-language-reference/update.adoc[N1QL UPDATE] to update documents based on specific query criteria:
 
 [source,sql]
 ----
@@ -64,7 +64,7 @@ update `default` SET sale_price = msrp * 0.75 WHERE msrp < 19.95;
 ----
 ====
 
-include::6.5@sdk:shared:partial$documents.adoc[tag=get_generic]
+include::7.0@sdk:shared:partial$documents.adoc[tag=get_generic]
 
 [source,sql]
 ----
@@ -87,7 +87,7 @@ name, email = cb.retrieve_in('user:kingarthur', 'contact.name', 'contact.email')
 
 // Counters
 
-include::6.5@sdk:shared:partial$documents.adoc[tag=counters1]
+include::7.0@sdk:shared:partial$documents.adoc[tag=counters1]
 
 [source,java]
 ----
@@ -108,7 +108,7 @@ You can simplify by importing `decrementOptions()` statically:
 collection.binary().decrement(counterDocId, decrementOptions().delta(5));   
 ----
 
-include::6.5@sdk:shared:partial$documents.adoc[tag=counters2]
+include::7.0@sdk:shared:partial$documents.adoc[tag=counters2]
 
 [source,python]
 ----
@@ -119,7 +119,7 @@ if should_increment_value(value):
   cb.upsert('counter_id', value + increment_amount, cas=cas)
 ----
 
-include::6.5@sdk:shared:partial$documents.adoc[tag=counters3]
+include::7.0@sdk:shared:partial$documents.adoc[tag=counters3]
 
 
 === Use Cases
@@ -130,22 +130,22 @@ You will find several ways of working with counters https://docs.couchbase.com/s
 
 
 // Expiry
-include::6.5@sdk:shared:partial$documents.adoc[tag=expiration]
+include::7.0@sdk:shared:partial$documents.adoc[tag=expiration]
 
 
 ////
-include::6.5@sdk:shared:partial$documents.adoc[tag=]
+include::7.0@sdk:shared:partial$documents.adoc[tag=]
 
 
-include::6.5@sdk:shared:partial$documents.adoc[tag=]
+include::7.0@sdk:shared:partial$documents.adoc[tag=]
 
-include::6.5@sdk:shared:partial$documents.adoc[tag=]
+include::7.0@sdk:shared:partial$documents.adoc[tag=]
 
-include::6.5@sdk:shared:partial$documents.adoc[tag=]
+include::7.0@sdk:shared:partial$documents.adoc[tag=]
 
-include::6.5@sdk:shared:partial$documents.adoc[tag=]
+include::7.0@sdk:shared:partial$documents.adoc[tag=]
 
-include::6.5@sdk:shared:partial$documents.adoc[tag=]
+include::7.0@sdk:shared:partial$documents.adoc[tag=]
 
-include::6.5@sdk:shared:partial$documents.adoc[tag=]
+include::7.0@sdk:shared:partial$documents.adoc[tag=]
 ////

--- a/modules/concept-docs/pages/durability-replication-failure-considerations.adoc
+++ b/modules/concept-docs/pages/durability-replication-failure-considerations.adoc
@@ -2,7 +2,7 @@
 :description: Data durability refers to the fault tolerance and persistence of data in the face of software or hardware failure.
 :page-topic-type: concept
 // :page-aliases: ROOT:failure-considerations,ROOT:durability,ROOT:enhanced-durability
-// :page-aliases: 6.6@server:sdk:durability.adoc
+// :page-aliases: 7.0@server:sdk:durability.adoc
 
 
 [abstract]
@@ -11,19 +11,19 @@ Even the most reliable software and hardware might fail at some point, and along
 Couchbase’s durability features include Synchronous Replication, and the possibility to use distributed, multi-document ACID transactions.
 It is the responsibility of the development team and the software architect to evaluate the best choice for each use case.
 
-include::6.5@sdk:shared:partial$durability-replication-failure-considerations.adoc[tag=intro]
+include::7.0@sdk:shared:partial$durability-replication-failure-considerations.adoc[tag=intro]
 
-include::6.5@sdk:shared:partial$durability-replication-failure-considerations.adoc[tag=syncrep]
-include::6.5@sdk:shared:partial$durability-replication-failure-considerations.adoc[tag=syncrep2]
-include::6.5@sdk:shared:partial$durability-replication-failure-considerations.adoc[tag=syncrep3]
+include::7.0@sdk:shared:partial$durability-replication-failure-considerations.adoc[tag=syncrep]
+include::7.0@sdk:shared:partial$durability-replication-failure-considerations.adoc[tag=syncrep2]
+include::7.0@sdk:shared:partial$durability-replication-failure-considerations.adoc[tag=syncrep3]
 
-include::6.5@sdk:shared:partial$durability-replication-failure-considerations.adoc[tag=older]
+include::7.0@sdk:shared:partial$durability-replication-failure-considerations.adoc[tag=older]
 
-include::6.5@sdk:shared:partial$durability-replication-failure-considerations.adoc[tag=performance]
+include::7.0@sdk:shared:partial$durability-replication-failure-considerations.adoc[tag=performance]
 
-include::6.5@sdk:shared:partial$durability-replication-failure-considerations.adoc[tag=txns]
+include::7.0@sdk:shared:partial$durability-replication-failure-considerations.adoc[tag=txns]
 
-// include::6.5@sdk:shared:partial$durability-replication-failure-considerations.adoc[tag=failover]
+// include::7.0@sdk:shared:partial$durability-replication-failure-considerations.adoc[tag=failover]
 
 == Further Reading
 

--- a/modules/concept-docs/pages/durability-replication-failure-considerations.adoc
+++ b/modules/concept-docs/pages/durability-replication-failure-considerations.adoc
@@ -1,8 +1,7 @@
 = Durability & Failure
 :description: Data durability refers to the fault tolerance and persistence of data in the face of software or hardware failure.
 :page-topic-type: concept
-// :page-aliases: ROOT:failure-considerations,ROOT:durability,ROOT:enhanced-durability
-// :page-aliases: 7.0@server:sdk:durability.adoc
+:page-aliases: ROOT:failure-considerations,ROOT:durability,ROOT:enhanced-durability,7.0@server:developer-guide:durability.adoc
 
 
 [abstract]

--- a/modules/concept-docs/pages/encryption.adoc
+++ b/modules/concept-docs/pages/encryption.adoc
@@ -1,1 +1,1 @@
-include::6.6@sdk:pages:partial$encryption.adoc[]
+include::7.0@sdk:pages:partial$encryption.adoc[]

--- a/modules/concept-docs/pages/errors.adoc
+++ b/modules/concept-docs/pages/errors.adoc
@@ -10,19 +10,19 @@
 
 == General Approach to Java Exceptions
 
-include::6.5@sdk:shared:partial$errors.adoc[tag=exception]
+include::7.0@sdk:shared:partial$errors.adoc[tag=exception]
 
-include::6.5@sdk:shared:partial$errors.adoc[tag=ref]
+include::7.0@sdk:shared:partial$errors.adoc[tag=ref]
 
-include::6.5@sdk:shared:partial$errors.adoc[tag=durability]
+include::7.0@sdk:shared:partial$errors.adoc[tag=durability]
 
-include::6.5@sdk:shared:partial$errors.adoc[tag=diag]
+include::7.0@sdk:shared:partial$errors.adoc[tag=diag]
 
 // Slow Operations Logging
-include::6.5@sdk:shared:partial$errors.adoc[tag=observability]
+include::7.0@sdk:shared:partial$errors.adoc[tag=observability]
 
 // until opentelemetry release for link below, could add note on API to expose own tracing features?
-// include::6.5@sdk:shared:partial$errors.adoc[tag=rto]
+// include::7.0@sdk:shared:partial$errors.adoc[tag=rto]
 
 == ACID Transactions
 

--- a/modules/concept-docs/pages/full-text-search-overview.adoc
+++ b/modules/concept-docs/pages/full-text-search-overview.adoc
@@ -1,1 +1,1 @@
-include::6.5@sdk:pages:partial$search.adoc[]
+include::7.0@sdk:pages:partial$search.adoc[]

--- a/modules/concept-docs/pages/health-check.adoc
+++ b/modules/concept-docs/pages/health-check.adoc
@@ -8,9 +8,9 @@
 {description}
 
 
-include::6.5@sdk:pages:partial$health-check.adoc[tag="intro"]
+include::7.0@sdk:pages:partial$health-check.adoc[tag="intro"]
 
-include::6.5@sdk:pages:partial$health-check.adoc[tag="uses"]
+include::7.0@sdk:pages:partial$health-check.adoc[tag="uses"]
 
 == Ping
 A call to `ping` actively sends requests to the different services on the target cluster, measuring the latency and returning any errors as part of the report.

--- a/modules/concept-docs/pages/health-check.adoc
+++ b/modules/concept-docs/pages/health-check.adoc
@@ -2,7 +2,6 @@
 :description: Health Check provides ping() and diagnostics() tests for the health of the network and the cluster.
 :nav-title: Health Check
 :page-topic-type: concept
-:page-aliases: ROOT:health-check
 
 [abstract]
 {description}

--- a/modules/concept-docs/pages/n1ql-query.adoc
+++ b/modules/concept-docs/pages/n1ql-query.adoc
@@ -8,11 +8,11 @@
 {description}
 
 
-include::6.5@sdk:shared:partial$n1ql-queries.adoc[tag=intro]
+include::7.0@sdk:shared:partial$n1ql-queries.adoc[tag=intro]
 
 
 // Prepared Statements for Query Optimization
-include::6.5@sdk:shared:partial$n1ql-queries.adoc[tag=prepared]
+include::7.0@sdk:shared:partial$n1ql-queries.adoc[tag=prepared]
 The maximum client-side query cache size is 5000 entries.
 
 [source,java]
@@ -23,10 +23,10 @@ include::example$N1qlQueryExample.java[tag=n1ql_query_1,indent=0]
 
 == Indexes
 
-The Couchbase Query Service makes use of xref:6.5@server:learn:services-and-indexes/indexes/indexes.adoc[_indexes_] in order to do its work.
+The Couchbase Query Service makes use of xref:7.0@server:learn:services-and-indexes/indexes/indexes.adoc[_indexes_] in order to do its work.
 Indexes replicate subsets of documents from data nodes over to index nodes,
 allowing specific data (for example, specific document properties) to be retrieved quickly,
-and to distribute load away from data nodes in xref:6.5@server:learn:services-and-indexes/services/services.adoc[MDS] topologies.
+and to distribute load away from data nodes in xref:7.0@server:learn:services-and-indexes/services/services.adoc[MDS] topologies.
 
 [IMPORTANT]
 In order to make a bucket queryable, it must have at least one index defined.
@@ -59,7 +59,7 @@ Indexes help improve the performance of a query.
 When an index includes the actual values of all the fields specified in the query,
 the index _covers_ the query, and eliminates the need to fetch the actual values from the Data Service.
 An index, in this case, is called a _covering index_, and the query is called a _covered_ query.
-For more information, see xref:6.5@server:n1ql:n1ql-language-reference/covering-indexes.adoc[Covering Indexes].
+For more information, see xref:7.0@server:n1ql:n1ql-language-reference/covering-indexes.adoc[Covering Indexes].
 
 You can also create and define indexes in the SDK using:
 
@@ -96,11 +96,11 @@ include::example$N1qlQueryExample.java[tag=n1ql_query_3,indent=0]
 
 
 // Index Consistency
-include::6.5@sdk:shared:partial$n1ql-queries.adoc[tag=index-consistency]
+include::7.0@sdk:shared:partial$n1ql-queries.adoc[tag=index-consistency]
 
 The following options are available:
 
-include::6.5@server:learn:page$services-and-indexes/indexes/index-replication.adoc[tag=scan_consistency]
+include::7.0@server:learn:page$services-and-indexes/indexes/index-replication.adoc[tag=scan_consistency]
 
 Consider the following snippet:
 

--- a/modules/concept-docs/pages/nonjson.adoc
+++ b/modules/concept-docs/pages/nonjson.adoc
@@ -7,7 +7,7 @@
 [abstract]
 {description}
 
-include::6.6@sdk:shared:partial$nonjson.adoc[tag=intro]
+include::7.0@sdk:shared:partial$nonjson.adoc[tag=intro]
 
-include::6.6@sdk:shared:partial$nonjson.adoc[tag=using]
+include::7.0@sdk:shared:partial$nonjson.adoc[tag=using]
 

--- a/modules/concept-docs/pages/rbac.adoc
+++ b/modules/concept-docs/pages/rbac.adoc
@@ -1,1 +1,1 @@
-include::6.5@sdk:pages:partial$rbac.adoc[]
+include::7.0@sdk:pages:partial$rbac.adoc[]

--- a/modules/concept-docs/pages/response-time-observability.adoc
+++ b/modules/concept-docs/pages/response-time-observability.adoc
@@ -7,7 +7,7 @@
 [abstract]
 {description}
 
-include::6.5@sdk:shared:partial$rto.adoc[tag=placeholder]
+include::7.0@sdk:shared:partial$rto.adoc[tag=placeholder]
 
 
 == Additional Information

--- a/modules/concept-docs/pages/sdk-user-management-overview.adoc
+++ b/modules/concept-docs/pages/sdk-user-management-overview.adoc
@@ -1,1 +1,1 @@
-include::6.5@sdk:pages:partial$user-management.adoc[]
+include::7.0@sdk:pages:partial$user-management.adoc[]

--- a/modules/concept-docs/pages/subdocument-operations.adoc
+++ b/modules/concept-docs/pages/subdocument-operations.adoc
@@ -1,1 +1,1 @@
-include::6.5@sdk:pages:partial$subdoc.adoc[]
+include::7.0@sdk:pages:partial$subdoc.adoc[]

--- a/modules/concept-docs/pages/understanding-views.adoc
+++ b/modules/concept-docs/pages/understanding-views.adoc
@@ -1,1 +1,1 @@
-include::6.5@sdk:pages:partial$views.adoc[]
+include::7.0@sdk:pages:partial$views.adoc[]

--- a/modules/concept-docs/pages/xattr.adoc
+++ b/modules/concept-docs/pages/xattr.adoc
@@ -7,11 +7,11 @@
 [abstract]
 {description}
 
-include::6.5@sdk:shared:partial$sdk-xattr-overview.adoc[tag=intro_extended_attributes]
+include::7.0@sdk:shared:partial$sdk-xattr-overview.adoc[tag=intro_extended_attributes]
 
-include::6.5@sdk:shared:partial$sdk-xattr-overview.adoc[tag=using_extended_attributes]
+include::7.0@sdk:shared:partial$sdk-xattr-overview.adoc[tag=using_extended_attributes]
 
-include::6.5@sdk:shared:partial$sdk-xattr-overview.adoc[tag=virtual_extended_attributes]
+include::7.0@sdk:shared:partial$sdk-xattr-overview.adoc[tag=virtual_extended_attributes]
 
 [source,java]
 ----

--- a/modules/devguide/examples/CloudConnect.java
+++ b/modules/devguide/examples/CloudConnect.java
@@ -25,6 +25,7 @@ import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.ClusterOptions;
 import com.couchbase.client.java.Collection;
+import com.couchbase.client.java.Scope;
 import com.couchbase.client.java.env.ClusterEnvironment;
 import com.couchbase.client.java.json.JsonArray;
 import com.couchbase.client.java.json.JsonObject;
@@ -50,7 +51,8 @@ public class CloudConnect {
         Cluster cluster = Cluster.connect(endpoint, ClusterOptions.clusterOptions(username, password).environment(env));
         Bucket bucket = cluster.bucket(bucketName);
         bucket.waitUntilReady(Duration.parse("PT10S"));
-        Collection collection = bucket.defaultCollection();
+        Scope scope = bucket.scope("travel_agent_00");
+        Collection collection = scope.collection("users");
 
         cluster.queryIndexes().createPrimaryIndex(bucketName,
                 CreatePrimaryQueryIndexOptions.createPrimaryQueryIndexOptions().ignoreIfExists(true));

--- a/modules/hello-world/examples/Overview.java
+++ b/modules/hello-world/examples/Overview.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static com.couchbase.client.java.kv.MutateInOptions.mutateInOptions;
+
+import java.util.Collections;
+
+import com.couchbase.client.core.msg.kv.DurabilityLevel;
+import com.couchbase.client.java.Bucket;
+import com.couchbase.client.java.Cluster;
+import com.couchbase.client.java.Collection;
+import com.couchbase.client.java.Scope;
+import com.couchbase.client.java.kv.GetResult;
+import com.couchbase.client.java.kv.MutateInSpec;
+import com.couchbase.client.java.kv.MutationResult;
+
+public class Overview {
+
+    static String connectionString = "localhost";
+    static String username = "Administrator";
+    static String password = "password";
+    static String bucketName = "travel-sample";
+
+    public static void main(String... args) {
+        Cluster cluster = Cluster.connect(connectionString, username, password);
+        Bucket bucket = cluster.bucket(bucketName);
+        // tag::overview[]
+        Scope scope = bucket.scope("inventory");
+        Collection collection = scope.collection("airport");
+        MutationResult result = collection.mutateIn(
+                "airport_1254",
+                Collections.singletonList(MutateInSpec.upsert("foo", "bar")),
+                mutateInOptions().durability(DurabilityLevel.MAJORITY)
+        );
+        // end::overview[]
+        GetResult getResult = collection.get("airport_1254");
+        String foo = getResult.contentAsObject().getString("foo");
+        System.out.println("RESULT: " + foo); // foo == "bar"
+    }
+
+}

--- a/modules/hello-world/examples/StartUsing.java
+++ b/modules/hello-world/examples/StartUsing.java
@@ -28,23 +28,6 @@ public class StartUsing {
   static String password = "password";
   static String bucketName = "travel-sample";
 
-  public static void local(String... args) {
-    // tag::connect_local[]
-    Cluster cluster = Cluster.connect(connectionString, username, password);
-    Bucket bucket = cluster.bucket(bucketName);
-    Collection collection = bucket.defaultCollection();
-    MutationResult upsertResult = collection.upsert(
-        "my-document",
-        JsonObject.create().put("name", "mike")
-    );
-    GetResult getResult = collection.get("my-document");
-    String name = getResult.contentAsObject().getString("name");
-    System.out.println(name); // name == "mike"
-    QueryResult result = cluster.query("select \"Hello World\" as greeting");
-    System.out.println(result.rowsAsObject());
-    // end::connect_local[]
-  }
-
   public static void main(String... args) {
     // tag::connect[]
     Cluster cluster = Cluster.connect(connectionString, username, password);
@@ -56,28 +39,45 @@ public class StartUsing {
     // end::bucket[]
 
     // tag::collection[]
-    // get a collection reference
-    Collection collection = bucket.defaultCollection();
+    // get a user defined collection reference
+    Scope scope = bucket.scope("tenant_agent_00");
+    Collection collection = scope.collection("users");
     // end::collection[]
 
-    // tag::upsert-get[]
-    // Upsert Document
-    MutationResult upsertResult = collection.upsert(
-        "my-document",
-        JsonObject.create().put("name", "mike")
-    );
+    {
+      // tag::upsert[]
+      MutationResult upsertResult = collection.upsert(
+              "my-document",
+              JsonObject.create().put("name", "mike")
+      );
 
-    // Get Document
-    GetResult getResult = collection.get("my-document");
-    String name = getResult.contentAsObject().getString("name");
-    System.out.println(name); // name == "mike"
-    // end::upsert-get[]
+      GetResult getResult = collection.get("my-document");
+      String name = getResult.contentAsObject().getString("name");
+      System.out.println(name); // name == "mike"
+      QueryResult result = cluster.query("select \"Hello World\" as greeting");
+      System.out.println(result.rowsAsObject());
+      // end::upsert[]
+    }
 
-    // tag::n1ql-query[]
-    QueryResult result = cluster.query("select \"Hello World\" as greeting");
-    System.out.println(result.rowsAsObject());
-    // end::n1ql-query[]
+    {
+      // tag::upsert-get[]
+      // Upsert Document
+      MutationResult upsertResult = collection.upsert(
+              "my-document",
+              JsonObject.create().put("name", "mike")
+      );
 
+      // Get Document
+      GetResult getResult = collection.get("my-document");
+      String name = getResult.contentAsObject().getString("name");
+      System.out.println(name); // name == "mike"
+      // end::upsert-get[]
+
+      // tag::n1ql-query[]
+      QueryResult result = cluster.query("select \"Hello World\" as greeting");
+      System.out.println(result.rowsAsObject());
+      // end::n1ql-query[]
+    }
   }
 
 }

--- a/modules/hello-world/pages/overview.adoc
+++ b/modules/hello-world/pages/overview.adoc
@@ -1,9 +1,8 @@
-= Couchbase Java SDK 3.1
+= Couchbase Java SDK 3.2
 :page-type: landing-page
 :page-layout: landing-page-top-level-sdk
 :page-role: tiles
 :!sectids:
-// :page-aliases: ROOT:dotjavanet-sdk.sdoc
 
 
 ++++
@@ -14,18 +13,14 @@
 [.column]
 ====== {empty}
 [.content]
-The Couchbase Java client allow Java applications to access a Couchbase cluster. 
+The Couchbase Java client allows Java applications to access a Couchbase cluster.
 It offers synchronous APIs as well as reactive and asynchronous equivalents to maximize flexibility and performance.
 
 [.column]
 [.content]
 [source,java]
 ----
-MutationResult result = collection.mutateIn(
-    "airport_1254",
-    Collections.singletonList(MutateInSpec.upsert("foo", "bar")),
-    mutateInOptions().durability(DurabilityLevel.MAJORITY)
-);
+include::hello-world:example$Overview.java[tag=overview,indent=0]
 ----
 
 ++++
@@ -51,7 +46,7 @@ MutationResult result = collection.mutateIn(
 [.content]
 * Dive right in with a xref:start-using-sdk.adoc[quick install and Hello World].
 * Try out our xref:sample-application.adoc[Travel Sample Application].
-* Take a look at the xref:howtos:working-with-collections.adoc[developer preview of Collections].
+* Take a look at the xref:howtos:working-with-collections.adoc[Collections feature].
 ////
 []
 [source,xml]
@@ -93,7 +88,7 @@ https://docs.couchbase.com/sdk-api/couchbase-java-client/[API Docs^]
 .What's Hot?
 
 [.content]
-The Couchbase Java SDK 3.0 is a complete rewrite of the 2.x API, providing a simpler surface area and adding support for future Couchbase Server features like Collections and Scopes (available in Couchbase Server 6.5 and 6.6 as a developer preview). 
+The Couchbase Java SDK 3.x is a complete rewrite of the 2.x API, providing a simpler surface area and adding support for Couchbase Server features like Collections and Scopes (available in Couchbase Server 7.0).
 The (reactive) API also migrated from RxJava to Reactor, along with other improvements to performance, logging, debugging and timeout troubleshooting.
 
 Introducing xref:howtos:distributed-acid-transactions-from-the-sdk.adoc[Distributed ACID Transactions from the Java SDK].
@@ -107,7 +102,7 @@ Those useful nuts-and-bolts guides to
 xref:project-docs:compatibility.adoc[compatibility tables]; 
 xref:project-docs:sdk-release-notes.adoc[release notes]; 
 xref:project-docs:get-involved.adoc[contribution guide]; and the 
-xref:project-docs:migrating-sdk-code-to-3.n.adoc[migration guide] for moving to the 3.0 API.
+xref:project-docs:migrating-sdk-code-to-3.n.adoc[migration guide] for moving to the 3.x API.
 
 [.column]
 ====== {empty}

--- a/modules/hello-world/pages/sample-application.adoc
+++ b/modules/hello-world/pages/sample-application.adoc
@@ -8,12 +8,12 @@
 [abstract]
 {description}
 
-include::6.6@sdk:shared:partial$sample-application.adoc[tag=prereq]
+include::7.0@sdk:shared:partial$sample-application.adoc[tag=prereq]
 
 
 == Preparation
 
-As well as the xref:start-using-sdk.adoc[Java SDK 3.1] and Couchbase Server, 
+As well as the xref:start-using-sdk.adoc[Java SDK 3.2] and Couchbase Server,
 set up as described above, you will need `git` to fetch the travel sample application code:
 
 [source,console]
@@ -25,7 +25,7 @@ Change directory into your cloned repository, and check out the latest branch (t
 
 [source,console]
 ----
-$ git checkout 6.5
+$ git checkout 7.0
 ----
 
 

--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -8,7 +8,7 @@
 The Couchbase Java SDK allows Java applications to access a Couchbase cluster.
 It offers synchronous APIs as well as reactive and asynchronous equivalents to maximize flexibility and performance.
 
-The Couchbase Java SDK 3._x_ is a complete rewrite of the 2.x API, providing a simpler surface area and adding support for future Couchbase Server features like Collections and Scopes (available in Couchbase Server 6.5 as a xref:concept-docs:collections.adoc[developer preview]).
+The Couchbase Java SDK 3._x_ is a complete rewrite of the 2.x API, providing a simpler surface area and adding support for Couchbase Server features like xref:concept-docs:collections.adoc[Collections and Scopes] (available in Couchbase Server 7.0).
 The (reactive) API also migrated from `RxJava` to `Reactor`, along with other improvements to performance, logging, debugging and timeout troubleshooting.
 If you're upgrading your application from Java SDK 2.x, please read our xref:project-docs:migrating-sdk-code-to-3.n.adoc[Migrating 2.x code to SDK 3.0 Guide].
 
@@ -22,7 +22,7 @@ Couchbase publishes all stable artifacts to https://search.maven.org/search?q=co
 The latest version (as of June 2021) is https://search.maven.org/artifact/com.couchbase.client/java-client/3.1.6/jar[3.1.6].
 
 You can use your favorite dependency management tool to install the SDK.
-The following snippet shows how to do it with https://maven.apache.org/[maven].
+The following snippet shows how to do it with https://maven.apache.org/[Maven].
 
 [source,xml]
 ----
@@ -35,7 +35,7 @@ The following snippet shows how to do it with https://maven.apache.org/[maven].
 </dependencies>
 ----
 
-For https://gradle.org/[gradle], you can use:
+For https://gradle.org/[Gradle], you can use:
 
 [source,groovy]
 ----
@@ -53,14 +53,14 @@ Once you have the Java client installed, open your IDE, and try out the followin
 include::example$StartUsing.java[tag=connect,indent=0]
 ----
 
-Couchbase uses xref:6.5@server:learn:security/roles.adoc[Role Based Access Control (RBAC)] to control access to resources.
+Couchbase uses xref:7.0@server:learn:security/roles.adoc[Role Based Access Control (RBAC)] to control access to resources.
 Here we will use the _Full Admin_ role created during installation of the Couchbase Data Platform.
 For production client code, you will want to use more appropriate, restrictive settings -- but here we want to get you up and running quickly.
 If you're developing client code on the same VM or machine as the Couchbase Server, your connection string can be just `localhost`.
 
 The `Cluster` provides access to cluster-level operations like N1Ql queries, analytics or full-text search. You will also find different management APIs on it.
 
-If you are not using an IDE or are new to java, the following imports are necessary to build the following snippets:
+If you are not using an IDE or are new to Java, the following imports are necessary to build the following snippets:
 
 [source,java]
 ----
@@ -74,11 +74,11 @@ To access the KV (Key/Value) API or to query views, you need to open a `Bucket`:
 include::example$StartUsing.java[tag=bucket,indent=0]
 ----
 
-If you installed the travel-sample` data bucket, substitute _travel-sample_ for _bucket-name_.
+If you installed the `travel-sample` data bucket, substitute _travel-sample_ for _bucket-name_.
 
-The 3.0 SDK is ready for the introduction of xref:concept-docs:collections.adoc[Collections] in an upcoming release of the Couchbase Data Platform.
-The latest release, Couchbase Server 6.5, brings a limited _Developer Preview_ of Collections, allowing Documents to be grouped by purpose or theme, according to specified _Scope_.
-Here we will use the `defaultCollection`, which covers the whole Bucket and _must be used when connecting to a 6.5 cluster or earlier_.
+The 3.2 SDK supports full integration with the xref:concept-docs:collections.adoc[Collections] feature in the latest release of the Couchbase Data Platform, Couchbase Server 7.0.
+This brings complete support of Collections, allowing Documents to be grouped by purpose or theme, according to a specified _Scope_.
+Here we will use the `users` collection within the `tenant_agent_00` scope from `travel-sample` bucket as an example.
 
 [source,java]
 ----
@@ -114,7 +114,10 @@ Local Couchbase Server::
 -- 
 [source,java]
 ----
-include::example$StartUsing.java[tag=connect_local,indent=0]
+include::example$StartUsing.java[tag=connect,indent=0]
+include::example$StartUsing.java[tag=bucket,indent=0]
+include::example$StartUsing.java[tag=collection,indent=0]
+include::example$StartUsing.java[tag=upsert,indent=0]
 ----
 --
 

--- a/modules/hello-world/pages/webui-cli-access.adoc
+++ b/modules/hello-world/pages/webui-cli-access.adoc
@@ -1,1 +1,1 @@
-include::6.5@sdk:pages:partial$webui-cli-access.adoc[]
+include::7.0@sdk:pages:partial$webui-cli-access.adoc[]

--- a/modules/howtos/examples/Analytics.java
+++ b/modules/howtos/examples/Analytics.java
@@ -86,7 +86,7 @@ public class Analytics {
     {
       // tag::named[]
       AnalyticsResult result = cluster.analyticsQuery(
-        "select count(*) from airports where country = $country",
+        "select count(*) from `travel-sample`.inventory.airport where country = $country",
         analyticsOptions().parameters(JsonObject.create().put("country", "France")));
       // end::named[]
       show("named", result);
@@ -95,7 +95,7 @@ public class Analytics {
     {
       // tag::positional[]
       AnalyticsResult result = cluster.analyticsQuery(
-        "select count(*) from airports where country = ?",
+        "select count(*) from `travel-sample`.inventory.airport where country = ?",
         analyticsOptions().parameters(JsonArray.from("France"))
       );
       // end::positional[]
@@ -105,7 +105,7 @@ public class Analytics {
     {
       // tag::scanconsistency[]
       AnalyticsResult result = cluster.analyticsQuery(
-        "select count(*) from airports where country = 'France'",
+        "select count(*) from `travel-sample`.inventory.airport where country = 'France'",
         analyticsOptions().scanConsistency(AnalyticsScanConsistency.REQUEST_PLUS)
       );
       // end::scanconsistency[]
@@ -115,7 +115,7 @@ public class Analytics {
     {
       // tag::clientcontextid[]
       AnalyticsResult result = cluster.analyticsQuery(
-        "select count(*) from airports where country = 'France'",
+        "select count(*) from `travel-sample`.inventory.airport where country = 'France'",
         analyticsOptions().clientContextId("user-44" + UUID.randomUUID())
       );
       // end::clientcontextid[]
@@ -125,7 +125,7 @@ public class Analytics {
     {
       // tag::priority[]
       AnalyticsResult result = cluster.analyticsQuery(
-        "select count(*) from airports where country = 'France'",
+        "select count(*) from `travel-sample`.inventory.airport where country = 'France'",
         analyticsOptions().priority(true)
       );
       // end::priority[]
@@ -135,7 +135,7 @@ public class Analytics {
     {
       // tag::readonly[]
       AnalyticsResult result = cluster.analyticsQuery(
-        "select count(*) from airports where country = 'France'",
+        "select count(*) from `travel-sample`.inventory.airport where country = 'France'",
         analyticsOptions().readonly(true)
       );
       // end::readonly[]
@@ -154,7 +154,7 @@ public class Analytics {
     {
       // tag::rowsasobject[]
       AnalyticsResult result = cluster.analyticsQuery(
-        "select * from airports limit 3"
+        "select * from `travel-sample`.inventory.airport limit 3"
       );
       for (JsonObject row : result.rowsAsObject()) {
         System.out.println("Found row: " + row);

--- a/modules/howtos/examples/Analytics.java
+++ b/modules/howtos/examples/Analytics.java
@@ -86,7 +86,7 @@ public class Analytics {
     {
       // tag::named[]
       AnalyticsResult result = cluster.analyticsQuery(
-        "select count(*) from `travel-sample`.inventory.airport where country = $country",
+        "select count(*) from airports where country = $country",
         analyticsOptions().parameters(JsonObject.create().put("country", "France")));
       // end::named[]
       show("named", result);
@@ -95,7 +95,7 @@ public class Analytics {
     {
       // tag::positional[]
       AnalyticsResult result = cluster.analyticsQuery(
-        "select count(*) from `travel-sample`.inventory.airport where country = ?",
+        "select count(*) from airports where country = ?",
         analyticsOptions().parameters(JsonArray.from("France"))
       );
       // end::positional[]
@@ -105,7 +105,7 @@ public class Analytics {
     {
       // tag::scanconsistency[]
       AnalyticsResult result = cluster.analyticsQuery(
-        "select count(*) from `travel-sample`.inventory.airport where country = 'France'",
+        "select count(*) from airports where country = 'France'",
         analyticsOptions().scanConsistency(AnalyticsScanConsistency.REQUEST_PLUS)
       );
       // end::scanconsistency[]
@@ -115,7 +115,7 @@ public class Analytics {
     {
       // tag::clientcontextid[]
       AnalyticsResult result = cluster.analyticsQuery(
-        "select count(*) from `travel-sample`.inventory.airport where country = 'France'",
+        "select count(*) from airports where country = 'France'",
         analyticsOptions().clientContextId("user-44" + UUID.randomUUID())
       );
       // end::clientcontextid[]
@@ -125,7 +125,7 @@ public class Analytics {
     {
       // tag::priority[]
       AnalyticsResult result = cluster.analyticsQuery(
-        "select count(*) from `travel-sample`.inventory.airport where country = 'France'",
+        "select count(*) from airports where country = 'France'",
         analyticsOptions().priority(true)
       );
       // end::priority[]
@@ -135,7 +135,7 @@ public class Analytics {
     {
       // tag::readonly[]
       AnalyticsResult result = cluster.analyticsQuery(
-        "select count(*) from `travel-sample`.inventory.airport where country = 'France'",
+        "select count(*) from airports where country = 'France'",
         analyticsOptions().readonly(true)
       );
       // end::readonly[]
@@ -154,7 +154,7 @@ public class Analytics {
     {
       // tag::rowsasobject[]
       AnalyticsResult result = cluster.analyticsQuery(
-        "select * from `travel-sample`.inventory.airport limit 3"
+        "select * from airports limit 3"
       );
       for (JsonObject row : result.rowsAsObject()) {
         System.out.println("Found row: " + row);

--- a/modules/howtos/examples/AsyncOperations.java
+++ b/modules/howtos/examples/AsyncOperations.java
@@ -30,9 +30,11 @@ import com.couchbase.client.java.AsyncCollection;
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.Collection;
+import com.couchbase.client.java.Scope;
 import com.couchbase.client.java.ReactiveBucket;
 import com.couchbase.client.java.ReactiveCluster;
 import com.couchbase.client.java.ReactiveCollection;
+import com.couchbase.client.java.ReactiveScope;
 import com.couchbase.client.java.json.JsonObject;
 import com.couchbase.client.java.kv.GetResult;
 
@@ -52,7 +54,10 @@ public class AsyncOperations {
     Bucket bucket = cluster.bucket("travel-sample");
     ReactiveBucket reactiveBucket = bucket.reactive();
 
-    Collection collection = bucket.defaultCollection();
+    Scope scope = bucket.scope("inventory");
+    ReactiveScope reactiveScope = scope.reactive();
+
+    Collection collection = scope.collection("airline");
     ReactiveCollection reactiveCollection = collection.reactive();
     // end::access[]
 
@@ -71,7 +76,7 @@ public class AsyncOperations {
     // end::non-used-upsert[]
 
     // tag::verbose-query[]
-    reactiveCluster.query("select * from `travel-sample`").flux().flatMap(result -> {
+    reactiveCluster.query("select * from `travel-sample`.inventory.airline").flux().flatMap(result -> {
       Flux<JsonObject> rows = result.rowsAs(JsonObject.class);
       return rows;
     }).subscribe(row -> {

--- a/modules/howtos/examples/Cas.java
+++ b/modules/howtos/examples/Cas.java
@@ -22,6 +22,7 @@ import com.couchbase.client.core.error.CasMismatchException;
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.Collection;
+import com.couchbase.client.java.Scope;
 import com.couchbase.client.java.json.JsonObject;
 import com.couchbase.client.java.kv.GetResult;
 
@@ -32,7 +33,8 @@ public class Cas {
     Cluster cluster = Cluster.connect("localhost", "Administrator", "password");
 
     Bucket bucket = cluster.bucket("travel-sample");
-    Collection collection = bucket.defaultCollection();
+    Scope scope = bucket.scope("inventory");
+    Collection collection = scope.collection("airline");
 
     {
       // tag::handlingerrors[]

--- a/modules/howtos/examples/CollectingInformationAndLogging.java
+++ b/modules/howtos/examples/CollectingInformationAndLogging.java
@@ -47,8 +47,8 @@ public class CollectingInformationAndLogging {
     ClusterEnvironment environment = ClusterEnvironment.builder().build();
     cluster = Cluster.connect(connectionString,      ClusterOptions.clusterOptions(username, password).environment(environment));
     bucket = cluster.bucket(bucketName);
-    scope = bucket.defaultScope();
-    collection = bucket.defaultCollection();
+    scope = bucket.scope("inventory");
+    collection = scope.collection("airport");
     // end::connection_1[]
   }
   public void collecting_information_and_logging_1() throws Exception { // file: howtos/pages/collecting-information-and-logging.adoc line: 114

--- a/modules/howtos/examples/EncryptingUsingSDK.java
+++ b/modules/howtos/examples/EncryptingUsingSDK.java
@@ -58,8 +58,9 @@ public class EncryptingUsingSDK {
     cluster = Cluster.connect(connectionString,
         ClusterOptions.clusterOptions(username, password).environment(environment));
     bucket = cluster.bucket("travel-sample");
-    scope = bucket.defaultScope();
-    collection = bucket.defaultCollection(); // end::connection_1[]
+    scope = bucket.scope("tenant_agent_00");
+    collection = scope.collection("users");
+    // end::connection_1[]
   }
 
   public void encrypting_using_sdk_1() throws Exception { // file: howtos/pages/encrypting-using-sdk.adoc line: 60
@@ -100,10 +101,9 @@ public class EncryptingUsingSDK {
   }
 
   // end::encrypting_using_sdk_2[]
+
   public void encrypting_using_sdk_3() throws Exception { // file: howtos/pages/encrypting-using-sdk.adoc line: 116
     // tag::encrypting_using_sdk_3[]
-    Collection collection = cluster.bucket("myBucket").defaultCollection();
-
     Employee employee = new Employee();
     employee.setReplicant(true);
     collection.upsert("employee:1234", employee); // encrypts the "replicant" field
@@ -176,8 +176,6 @@ public class EncryptingUsingSDK {
 
   public void encrypting_using_sdk_7() throws Exception { // file: howtos/pages/encrypting-using-sdk.adoc line: 204
     // tag::encrypting_using_sdk_7[]
-    Collection collection = cluster.bucket("myBucket").defaultCollection();
-
     JsonObject document = JsonObject.create();
     JsonObjectCrypto crypto = document.crypto(collection);
 

--- a/modules/howtos/examples/ErrorHandling.java
+++ b/modules/howtos/examples/ErrorHandling.java
@@ -16,6 +16,7 @@ import com.couchbase.client.core.retry.RetryStrategy;
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.Collection;
+import com.couchbase.client.java.Scope;
 import com.couchbase.client.java.analytics.AnalyticsResult;
 import com.couchbase.client.java.env.ClusterEnvironment;
 import com.couchbase.client.java.json.JsonObject;
@@ -33,12 +34,13 @@ public class ErrorHandling {
   public static void main(String... args) {
     Cluster cluster = Cluster.connect("127.0.0.1", "Administrator", "password");
     Bucket bucket = cluster.bucket("travel-sample");
-    Collection collection = bucket.collection("travel-sample");
+    Scope scope = bucket.scope("inventory");
+    Collection collection = bucket.collection("airport");
 
     // tag::readonly[]
-    QueryResult queryResult = cluster.query("SELECT * FROM bucket", queryOptions().readonly(true));
+    QueryResult queryResult = cluster.query("SELECT * FROM `travel-sample`", queryOptions().readonly(true));
 
-    AnalyticsResult analyticsResult = cluster.analyticsQuery("SELECT * FROM dataset",
+    AnalyticsResult analyticsResult = cluster.analyticsQuery("SELECT * FROM `travel-sample`.inventory.airport",
         analyticsOptions().readonly(true));
     // end::readonly[]
 

--- a/modules/howtos/examples/HealthCheck.java
+++ b/modules/howtos/examples/HealthCheck.java
@@ -35,60 +35,53 @@ public class HealthCheck {
   public static void main(String... args) {
     Cluster cluster = Cluster.connect("127.0.0.1", "Administrator", "password");
 
-    Bucket bucket = cluster.bucket("bucket-name");
-    Scope scope = bucket.scope("scope-name");
-    Collection collection = scope.collection("collection-name");
+    Bucket bucket = cluster.bucket("travel-sample");
+    Scope scope = bucket.scope("inventory");
+    Collection collection = scope.collection("hotel");
 
     {
-// tag::ping-basic[]
-PingResult pingResult = cluster.ping();
-
-for (Map.Entry<ServiceType, List<EndpointPingReport>> service : pingResult.endpoints().entrySet()) {
-  for (EndpointPingReport er : service.getValue()) {
-    System.err.println(
-      service.getKey() + ": " + er.remote() + " took " + er.latency()
-    );
-  }
-}
-// end::ping-basic[]
+        // tag::ping-basic[]
+        PingResult pingResult = cluster.ping();
+        for (Map.Entry<ServiceType, List<EndpointPingReport>> service : pingResult.endpoints().entrySet()) {
+            for (EndpointPingReport er : service.getValue()) {
+                System.err.println(service.getKey() + ": " + er.remote() + " took " + er.latency());
+            }
+        }
+        // end::ping-basic[]
     }
 
     {
-// tag::ping-json-export[]
-PingResult pingResult = cluster.ping();
-
-System.out.println(pingResult.exportToJson());
-// end::ping-json-export[]
+        // tag::ping-json-export[]
+        PingResult pingResult = cluster.ping();
+        System.out.println(pingResult.exportToJson());
+        // end::ping-json-export[]
     }
 
     {
-// tag::ping-options[]
-PingResult pingResult = cluster.ping(pingOptions().serviceTypes(EnumSet.of(ServiceType.QUERY)));
-
-System.out.println(pingResult.exportToJson());
-// end::ping-options[]
+        // tag::ping-options[]
+        PingResult pingResult = cluster.ping(pingOptions().serviceTypes(EnumSet.of(ServiceType.QUERY)));
+        System.out.println(pingResult.exportToJson());
+        // end::ping-options[]
     }
 
     {
-// tag::diagnostics-basic[]
-DiagnosticsResult diagnosticsResult = cluster.diagnostics();
-
-for (Map.Entry<ServiceType, List<EndpointDiagnostics>> service : diagnosticsResult.endpoints().entrySet()) {
-  for (EndpointDiagnostics ed : service.getValue()) {
-    System.err.println(
-      service.getKey() + ": " + ed.remote() + " last activity  " + ed.lastActivity()
-    );
-  }
-}
-// end::diagnostics-basic[]
+        // tag::diagnostics-basic[]
+        DiagnosticsResult diagnosticsResult = cluster.diagnostics();
+        for (Map.Entry<ServiceType, List<EndpointDiagnostics>> service : diagnosticsResult.endpoints().entrySet()) {
+            for (EndpointDiagnostics ed : service.getValue()) {
+                System.err.println(
+                        service.getKey() + ": " + ed.remote() + " last activity  " + ed.lastActivity()
+                );
+            }
+        }
+        // end::diagnostics-basic[]
     }
 
     {
-// tag::diagnostics-options[]
-DiagnosticsResult diagnosticsResult = cluster.diagnostics();
-
-System.out.println(diagnosticsResult.exportToJson());
-// end::diagnostics-options[]
+        // tag::diagnostics-options[]
+        DiagnosticsResult diagnosticsResult = cluster.diagnostics();
+        System.out.println(diagnosticsResult.exportToJson());
+        // end::diagnostics-options[]
     }
   }
 

--- a/modules/howtos/examples/KvOperations.java
+++ b/modules/howtos/examples/KvOperations.java
@@ -51,10 +51,8 @@ public class KvOperations {
     Cluster cluster = Cluster.connect("localhost", "Administrator", "password");
 
     Bucket bucket = cluster.bucket("travel-sample");
-    // tag::named-scope-and-collection[]
-    Scope scope = bucket.scope("tenant_agent_00");
-    Collection collection = scope.collection("users");
-    // end::named-scope-and-collection[]
+    Scope scope = bucket.scope("_default");
+    Collection collection = scope.collection("_default");
 
     JsonObject json = JsonObject.create().put("title", "My Blog Post").put("author", "mike");
 
@@ -229,9 +227,12 @@ public class KvOperations {
     {
       System.out.println("\nExample: [named-collection-upsert]");
       // tag::named-collection-upsert[]
+      Scope agentScope = bucket.scope("tenant_agent_00");
+      Collection usersCollection = agentScope.collection("users");
+
       JsonObject content = JsonObject.create().put("name", "John Doe").put("preferred_email",
           "johndoe111@test123.test");
-      MutationResult result = collection.upsert("user-key", content);
+      MutationResult result = usersCollection.upsert("user-key", content);
       // end::named-collection-upsert[]
 
       System.out.println("cas value: " + result.cas());

--- a/modules/howtos/examples/KvOperations.java
+++ b/modules/howtos/examples/KvOperations.java
@@ -51,8 +51,10 @@ public class KvOperations {
     Cluster cluster = Cluster.connect("localhost", "Administrator", "password");
 
     Bucket bucket = cluster.bucket("travel-sample");
-    Scope scope = bucket.scope("_default");
-    Collection collection = scope.collection("_default");
+    // tag::named-scope-and-collection[]
+    Scope scope = bucket.scope("tenant_agent_00");
+    Collection collection = scope.collection("users");
+    // end::named-scope-and-collection[]
 
     JsonObject json = JsonObject.create().put("title", "My Blog Post").put("author", "mike");
 
@@ -227,12 +229,9 @@ public class KvOperations {
     {
       System.out.println("\nExample: [named-collection-upsert]");
       // tag::named-collection-upsert[]
-      Scope agentScope = bucket.scope("tenant_agent_00");
-      Collection usersCollection = agentScope.collection("users");
-
       JsonObject content = JsonObject.create().put("name", "John Doe").put("preferred_email",
           "johndoe111@test123.test");
-      MutationResult result = usersCollection.upsert("user-key", content);
+      MutationResult result = collection.upsert("user-key", content);
       // end::named-collection-upsert[]
 
       System.out.println("cas value: " + result.cas());

--- a/modules/howtos/examples/Queries.java
+++ b/modules/howtos/examples/Queries.java
@@ -98,17 +98,18 @@ public class Queries {
 
     // NOTE: This currently fails with Couchbase Internal Server error.
     // Server issue tracked here: https://issues.couchbase.com/browse/MB-46876
-    {
-      System.out.println("\nExample: [scanconsistency_with]");
-      // tag::scanconsistency_with[]
-      Collection collection = scope.collection("airport");
-      MutationResult mr = collection.upsert("someDoc", JsonObject.create().put("name", "roi"));
-      MutationState mutationState = MutationState.from(mr.mutationToken().get());
-
-      QueryOptions qo = QueryOptions.queryOptions().consistentWith(mutationState);
-      QueryResult result = cluster.query("select raw meta().id from `travel-sample`.inventory.airport limit 100", qo);
-      // end::scanconsistency_with[]
-    }
+    // Add back in once Couchbase Server 7.0.1 is available, which will fix this issue.
+//    {
+//      System.out.println("\nExample: [scanconsistency_with]");
+//      // tag::scanconsistency_with[]
+//      Collection collection = scope.collection("airport");
+//      MutationResult mr = collection.upsert("someDoc", JsonObject.create().put("name", "roi"));
+//      MutationState mutationState = MutationState.from(mr.mutationToken().get());
+//
+//      QueryOptions qo = QueryOptions.queryOptions().consistentWith(mutationState);
+//      QueryResult result = cluster.query("select raw meta().id from `travel-sample`.inventory.airport limit 100", qo);
+//      // end::scanconsistency_with[]
+//    }
 
     {
       System.out.println("\nExample: [clientcontextid]");

--- a/modules/howtos/examples/Queries.java
+++ b/modules/howtos/examples/Queries.java
@@ -44,14 +44,18 @@ import reactor.core.publisher.Mono;
 
 public class Queries {
 
-  static Cluster cluster = Cluster.connect("localhost", "Administrator", "password");
-
   public static void main(String[] args) throws Exception {
+    Cluster cluster = Cluster.connect("localhost", "Administrator", "password");
+    // tag::connect-bucket-and-scope[]
+    Bucket bucket = cluster.bucket("travel-sample");
+    Scope scope = bucket.scope("inventory");
+    // end::connect-bucket-and-scope[]
+
     {
       System.out.println("Example: [simple]");
       // tag::simple[]
       try {
-        final QueryResult result = cluster.query("select * from `travel-sample` limit 10",
+        final QueryResult result = cluster.query("select * from `travel-sample`.inventory.airline limit 100",
             queryOptions().metrics(true));
 
         for (JsonObject row : result.rowsAsObject()) {
@@ -69,7 +73,7 @@ public class Queries {
       System.out.println("\nExample: [named]");
       // tag::named[]
       QueryResult result = cluster.query(
-          "select count(*) from `travel-sample` where type = \"airport\" and country = $country",
+          "select count(*) from `travel-sample`.inventory.airline where country = $country",
           queryOptions().parameters(JsonObject.create().put("country", "France")));
       // end::named[]
     }
@@ -78,7 +82,7 @@ public class Queries {
       System.out.println("\nExample: [positional]");
       // tag::positional[]
       QueryResult result = cluster.query(
-          "select count(*) from `travel-sample` where type = \"airport\" and country = ?",
+          "select count(*) from `travel-sample`.inventory.airline where country = ?",
           queryOptions().parameters(JsonArray.from("France")));
       // end::positional[]
     }
@@ -87,21 +91,22 @@ public class Queries {
       System.out.println("\nExample: [scanconsistency]");
       // tag::scanconsistency[]
       QueryResult result = cluster.query(
-          "select count(*) from `travel-sample` where type = \"airport\" and country = 'France'",
+          "select count(*) from `travel-sample`.inventory.airline where country = 'France'",
           queryOptions().scanConsistency(QueryScanConsistency.REQUEST_PLUS));
       // end::scanconsistency[]
     }
 
+    // NOTE: This currently fails with Couchbase Internal Server error.
+    // Server issue tracked here: https://issues.couchbase.com/browse/MB-46876
     {
       System.out.println("\nExample: [scanconsistency_with]");
       // tag::scanconsistency_with[]
-      Bucket bucket = cluster.bucket("travel-sample");
-      Collection collection = bucket.defaultCollection();
+      Collection collection = scope.collection("airport");
       MutationResult mr = collection.upsert("someDoc", JsonObject.create().put("name", "roi"));
       MutationState mutationState = MutationState.from(mr.mutationToken().get());
 
       QueryOptions qo = QueryOptions.queryOptions().consistentWith(mutationState);
-      QueryResult result = cluster.query("select raw meta().id from `travel-sample` limit 100;", qo);
+      QueryResult result = cluster.query("select raw meta().id from `travel-sample`.inventory.airport limit 100", qo);
       // end::scanconsistency_with[]
     }
 
@@ -109,7 +114,7 @@ public class Queries {
       System.out.println("\nExample: [clientcontextid]");
       // tag::clientcontextid[]
       QueryResult result = cluster.query(
-          "select count(*) from `travel-sample` where type = \"airport\" and country = 'France'",
+          "select count(*) from `travel-sample`.inventory.airline where country = 'France'",
           queryOptions().clientContextId("user-44" + UUID.randomUUID()));
       // end::clientcontextid[]
     }
@@ -118,7 +123,7 @@ public class Queries {
       System.out.println("\nExample: [readonly]");
       // tag::readonly[]
       QueryResult result = cluster.query(
-          "select count(*) from `travel-sample` where type = \"airport\" and country = 'France'",
+          "select count(*) from `travel-sample`.inventory.airline where country = 'France'",
           queryOptions().readonly(true));
       // end::readonly[]
     }
@@ -134,7 +139,7 @@ public class Queries {
     {
       System.out.println("\nExample: [rowsasobject]");
       // tag::rowsasobject[]
-      QueryResult result = cluster.query("select * from `travel-sample` limit 10");
+      QueryResult result = cluster.query("select * from `travel-sample`.inventory.airline limit 10");
       for (JsonObject row : result.rowsAsObject()) {
         System.out.println("Found row: " + row);
       }
@@ -153,7 +158,7 @@ public class Queries {
     {
       System.out.println("\nExample: [backpressure]");
       // tag::backpressure[]
-      Mono<ReactiveQueryResult> result = cluster.reactive().query("select * from `travel-sample`");
+      Mono<ReactiveQueryResult> result = cluster.reactive().query("select * from `travel-sample`.inventory.route");
 
       result.flatMapMany(ReactiveQueryResult::rowsAsObject).subscribe(new BaseSubscriber<JsonObject>() {
         // Number of outstanding requests
@@ -179,9 +184,6 @@ public class Queries {
     {
       System.out.println("\nExample: [scope-level-query]");
       // tag::scope-level-query[]
-      Bucket bucket = cluster.bucket("travel-sample");
-      Scope scope = bucket.scope("inventory");
-
       QueryResult result = scope.query("select * from `airline` where country = $country LIMIT 10",
           queryOptions().parameters(JsonObject.create().put("country", "France")));
 

--- a/modules/howtos/examples/Search.java
+++ b/modules/howtos/examples/Search.java
@@ -24,6 +24,7 @@ import com.couchbase.client.core.error.CouchbaseException;
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.Collection;
+import com.couchbase.client.java.Scope;
 import com.couchbase.client.java.json.JsonObject;
 import com.couchbase.client.java.kv.MutationResult;
 import com.couchbase.client.java.kv.MutationState;
@@ -48,7 +49,8 @@ public class Search {
 
   static Cluster cluster = Cluster.connect("localhost", "Administrator", "password");
   static Bucket bucket = cluster.bucket("travel-sample");
-  static Collection collection = bucket.defaultCollection();
+  static Scope scope = bucket.scope("inventory");
+  static Collection collection = scope.collection("hotel");
 
   public static void main(String... args) {
 
@@ -92,7 +94,7 @@ public class Search {
 
     {
       // tag::ryow[]
-      MutationResult mutationResult = collection.upsert("key", JsonObject.create());
+      MutationResult mutationResult = collection.upsert("key", JsonObject.create().put("description", "swanky"));
       MutationState mutationState = MutationState.from(mutationResult.mutationToken().get());
 
       SearchResult searchResult = cluster.searchQuery("travel-sample-index", SearchQuery.queryString("swanky"),
@@ -129,6 +131,13 @@ public class Search {
       SearchResult result = cluster.searchQuery("travel-sample-index", SearchQuery.queryString("swanky"),
           searchOptions().fields("description", "type"));
       // end::fields[]
+    }
+
+    {
+      // tag::collections[]
+      SearchResult result = cluster.searchQuery("travel-sample-index", SearchQuery.queryString("San Francisco"),
+          searchOptions().collections("landmark", "airport"));
+      // end::collections[]
     }
 
     {

--- a/modules/howtos/examples/SubDocument.java
+++ b/modules/howtos/examples/SubDocument.java
@@ -64,8 +64,8 @@ public class SubDocument {
     Cluster cluster = Cluster.connect("127.0.0.1", "Administrator", "password");
 
     Bucket bucket = cluster.bucket("travel-sample");
-    Scope scope = bucket.defaultScope();
-    collection = scope.collection("_default");
+    Scope scope = bucket.scope("inventory");
+    collection = scope.collection("hotel");
     bucket.waitUntilReady(Duration.ofSeconds(10));
     getFunc();
     existsFunc();
@@ -76,9 +76,9 @@ public class SubDocument {
     insertFunc();
     multiFunc();
     arrayAppendObjFunc();
-    // arrayAppendFunc();
+    arrayAppendFunc();
     arrayPrependObjFunc();
-    // arrayPrependFunc();
+    arrayPrependFunc();
     full_doc_replaceFunc();
     createAndPopulateArrays();
     arrayCreate();
@@ -96,10 +96,10 @@ public class SubDocument {
 
   static void getFunc() {
     // tag::get[]
-    LookupInResult result = collection.lookupIn("airport_1254", Collections.singletonList(get("geo.alt")));
+    LookupInResult result = collection.lookupIn("hotel_1368", Collections.singletonList(get("geo.lat")));
 
     String str = result.contentAs(0, String.class);
-    System.out.println("getFunc: Altitude = " + str);
+    System.out.println("getFunc: Latitude = " + str);
     // end::get[]
   }
 
@@ -107,8 +107,8 @@ public class SubDocument {
 
     // tag::exists[]
     try {
-      LookupInResult result = collection.lookupIn("airport_1254",
-          Collections.singletonList(exists("addresses.delivery.does_not_exist")));
+      LookupInResult result = collection.lookupIn("hotel_1368",
+          Collections.singletonList(exists("address.does_not_exist")));
     } catch (PathNotFoundException e) {
       System.out.println("existsFunc: " + e);
     }
@@ -118,8 +118,8 @@ public class SubDocument {
   static void combine() {
     // tag::combine[]
     try {
-      LookupInResult result = collection.lookupIn("airport_1254",
-          Arrays.asList(get("geo.alt"), exists("addresses.delivery.does_not_exist")));
+      LookupInResult result = collection.lookupIn("hotel_1368",
+          Arrays.asList(get("geo.lat"), exists("address.does_not_exist")));
     } catch (PathNotFoundException e) {
       System.out.println("combine: " + e);
     }
@@ -128,12 +128,12 @@ public class SubDocument {
 
   static void future() {
     // tag::get-future[]
-    CompletableFuture<LookupInResult> future = collection.async().lookupIn("airport_1254",
-        Collections.singletonList(get("geo.alt")));
+    CompletableFuture<LookupInResult> future = collection.async().lookupIn("hotel_1368",
+        Collections.singletonList(get("geo.lat")));
 
     try {
       LookupInResult result = future.get();
-      System.out.println("future: Altitude: " + result.contentAs(0, Number.class));
+      System.out.println("future: Latitude: " + result.contentAs(0, Number.class));
     } catch (InterruptedException | ExecutionException e) {
       e.printStackTrace();
     }
@@ -143,26 +143,26 @@ public class SubDocument {
 
   static void reactive() {
     // tag::get-reactive[]
-    Mono<LookupInResult> mono = collection.reactive().lookupIn("airport_1254",
-        Collections.singletonList(get("geo.alt")));
+    Mono<LookupInResult> mono = collection.reactive().lookupIn("hotel_1368",
+        Collections.singletonList(get("geo.lat")));
 
     // Just for example, block on the result - this is not best practice
     LookupInResult result = mono.block();
     // end::get-reactive[]
-    System.out.println("reactive: Altitude: " + result.contentAs(0, Number.class));
+    System.out.println("reactive: Latitude: " + result.contentAs(0, Number.class));
   }
 
   static void upsertFunc() {
     // tag::upsert[]
-    collection.mutateIn("airport_1254", Arrays.asList(upsert("email", "dougr96@hotmail.com")));
+    collection.mutateIn("hotel_1368", Arrays.asList(upsert("email", "hotel96@hotmail.com")));
     // end::upsert[]
-    System.out.println("upsertFunc: airport_1254 email");
+    System.out.println("upsertFunc: hotel_1368 email");
   }
 
   static void insertFunc() {
     // tag::insert[]
     try {
-      collection.mutateIn("airport_1254", Collections.singletonList(insert("email", "dougr96@hotmail.com")));
+      collection.mutateIn("hotel_1368", Collections.singletonList(insert("alt_email", "alt_hotel96@hotmail.com")));
     } catch (PathExistsException err) {
       System.out.println("insertFunc: exception caught, path already exists");
     }
@@ -171,69 +171,78 @@ public class SubDocument {
 
   static void multiFunc() {
     try {
-      collection.mutateIn("airport_1254", Arrays.asList(upsert("tz", "EST")));
+      collection.mutateIn("hotel_1368", Arrays.asList(upsert("tz", "EST")));
     } catch (PathExistsException e) {
     }
     try {
-      collection.mutateIn("airport_1254", Arrays.asList(remove("email")));
+      collection.mutateIn("hotel_1368", Arrays.asList(remove("alt_email")));
     } catch (PathNotFoundException e) {
     }
     // tag::multi[]
-    collection.mutateIn("airport_1254", Arrays.asList(remove("tz"), insert("email", "fredk84@hotmail.com")));
+    collection.mutateIn("hotel_1368", Arrays.asList(remove("tz"), insert("alt_email", "hotel84@hotmail.com")));
     // end::multi[]
-    System.out.println("upsertFunc: airport_1254 email");
+    System.out.println("upsertFunc: hotel_1368 alt_email");
   }
 
   static void arrayAppendObjFunc() {
 
     JsonObject docContent = JsonObject.create();
-    docContent.put("day", 6);
-    docContent.put("flight", "DL999");
-    docContent.put("utc", "11:59:59");
+    docContent.put("content", "very nice hotel");
+    docContent.put("author", "Nedra Cronin");
+    docContent.put("date", "2012-01-14 02:15:51 +0300");
 
     // tag::array-appendobj[]
-    collection.mutateIn("route_21254",
-        Collections.singletonList(arrayAppend("schedule", Collections.singletonList(docContent))));
+    collection.mutateIn("hotel_1368",
+        Collections.singletonList(arrayAppend("reviews", Collections.singletonList(docContent))));
     // end::array-appendobj[]
-    System.out.println("arrayAppendObjFunc: route_21254 schedule");
+    System.out.println("arrayAppendObjFunc: hotel_1368 reviews");
   }
 
   static void arrayAppendFunc() {
     // tag::array-append[]
-    MutationResult result = collection.mutateIn("customer123",
-        Collections.singletonList(arrayAppend("purchases.complete", Collections.singletonList(777))));
-    // purchases.complete is now [339, 976, 442, 666, 777]
+    MutationResult result = collection.mutateIn("hotel_1368",
+        Collections.singletonList(arrayAppend("public_likes", Collections.singletonList("Mike Rutherford"))));
+    /*
+      public_likes is now:
+      ["Georgette Rutherford V", "Ms. Devante Bruen", "Anderson Schmidt", "Mr. Kareem Harvey", "Tessie Shields",
+      "Floyd Bradtke III", "Maurice McDermott", "Michel Franecki", "Laila Ernser", "Mike Rutherford"]
+    */
     // end::array-append[]
   }
 
   static void arrayPrependObjFunc() {
     JsonObject docContent = JsonObject.create();
-    docContent.put("day", 0);
-    docContent.put("flight", "DL000");
-    docContent.put("utc", "00:00:00");
+    docContent.put("content", "not a very nice hotel");
+    docContent.put("author", "Terry Smith");
+    docContent.put("date", "2013-01-14 03:16:51 +0300");
+
     // tag::array-prependobj[]
-    collection.mutateIn("route_21254",
-        Collections.singletonList(arrayPrepend("schedule", Collections.singletonList(docContent))));
+    collection.mutateIn("hotel_1501",
+        Collections.singletonList(arrayPrepend("reviews", Collections.singletonList(docContent))));
     // end::array-prependobj[]
-    System.out.println("arrayAppendObjFunc: route_21254 schedule");
+    System.out.println("arrayAppendObjFunc: hotel_1501 reviews");
   }
 
   static void arrayPrependFunc() {
     // tag::array-prepend[]
-    MutationResult result = collection.mutateIn("customer123",
-        Collections.singletonList(arrayPrepend("purchases.abandoned", Collections.singletonList(18))));
+    MutationResult result = collection.mutateIn("hotel_1368",
+        Collections.singletonList(arrayPrepend("public_likes", Collections.singletonList("John Smith"))));
 
-    // purchases.abandoned is now [18, 157, 49, 999]
+    /*
+      public_likes is now:
+      ["John Smith", "Georgette Rutherford V", "Ms. Devante Bruen", "Anderson Schmidt", "Mr. Kareem Harvey", "Tessie Shields",
+      "Floyd Bradtke III", "Maurice McDermott", "Michel Franecki", "Laila Ernser", "Mike Rutherford"]
+    */
     // end::array-prepend[]
   }
 
   static void full_doc_replaceFunc() {
     // tag::full_doc_replace[]
     JsonObject docContent = JsonObject.create().put("body", "value");
-    collection.mutateIn("airport_1255",
+    collection.mutateIn("hotel_14006",
         Arrays.asList(MutateInSpec.upsert("foo", "bar").xattr().createPath(), MutateInSpec.replace("", docContent)));
     // end::full_doc_replace[]
-    System.out.println("full_doc_replaceFunc: airport_1255 foo");
+    System.out.println("full_doc_replaceFunc: hotel_14006 foo");
 
   }
 
@@ -251,20 +260,20 @@ public class SubDocument {
 
   static void arrayCreate() {
     // tag::array-upsert[]
-    MutateInResult result = collection.mutateIn("airport_1256",
+    MutateInResult result = collection.mutateIn("hotel_14225",
         Collections.singletonList(arrayAppend("some.array", Collections.singletonList("hello world")).createPath()));
     // end::array-upsert[]
-    System.out.println("arrayCreate: airport_1256 some.array " + result);
+    System.out.println("arrayCreate: hotel_14225 some.array " + result);
 
   }
 
   static void arrayUnique() {
-    collection.mutateIn("airport_1257", Arrays.asList(MutateInSpec.upsert("unique", Collections.singletonList(88))));
+    collection.mutateIn("hotel_14226", Arrays.asList(MutateInSpec.upsert("unique", Collections.singletonList(88))));
     // tag::array-unique[]
-    collection.mutateIn("airport_1257", Collections.singletonList(arrayAddUnique("unique", 95)));
+    collection.mutateIn("hotel_14226", Collections.singletonList(arrayAddUnique("unique", 95)));
 
     try {
-      collection.mutateIn("airport_1257", Collections.singletonList(arrayAddUnique("unique", 95)));
+      collection.mutateIn("hotel_14226", Collections.singletonList(arrayAddUnique("unique", 95)));
       throw new RuntimeException("should have thrown PathExistsException");
     } catch (PathExistsException err) {
       System.out.println("arrayUnique: caught exception, path already exists");
@@ -273,61 +282,61 @@ public class SubDocument {
   }
 
   static void arrayInsertFunc() {
-    collection.mutateIn("airport_1258", Arrays.asList(MutateInSpec.upsert("foo", Collections.singletonList(88))));
+    collection.mutateIn("hotel_1501", Arrays.asList(MutateInSpec.upsert("foo", Collections.singletonList(88))));
     // tag::array-insert[]
-    MutateInResult result = collection.mutateIn("airport_1258",
+    MutateInResult result = collection.mutateIn("hotel_1501",
         Collections.singletonList(arrayInsert("foo[1]", Collections.singletonList("cruel"))));
     // end::array-insert[]
-    System.out.println("arrayInsertFunc: airport_1258 foo " + result);
+    System.out.println("arrayInsertFunc: hotel_1501 foo " + result);
 
   }
 
   static void counterInc() {
-    collection.mutateIn("airport_1254", Arrays.asList(MutateInSpec.upsert("logins", 1)));
+    collection.mutateIn("hotel_1368", Arrays.asList(MutateInSpec.upsert("logins", 1)));
     // tag::counter-inc[]
-    MutateInResult result = collection.mutateIn("airport_1254", Collections.singletonList(increment("logins", 1)));
+    MutateInResult result = collection.mutateIn("hotel_1368", Collections.singletonList(increment("logins", 1)));
 
     // Counter operations return the updated count
     Long count = result.contentAs(0, Long.class);
     // end::counter-inc[]
-    System.out.println("counterInc: airport_1254 logins " + count);
+    System.out.println("counterInc: hotel_1368 logins " + count);
 
   }
 
   static void counterDec() {
-    collection.mutateIn("airport_1254", Arrays.asList(MutateInSpec.upsert("logouts", 1000)));
+    collection.mutateIn("hotel_1368", Arrays.asList(MutateInSpec.upsert("logouts", 1000)));
     // tag::counter-dec[]
 
-    MutateInResult result = collection.mutateIn("airport_1254", Collections.singletonList(decrement("logouts", 150)));
+    MutateInResult result = collection.mutateIn("hotel_1368", Collections.singletonList(decrement("logouts", 150)));
     // Counter operations return the updated count
     Long count = result.contentAs(0, Long.class);
     // end::counter-dec[]
-    System.out.println("counterDec: airport_1254 logouts " + count);
+    System.out.println("counterDec: hotel_1368 logouts " + count);
 
   }
 
   static void createPath() {
     // tag::create-path[]
-    MutateInResult result = collection.mutateIn("airport_1254",
+    MutateInResult result = collection.mutateIn("hotel_1368",
         Collections.singletonList(
             upsert("level_0.level_1.foo.bar.phone", JsonObject.create().put("num", "311-555-0101").put("ext", 16))
                 .createPath()));
     // end::create-path[]
-    System.out.println("createPath: airport_1254 " + result);
+    System.out.println("createPath: hotel_1368 " + result);
   }
 
   static void concurrent() {
     // tag::concurrent[]
     Thread thread1 = new Thread() {
       public void run() {
-        collection.mutateIn("airport_1258",
+        collection.mutateIn("hotel_1501",
             Collections.singletonList(arrayAppend("foo", Collections.singletonList(99))));
       }
     };
 
     Thread thread2 = new Thread() {
       public void run() {
-        collection.mutateIn("airport_1258",
+        collection.mutateIn("hotel_1501",
             Collections.singletonList(arrayAppend("foo", Collections.singletonList(101))));
       }
     };
@@ -344,25 +353,25 @@ public class SubDocument {
     } catch (InterruptedException e) {
       e.printStackTrace();
     }
-    GetResult doc = collection.get("airport_1258");
-    System.out.println("concurrent: airport_1258 " + doc);
+    GetResult doc = collection.get("hotel_1501");
+    System.out.println("concurrent: hotel_1501 " + doc);
 
   }
 
   static void cas() {
     // tag::cas[]
-    GetResult doc = collection.get("airport_1254");
-    MutationResult result = collection.mutateIn("airport_1254", Collections.singletonList(decrement("logouts", 150)),
+    GetResult doc = collection.get("hotel_1368");
+    MutationResult result = collection.mutateIn("hotel_1368", Collections.singletonList(decrement("logouts", 150)),
         mutateInOptions().cas(doc.cas()));
     // end::cas[]
-    System.out.println("cas: airport_1258 " + doc);
+    System.out.println("cas: hotel_1368 " + doc);
   }
 
   static void cas_fail() {
     // tag::cas_fail[]
-    GetResult doc = collection.get("airport_1254");
+    GetResult doc = collection.get("hotel_1368");
     try {
-      MutationResult result = collection.mutateIn("airport_1254", Collections.singletonList(decrement("logouts", 150)),
+      MutationResult result = collection.mutateIn("hotel_1368", Collections.singletonList(decrement("logouts", 150)),
           mutateInOptions().cas(doc.cas() + 1));
     } catch (CasMismatchException e) {
       System.out.println("cas_fail: " + e);
@@ -373,7 +382,7 @@ public class SubDocument {
   static void oldDurability() {
     try {
       // tag::old-durability[]
-      MutationResult result = collection.mutateIn("airport_1254",
+      MutationResult result = collection.mutateIn("hotel_1368",
           Collections.singletonList(MutateInSpec.upsert("foo", "bar")),
           mutateInOptions().durability(PersistTo.ACTIVE, ReplicateTo.ONE));
       // end::old-durability[]
@@ -386,7 +395,7 @@ public class SubDocument {
   static void newDurability() {
     try {
       // tag::new-durability[]
-      MutationResult result = collection.mutateIn("airport_1254",
+      MutationResult result = collection.mutateIn("hotel_1368",
           Collections.singletonList(MutateInSpec.upsert("foo", "bar")),
           mutateInOptions().durability(DurabilityLevel.MAJORITY));
       // end::new-durability[]

--- a/modules/howtos/examples/TransactionsExample.java
+++ b/modules/howtos/examples/TransactionsExample.java
@@ -27,6 +27,7 @@ import com.couchbase.client.core.cnc.RequestSpan;
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.Collection;
+import com.couchbase.client.java.Scope;
 import com.couchbase.client.java.ReactiveCollection;
 import com.couchbase.client.java.json.JsonObject;
 import com.couchbase.client.java.kv.GetResult;
@@ -65,7 +66,8 @@ public class TransactionsExample {
         // Initialize the Couchbase cluster
         Cluster cluster = Cluster.connect("localhost", "Administrator", "password");
         Bucket bucket = cluster.bucket("travel-sample");
-        Collection collection = bucket.defaultCollection();
+        Scope scope = bucket.scope("inventory");
+        Collection collection = scope.collection("airport");
 
         // Create the single Transactions object
         Transactions transactions = Transactions.create(cluster);

--- a/modules/howtos/examples/Transcoding.java
+++ b/modules/howtos/examples/Transcoding.java
@@ -29,6 +29,7 @@ import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.ClusterOptions;
 import com.couchbase.client.java.Collection;
+import com.couchbase.client.java.Scope;
 import com.couchbase.client.java.codec.JsonSerializer;
 import com.couchbase.client.java.codec.JsonTranscoder;
 import com.couchbase.client.java.codec.RawBinaryTranscoder;
@@ -159,10 +160,10 @@ public class Transcoding {
     @BeforeAll
     public static void BeforeAll() {
         Cluster cluster = Cluster.connect("127.0.0.1", "Administrator", "password");
-
-        Bucket bucket = cluster.bucket("default");
+        Bucket bucket = cluster.bucket("travel-sample");
         bucket.waitUntilReady(Duration.ofSeconds(30));
-        collection = bucket.defaultCollection();
+        Scope scope = bucket.scope("tenant_agent_00");
+        collection = scope.collection("users");
     }
 
     @Test

--- a/modules/howtos/examples/UserManagementExample.java
+++ b/modules/howtos/examples/UserManagementExample.java
@@ -18,6 +18,7 @@ import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.ClusterOptions;
 import com.couchbase.client.java.Collection;
+import com.couchbase.client.java.Scope;
 import com.couchbase.client.java.env.ClusterEnvironment;
 import com.couchbase.client.java.json.JsonObject;
 import com.couchbase.client.java.manager.query.CreatePrimaryQueryIndexOptions;
@@ -96,21 +97,22 @@ public class UserManagementExample {
     Cluster userCluster = Cluster.connect(connectionString,
         ClusterOptions.clusterOptions(testUsername, testPassword).environment(environment));
     Bucket userBucket = userCluster.bucket(bucketName);
-    Collection userCollection = userBucket.defaultCollection();
+    Scope scope = userBucket.scope("inventory");
+    Collection collection = scope.collection("airline");
 
     cluster.queryIndexes().createPrimaryIndex(bucketName, // create index if needed
         CreatePrimaryQueryIndexOptions.createPrimaryQueryIndexOptions().ignoreIfExists(true));
 
-    JsonObject returnedAirline10doc = userCollection.get("airline_10").contentAsObject();
+    JsonObject returnedAirline10doc = collection.get("airline_10").contentAsObject();
 
     JsonObject airline11Object = JsonObject.create().put("callsign", "MILE-AIR").put("iata", "Q5").put("icao", "MLA")
         .put("id", 11).put("name", "40-Mile Air").put("type", "airline");
 
-    userCollection.upsert("airline_11", airline11Object);
+    collection.upsert("airline_11", airline11Object);
 
-    JsonObject returnedAirline11Doc = userCollection.get("airline_11").contentAsObject();
+    JsonObject returnedAirline11Doc = collection.get("airline_11").contentAsObject();
 
-    QueryResult result = userCluster.query("SELECT * FROM `travel-sample` LIMIT 5");
+    QueryResult result = userCluster.query("SELECT * FROM `travel-sample`.inventory.airline LIMIT 5");
 
     userCluster.disconnect();
     // end::usermanagement_3[]

--- a/modules/howtos/examples/managing_connections.java
+++ b/modules/howtos/examples/managing_connections.java
@@ -47,8 +47,8 @@ public class managing_connections {
 		cluster = Cluster.connect(connectionString,
 				ClusterOptions.clusterOptions(username, password).environment(environment));
 		bucket = cluster.bucket("travel-sample");
-		scope = bucket.defaultScope();
-		collection = bucket.defaultCollection(); // end::connection_1[]
+		scope = bucket.scope("inventory");
+		collection = scope.collection("airport"); // end::connection_1[]
 	}
 
 	public void managing_connections_5() throws Exception { // file: howtos/pages/managing-connections.adoc line: 125

--- a/modules/howtos/pages/analytics-using-sdk.adoc
+++ b/modules/howtos/pages/analytics-using-sdk.adoc
@@ -5,20 +5,20 @@
 :page-aliases: analytics-query
 :page-edition: Enterprise Edition
 :lang: Java
-:version: 3.1.6
-:example-source: 3.1@java-sdk:howtos:example$Analytics.java
+:version: 3.2.0
+:example-source: 3.2@java-sdk:howtos:example$Analytics.java
 :example-source-lang: java
 
 [abstract]
 {description}
 
-For complex and long-running queries, involving large ad hoc join, set, aggregation, and grouping operations, the Couchbase Data Platform offers the xref:6.5@server:analytics:introduction.adoc[Couchbase Analytics Service (CBAS)].
+For complex and long-running queries, involving large ad hoc join, set, aggregation, and grouping operations, the Couchbase Data Platform offers the xref:7.0@server:analytics:introduction.adoc[Couchbase Analytics Service (CBAS)].
 This is the analytic counterpart to our xref:n1ql-queries-with-sdk.adoc[operational data focussed Query Service].
 The analytics service is available in Couchbase Data Platform 6.0 and later.
 
 == Getting Started
 
-After familiarizing yourself with our xref:6.6@server:analytics:primer-beer.adoc[introductory primer],
+After familiarizing yourself with our xref:7.0@server:analytics:primer-beer.adoc[introductory primer],
 in particular creating a dataset and linking it to a bucket, try Couchbase Analytics using the Java SDK.
 Intentionally, the API for analytics is nearly identical to that of the query service.
 
@@ -187,7 +187,7 @@ A simple reactive query is similar to the blocking one:
 include::example$Analytics.java[tag=simplereactive,indent=0]
 ----
 
-This query will stream all rows as they become available form the server. If you want to manually control the data flow (which is important if you are streaming a lot of rows which could cause a potential out of memory situation) you can do this by using explicit `request()` calls.
+This query will stream all rows as they become available from the server. If you want to manually control the data flow (which is important if you are streaming a lot of rows which could cause a potential out of memory situation) you can do this by using explicit `request()` calls.
 
 [source,java]
 ----
@@ -202,7 +202,7 @@ We always recommend not blocking in the first place in reactive code.
 
 == Scoped Queries on Named Collections
 
-In addition to creating a dataset with a WHERE clause to filter the results to documents with certain characteristics, SDK 3.1 now allows you to create a dataset against a named collection, for example:
+In addition to creating a dataset with a WHERE clause to filter the results to documents with certain characteristics, SDK 3.2 now allows you to create a dataset against a named collection, for example:
 
 [source,n1ql]
 ----

--- a/modules/howtos/pages/collecting-information-and-logging.adoc
+++ b/modules/howtos/pages/collecting-information-and-logging.adoc
@@ -184,6 +184,6 @@ include::example$CollectingInformationAndLogging.java[tag=collecting_information
 Different redaction levels are supported -- please see the `RedactionLevel` enum description for more information.
 
 Note that you need to run this command before any of the SDK code is initialized so all of the logs are captured properly. 
-Once the SDK writes the logs with the tags to a file, you can then use the xref:6.5@server:cli:cbcli/cblogredaction.adoc[`cblogredaction` tool] to obfuscate the log.
+Once the SDK writes the logs with the tags to a file, you can then use the xref:7.0@server:cli:cbcli/cblogredaction.adoc[`cblogredaction` tool] to obfuscate the log.
 
-* You may wish to read more on Log Redaction xref:6.5@server:manage:manage-logging/manage-logging.adoc#understanding_redaction[in the Server docs].
+* You may wish to read more on Log Redaction xref:7.0@server:manage:manage-logging/manage-logging.adoc#understanding_redaction[in the Server docs].

--- a/modules/howtos/pages/concurrent-document-mutations.adoc
+++ b/modules/howtos/pages/concurrent-document-mutations.adoc
@@ -3,13 +3,13 @@
 include::project-docs:partial$attributes.adoc[]
 :page-aliases: ROOT:concurrent-document-mutations.adoc
 
-include::6.5@sdk:shared:partial$cas.adoc[tag=intro]
+include::7.0@sdk:shared:partial$cas.adoc[tag=intro]
 
-include::6.5@sdk:shared:partial$cas.adoc[tag=demo]
+include::7.0@sdk:shared:partial$cas.adoc[tag=demo]
 
-include::6.5@sdk:shared:partial$cas.adoc[tag=example]
+include::7.0@sdk:shared:partial$cas.adoc[tag=example]
 
-include::6.5@sdk:shared:partial$cas.adoc[tag=errors]
+include::7.0@sdk:shared:partial$cas.adoc[tag=errors]
 
 [source,java]
 ----
@@ -19,11 +19,11 @@ include::example$Cas.java[tag=handlingerrors,indent=0]
 Sometimes more logic is needed when performing updates, for example, if a property is mutually exclusive with another property; only one or the other can exist, but not both.
 
 
-include::6.5@sdk:shared:partial$cas.adoc[tag=performance]
+include::7.0@sdk:shared:partial$cas.adoc[tag=performance]
 
-include::6.5@sdk:shared:partial$cas.adoc[tag=format]
+include::7.0@sdk:shared:partial$cas.adoc[tag=format]
 
-include::6.5@sdk:shared:partial$cas.adoc[tag=locking]
+include::7.0@sdk:shared:partial$cas.adoc[tag=locking]
 
 [source,java]
 ----

--- a/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
+++ b/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
@@ -10,7 +10,7 @@
 {description}
 
 
-include::6.6@sdk:shared:partial$acid-transactions.adoc[tag=intro]
+include::7.0@sdk:shared:partial$acid-transactions.adoc[tag=intro]
 
 
 Below we show you how to create Transactions, step-by-step.
@@ -24,7 +24,7 @@ Javadocs are available https://docs.couchbase.com/sdk-api/couchbase-transactions
 
 * Couchbase Server 6.6.1 or above.
 * Couchbase Java client 3.1.5 or above.  It is recommended to follow the transitive dependency for the transactions library from Maven.
-include::6.5@sdk:shared:partial$acid-transactions.adoc[tag=requirements]
+include::7.0@sdk:shared:partial$acid-transactions.adoc[tag=requirements]
 
 
 == Getting Started
@@ -85,10 +85,10 @@ Transactions can optionally be configured at the point of creating the `Transact
 include::example$TransactionsExample.java[tag=config,indent=0]
 ----
 
-include::6.6@sdk:shared:partial$acid-transactions.adoc[tag=config]
+include::7.0@sdk:shared:partial$acid-transactions.adoc[tag=config]
 
 
-include::6.6@sdk:shared:partial$acid-transactions.adoc[tag=creating]
+include::7.0@sdk:shared:partial$acid-transactions.adoc[tag=creating]
 
 As with the Couchbase Java Client, you can use the library in either synchronous mode (the exceptions will be explained later in <<Error Handling>>):
 
@@ -133,7 +133,7 @@ include::example$TransactionsExample.java[tag=examplesReactive,indent=0]
 ----
 
 
-include::6.6@sdk:shared:partial$acid-transactions.adoc[tag=mechanics]
+include::7.0@sdk:shared:partial$acid-transactions.adoc[tag=mechanics]
 
 
 == Mutating Documents
@@ -257,7 +257,7 @@ An asynchronous cleanup process ensures that once the transaction reaches the co
 
 
 // == A Full Transaction Example
-include::6.6@sdk:shared:partial$acid-transactions.adoc[tag=example]
+include::7.0@sdk:shared:partial$acid-transactions.adoc[tag=example]
 
 A complete version of this example is available on our https://github.com/couchbaselabs/couchbase-transactions-java-examples[GitHub transactions examples page].
 
@@ -268,7 +268,7 @@ include::example$TransactionsExample.java[tag=full,indent=0]
 
 
 // concurrency
-include::6.6@sdk:shared:partial$acid-transactions.adoc[tag=concurrency]
+include::7.0@sdk:shared:partial$acid-transactions.adoc[tag=concurrency]
 
 [source,java]
 ----
@@ -307,19 +307,19 @@ After a transaction is rolled back, it cannot be committed, no further operation
 
 
 //  Error Handling
-include::6.6@sdk:shared:partial$acid-transactions.adoc[tag=error]
+include::7.0@sdk:shared:partial$acid-transactions.adoc[tag=error]
 
 
 
 //  txnfailed
-include::6.5@sdk:shared:partial$acid-transactions.adoc[tag=txnfailed]
+include::7.0@sdk:shared:partial$acid-transactions.adoc[tag=txnfailed]
 
 [source,java]
 ----
 include::example$TransactionsExample.java[tag=config-expiration,indent=0]
 ----
 
-include::6.5@sdk:shared:partial$acid-transactions.adoc[tag=txnfailed1]
+include::7.0@sdk:shared:partial$acid-transactions.adoc[tag=txnfailed1]
 
 
 === Full Error Handling Example
@@ -332,7 +332,7 @@ include::example$TransactionsExample.java[tag=full-error-handling,indent=0]
 ----
 
 
-include::6.6@sdk:shared:partial$acid-transactions.adoc[tag=cleanup]
+include::7.0@sdk:shared:partial$acid-transactions.adoc[tag=cleanup]
 
 === Monitoring Cleanup
 
@@ -510,4 +510,4 @@ The transaction expiry timer (which is configurable) will begin ticking once the
 
 
 
-include::6.6@sdk:shared:partial$acid-transactions.adoc[tag=further]
+include::7.0@sdk:shared:partial$acid-transactions.adoc[tag=further]

--- a/modules/howtos/pages/encrypting-using-sdk.adoc
+++ b/modules/howtos/pages/encrypting-using-sdk.adoc
@@ -2,7 +2,7 @@
 :description: A practical guide for getting started with Field-Level Encryption, showing how to encrypt and decrypt JSON fields using the Java SDK.
 :page-topic-type: howto
 :page-edition: Enterprise Edition
-// :page-aliases: ROOT:encrypting-using-sdk.adoc
+:page-aliases: ROOT:encrypting-using-sdk.adoc
 
 [abstract]
 {description}

--- a/modules/howtos/pages/full-text-searching-with-sdk.adoc
+++ b/modules/howtos/pages/full-text-searching-with-sdk.adoc
@@ -2,7 +2,7 @@
 :description: You can use the Full Text Search service (FTS) to create queryable full-text indexes in Couchbase Server.
 :navtitle: Full Text Search using the SDK
 :page-topic-type: howto
-:page-aliases: ROOT:search-query
+:page-aliases: ROOT:search-query, ROOT:full-text-searching-with-sdk.adoc
 :lang: Java
 :version: 3.2.0
 :example-source: 3.2@java-sdk:howtos:example$Search.java

--- a/modules/howtos/pages/full-text-searching-with-sdk.adoc
+++ b/modules/howtos/pages/full-text-searching-with-sdk.adoc
@@ -4,8 +4,8 @@
 :page-topic-type: howto
 :page-aliases: ROOT:search-query
 :lang: Java
-:version: 3.1.6
-:example-source: 3.1@java-sdk:howtos:example$Search.java
+:version: 3.2.0
+:example-source: 3.2@java-sdk:howtos:example$Search.java
 :example-source-lang: java
 
 
@@ -44,7 +44,7 @@ Exception in thread "main" com.couchbase.client.core.error.IndexNotFoundExceptio
 [NOTE]
 .Open Buckets and Cluster-Level Queries
 ====
-If you are using a cluster older than Couchbase Server 6.5, it is required that there is at least one bucket open before performing a cluster-level query. 
+If you are using a cluster older than Couchbase Server 6.5, it is required that there is at least one bucket open before performing a cluster-level query.
 If you fail to do so, the SDK will return a `FeatureNotAvailableException` with a descriptive error message asking you to open one.
 ====
 
@@ -128,6 +128,7 @@ The Search Service provides an array of options to customize your query. The fol
 | `fields(String...)` | Specifies fields to be included.
 | `serializer(JsonSerializer)` | Allows to use a different serializer for the decoding of the rows.
 | `raw(String, Object)` | Escape hatch to add arguments that are not covered by these options.
+| `collections(String...)` | Limits the search query to a specific list of collection names.
 |====
 
 === Limit and Skip
@@ -193,6 +194,17 @@ You can tell the Search Engine to include the full content of a certain number o
 [source,java]
 ----
 include::example$Search.java[tag=fields,indent=0]
+----
+
+=== Collections
+
+It is now possible to limit the search query to a specific list of collection names.
+
+Note that this feature is only supported with Couchbase Server 7.0 or later.
+
+[source,java]
+----
+include::example$Search.java[tag=collections,indent=0]
 ----
 
 === Custom JSON Serializer

--- a/modules/howtos/pages/health-check.adoc
+++ b/modules/howtos/pages/health-check.adoc
@@ -2,7 +2,6 @@
 :description: In today's distributed and virtual environments, users will often not have full administrative control over their whole network.
 :navtitle: Health Check
 :page-topic-type: howto
-:page-aliases: ROOT:health-check.adoc
 
 [abstract]
 {description}

--- a/modules/howtos/pages/health-check.adoc
+++ b/modules/howtos/pages/health-check.adoc
@@ -2,6 +2,7 @@
 :description: In today's distributed and virtual environments, users will often not have full administrative control over their whole network.
 :navtitle: Health Check
 :page-topic-type: howto
+:page-aliases: ROOT:health-check.adoc
 
 [abstract]
 {description}

--- a/modules/howtos/pages/json.adoc
+++ b/modules/howtos/pages/json.adoc
@@ -1,1 +1,1 @@
- include::6.5@sdk:pages:partial$json.adoc[]
+ include::7.0@sdk:pages:partial$json.adoc[]

--- a/modules/howtos/pages/kv-operations.adoc
+++ b/modules/howtos/pages/kv-operations.adoc
@@ -3,14 +3,14 @@
 :navtitle: KV Operations
 :page-topic-type: howto
 :page-aliases: document-operations.adoc,ROOT:documents-creating,ROOT:documents-updating,ROOT:documents-retrieving,ROOT:documents-deleting
-:example-source: 3.1@java-sdk:howtos:example$Queries.java
+:example-source: 3.2@java-sdk:howtos:example$Queries.java
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]
 {description}
 Here we cover CRUD operations, document expiration, and optimistic locking with CAS.
 
-The complete code sample used on this page can be downloaded from https://github.com/couchbase/docs-sdk-java/blob/release/3.1/modules/howtos/examples/KvOperations.java[here].
+The complete code sample used on this page can be downloaded from https://github.com/couchbase/docs-sdk-java/blob/release/3.2/modules/howtos/examples/KvOperations.java[here].
 
 At its heart Couchbase Server is a high-performance key-value store, and the key-value interface outlined below is the fastest and best method to perform operations involving single documents.
 
@@ -248,7 +248,7 @@ It can be used like this:
 include::example$KvOperations.java[tag=expiry-touch]
 ----
 
-include::6.6@sdk:shared:partial$documents.adoc[tag=exp-note]
+include::7.0@sdk:shared:partial$documents.adoc[tag=exp-note]
 
 
 
@@ -284,16 +284,14 @@ NOTE: Increment & Decrement are considered part of the ‘binary’ API and as s
 
 == Scoped KV Operations
 
-From version 3.0.0 of the Java SDK, it is possible to perform scoped key-value operations on named xref:7.0@server:learn:data/scopes-and-collections.adoc[`Collections`] _with the beta version of the next Couchbase Server release, 7.0β_.
+It is possible to perform scoped key-value operations on named xref:7.0@server:learn:data/scopes-and-collections.adoc[`Collections`] _with Couchbase Server release 7.0_.
 See the https://docs.couchbase.com/sdk-api/couchbase-java-client/com/couchbase/client/java/Collection.html[API docs] for more information.
-
-CAUTION: This feature is marked xref:project-docs:compatibility.adoc#interface-stability[_Uncommitted_].
-Expect a promotion to _Committed_ API in a future minor release.
 
 Here is an example showing an upsert in the `users` collection, which lives in the `travel-sample.tenant_agent_00` keyspace:
 
 [source,java]
 ----
+include::example$KvOperations.java[tag=named-scope-and-collection]
 include::example$KvOperations.java[tag=named-collection-upsert]
 ----
 

--- a/modules/howtos/pages/kv-operations.adoc
+++ b/modules/howtos/pages/kv-operations.adoc
@@ -291,7 +291,6 @@ Here is an example showing an upsert in the `users` collection, which lives in t
 
 [source,java]
 ----
-include::example$KvOperations.java[tag=named-scope-and-collection]
 include::example$KvOperations.java[tag=named-collection-upsert]
 ----
 

--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -20,7 +20,7 @@ include::example$ManagingConnections.java[tag=simpleconnect,indent=0]
 ----
 
 NOTE: If you are connecting to a version of Couchbase Server older than 6.5, it will be more efficient if the addresses are those of data (KV) nodes.
-You will in any case, with 6.0 and earlier, need to open a ``Bucket` instance before connecting to any other HTTP services (such as _Query_ or _Search_.
+You will in any case, with 7.0 and earlier, need to open a ``Bucket` instance before connecting to any other HTTP services (such as _Query_ or _Search_.
 
 In a production environment, your connection string should include the addresses of multiple server nodes in case some are currently unavailable.
 Multiple addresses may be specified in a connection string by delimiting them with commas:
@@ -114,7 +114,7 @@ Both the client and server require special configuration in this case.
 On the server side, each server node must be configured to advertise its external address as well as any custom port mapping.
 This is done with the `setting-alternate-address` CLI command introduced in Couchbase Server 6.5.
 A node configured in this way will advertise two addresses: one for connecting from the same network, and another for connecting from an external network.
-// todo link to https://docs.couchbase.com/server/6.5/cli/cbcli/couchbase-cli-setting-alternate-address.html
+// todo link to https://docs.couchbase.com/server/7.0/cli/cbcli/couchbase-cli-setting-alternate-address.html
 
 On the client side, the externally visible ports must be used when connecting.
 If the external ports are not the default, you can specify custom ports using the overloaded `Cluster.connect()` method that takes a set of `SeedNode` objects instead of a connection string.
@@ -198,7 +198,7 @@ E.....@.@.............+....Z.'yZ..#........
 .%v.....4....m*...A.2I.1.&.*,6+..#..#.5
 ----
 
-include::6.0@sdk:shared:partial$dnssrv-pars.adoc[tag=dnssrv]
+include::7.0@sdk:shared:partial$dnssrv-pars.adoc[tag=dnssrv]
 
 DNS SRV bootstrapping is available in the Java SDK from version 2.1.0.
 In order to make the SDK actually use the SRV records, you need to enable DNS SRV on the environment and pass in the host name from your records (here `example.com`):
@@ -251,7 +251,7 @@ _plus_ it waits for the K-V (data) sockets to be ready.
 Other timeout issues may occur when using the SDK located geographically separately from the Couchbase Server cluster -- this is xref:project-docs:compatibility#network-requirements[not recommended].
 See the xref:#working-in-the-cloud[Cloud section] below for some suggestions of settings adjustments.
 
-include::6.5@sdk:shared:partial$managing-connections.adoc[tag=cloud]
+include::7.0@sdk:shared:partial$managing-connections.adoc[tag=cloud]
 
 
 == Async and Reactive APIs

--- a/modules/howtos/pages/n1ql-queries-with-sdk.adoc
+++ b/modules/howtos/pages/n1ql-queries-with-sdk.adoc
@@ -4,8 +4,8 @@
 :page-topic-type: howto
 :page-aliases: n1ql-query,ROOT:querying-n1ql
 :lang: Java
-:version: 3.1.6
-:example-source: 3.1@java-sdk:howtos:example$Queries.java
+:version: 3.2.0
+:example-source: 3.2@java-sdk:howtos:example$Queries.java
 include::howtos:partial$attributes.adoc[]
 
 [abstract]
@@ -146,6 +146,7 @@ Depending on the index update rate this might provide a speedier response.
 
 [source,java]
 ----
+include::example$Queries.java[tag=connect-bucket-and-scope,indent=0]
 include::example$Queries.java[tag=scanconsistency_with,indent=0]
 ----
 
@@ -227,19 +228,15 @@ As always we recommend not blocking in the first place in reactive code.
 
 == Querying at Scope Level
 
-From version 3.0.8 of the Java SDK, it is possible to query off the
-xref:concept-docs:n1ql-query.adoc#collections-and-scopes-and-the-query-context[`Scope` level]
-_with the beta version of the next Couchbase Server release, 7.0β_,
-using the `scope.query()` method.
+It is possible to query off the xref:concept-docs:n1ql-query.adoc#collections-and-scopes-and-the-query-context[`Scope` level],
+_with Couchbase Server release 7.0_, using the `scope.query()` method.
 It takes the statement as a required argument, and then allows additional options if needed.
-
-CAUTION: This feature is marked xref:project-docs:compatibility.adoc#interface-stability[_Uncommitted_].
-Expect a promotion to _Committed_ API in a future minor release.
 
 A complete list of `QueryOptions` can be found in the https://docs.couchbase.com/sdk-api/couchbase-java-client/com/couchbase/client/java/AsyncScope.html#query-java.lang.String-[API docs].
 
 [source,java]
 ----
+include::example$Queries.java[tag=connect-bucket-and-scope]
 include::example$Queries.java[tag=scope-level-query]
 ----
 
@@ -249,7 +246,7 @@ NOTE: N1QL is not the only query option in Couchbase.
 Be sure to check that xref:concept-docs:data-services.adoc[your use case fits your selection of query service].
 
 * For a deeper dive into N1QL from the SDK, refer to our xref:concept-docs:n1ql-query.adoc[N1QL SDK concept doc].
-* The xref:6.6@server:n1ql:n1ql-language-reference/index.adoc[Server doc N1QL intro] introduces a complete guide to the N1QL language, including all of the latest additions.
+* The xref:7.0@server:n1ql:n1ql-language-reference/index.adoc[Server doc N1QL intro] introduces a complete guide to the N1QL language, including all of the latest additions.
 * The http://query.pub.couchbase.com/tutorial/#1[N1QL interactive tutorial] is a good introduction to the basics of N1QL use.
-* For scaling up queries, be sure to xref:6.6@server:learn:services-and-indexes/indexes/index-replication.adoc[read up on Indexes].
+* For scaling up queries, be sure to xref:7.0@server:learn:services-and-indexes/indexes/index-replication.adoc[read up on Indexes].
 * N1QL is for operational queries; for analytical workloads, read more on xref:concept-docs:http-services.adoc#long-running-queries-big-data[when to choose Analytics], our implementation of SQL++ available in the Enterprise Edition.

--- a/modules/howtos/pages/n1ql-queries-with-sdk.adoc
+++ b/modules/howtos/pages/n1ql-queries-with-sdk.adoc
@@ -140,19 +140,22 @@ If `QueryScanConsistency.REQUEST_PLUS` is chosen, it will likely take a bit long
 include::example$Queries.java[tag=scanconsistency,indent=0]
 ----
 
-You can also use `consistentWith(MutationState)` for a more narrowed-down scan consistency.
-Construct the `MutationState` from individual `MutationToken`s that are returned from KV `MutationResult`s to make sure at least those mutations are visible.
-Depending on the index update rate this might provide a speedier response.
-
-[source,java]
-----
-include::example$Queries.java[tag=connect-bucket-and-scope,indent=0]
-include::example$Queries.java[tag=scanconsistency_with,indent=0]
-----
-
-Note that you cannot use this method and `scanConsistency(QueryScanConsistency)` at the same time, since they are mutually exclusive.
-As a rule of thumb, if you only care about being consistent with the mutation you just wrote on the same thread or app, use this method.
-If you need "global" scan consistency, use `QueryScanConsistency.REQUEST_PLUS` on `scanConsistency(QueryScanConsistency)`.
+// Due to https://issues.couchbase.com/browse/MB-46876 this section won’t work with named scopes and collections,
+// we need to omit this information until Couchbase Server 7.0.1 is available, which will contain the fix for this bug.
+// We should avoid showing the user this information until then.
+//You can also use `consistentWith(MutationState)` for a more narrowed-down scan consistency.
+//Construct the `MutationState` from individual `MutationToken`s that are returned from KV `MutationResult`s to make sure at least those mutations are visible.
+//Depending on the index update rate this might provide a speedier response.
+//
+//[source,java]
+//----
+//include::example$Queries.java[tag=connect-bucket-and-scope,indent=0]
+//include::example$Queries.java[tag=scanconsistency_with,indent=0]
+//----
+//
+//Note that you cannot use this method and `scanConsistency(QueryScanConsistency)` at the same time, since they are mutually exclusive.
+//As a rule of thumb, if you only care about being consistent with the mutation you just wrote on the same thread or app, use this method.
+//If you need "global" scan consistency, use `QueryScanConsistency.REQUEST_PLUS` on `scanConsistency(QueryScanConsistency)`.
 
 
 === Client Context Id

--- a/modules/howtos/pages/observability-metrics.adoc
+++ b/modules/howtos/pages/observability-metrics.adoc
@@ -2,6 +2,7 @@
 :description: Individual request tracing presents a very specific (though isolated) view of the system.
 :page-status: Developer Preview
 :page-topic-type: howto
+:page-aliases: ROOT:observability-metrics.adoc
 
 [abstract]
 {description}

--- a/modules/howtos/pages/observability-metrics.adoc
+++ b/modules/howtos/pages/observability-metrics.adoc
@@ -2,7 +2,6 @@
 :description: Individual request tracing presents a very specific (though isolated) view of the system.
 :page-status: Developer Preview
 :page-topic-type: howto
-:page-aliases: ROOT:observability-metrics.adoc
 
 [abstract]
 {description}

--- a/modules/howtos/pages/observability-orphan-logger.adoc
+++ b/modules/howtos/pages/observability-orphan-logger.adoc
@@ -1,6 +1,7 @@
 = Orphaned Requests Logging
 :description: In addition to request tracing and metrics reporting, logging orphaned requests provides additional insight into why an operation might have timed out (or got cancelled for a different reason).
 :page-topic-type: howto
+:page-aliases: ROOT:observability-orphan-logger.adoc
 
 [abstract]
 {description}

--- a/modules/howtos/pages/observability-orphan-logger.adoc
+++ b/modules/howtos/pages/observability-orphan-logger.adoc
@@ -1,7 +1,6 @@
 = Orphaned Requests Logging
 :description: In addition to request tracing and metrics reporting, logging orphaned requests provides additional insight into why an operation might have timed out (or got cancelled for a different reason).
 :page-topic-type: howto
-:page-aliases: ROOT:observability-orphan-logger.adoc
 
 [abstract]
 {description}

--- a/modules/howtos/pages/observability-tracing.adoc
+++ b/modules/howtos/pages/observability-tracing.adoc
@@ -1,7 +1,7 @@
 = Request Tracing
 :description: Collecting information about an individual request and its response is an essential feature of every observability stack.
 :page-topic-type: howto
-:page-aliases: ROOT:observability-tracing.adoc
+:page-aliases: ROOT:tracing-from-the-sdk.adoc
 
 [abstract]
 {description}

--- a/modules/howtos/pages/observability-tracing.adoc
+++ b/modules/howtos/pages/observability-tracing.adoc
@@ -1,6 +1,7 @@
 = Request Tracing
 :description: Collecting information about an individual request and its response is an essential feature of every observability stack.
 :page-topic-type: howto
+:page-aliases: ROOT:observability-tracing.adoc
 
 [abstract]
 {description}

--- a/modules/howtos/pages/provisioning-cluster-resources.adoc
+++ b/modules/howtos/pages/provisioning-cluster-resources.adoc
@@ -7,7 +7,7 @@
 {description}
 Common use cases are outlined here, more recherché use cases are covered in the https://pkg.go.dev/github.com/couchbase/gocb/v2?tab=doc[API docs].
 
-include::6.5@sdk:shared:partial$flush-info-pars.adoc[tag=management-intro]
+include::7.0@sdk:shared:partial$flush-info-pars.adoc[tag=management-intro]
 
 The Java SDK also comes with some convenience functionality for common Couchbase management requests.
 
@@ -41,7 +41,7 @@ include::devguide:example$go/provisioning-resources-buckets.go[tag=creatingbucke
 
 The `CreateBucketSettings` and `BucketSettings` structs are used for creating and updating buckets, `BucketSettings` is also used for exposing information about existing buckets.
 
-include::6.5@sdk:shared:partial$flush-info-pars.adoc[tag=update-bucket-warning]
+include::7.0@sdk:shared:partial$flush-info-pars.adoc[tag=update-bucket-warning]
 
 ////
 Here is the list of parameters available:
@@ -85,7 +85,7 @@ include::devguide:example$go/provisioning-resources-buckets.go[tag=removeBucket]
 [#go-flushing]
 == Flushing Buckets
 
-include::6.5@sdk:shared:partial$flush-info-pars.adoc[tag=flush-intro]
+include::7.0@sdk:shared:partial$flush-info-pars.adoc[tag=flush-intro]
 
 You can flush a bucket in the SDK by using the `FlushBucketOptions` -- see the https://docs.couchbase.com/sdk-api/couchbase-java-client/com/couchbase/client/java/manager/bucket/FlushBucketOptions.html[API docs].
 ////
@@ -163,7 +163,7 @@ For those occasions when you do, please see the relevant API docs:
 
 == View Management
 
-include::6.5@sdk:shared:partial$flush-info-pars.adoc[tag=view-management]
+include::7.0@sdk:shared:partial$flush-info-pars.adoc[tag=view-management]
 
 In the SDK, design documents are represented by the `DesignDocument` and `View` structs.
 All operations on design documents are performed on the `ViewIndexManager` instance:
@@ -181,7 +181,7 @@ The following example upserts a design document with two views:
 include::devguide:example$go/provisioning-resources-views.go[tag=createView]
 ----
 
-include::6.5@sdk:shared:partial$flush-info-pars.adoc[tag=one-view-update-warning]
+include::7.0@sdk:shared:partial$flush-info-pars.adoc[tag=one-view-update-warning]
 
 Note the use of `DesignDocumentNamespaceDevelopment`, the other option is `DesignDocumentNamespaceProduction`.
 This parameter specifies whether the design document should be created as development, or as production -- with the former running over only a small fraction of the documents.

--- a/modules/howtos/pages/sdk-authentication.adoc
+++ b/modules/howtos/pages/sdk-authentication.adoc
@@ -36,9 +36,9 @@ include::example$Auth.java[tag=rbac-pwd,indent=0]
 
 In this example, the `PLAIN` authentication mechanism is enabled as well, which is needed if LDAP is enabled on the server side and no TLS encrypted connection is used.
 
-include::6.5@sdk:shared:partial$auth-overview.adoc[tag=rbac]
+include::7.0@sdk:shared:partial$auth-overview.adoc[tag=rbac]
 
-include::6.5@sdk:shared:partial$auth-overview.adoc[tag=cert-auth]
+include::7.0@sdk:shared:partial$auth-overview.adoc[tag=cert-auth]
 
 
 == Authenticating the Java Client by Certificate
@@ -54,7 +54,7 @@ include::example$Auth.java[tag=certauth,indent=0]
 
 In addition to providing the initialized `KeyStore` directly, the `CertificateAuthenticator` can also be initialized from a key store path, a key directly or a `KeyManagerFactory` for maximum flexibility. Please see the API documentation for the `CertificateAuthenticator` for more details.
 
-include::6.5@sdk:shared:partial$auth-overview.adoc[tag=ldap]
+include::7.0@sdk:shared:partial$auth-overview.adoc[tag=ldap]
 
 [source,java]
 ----

--- a/modules/howtos/pages/slow-operations-logging.adoc
+++ b/modules/howtos/pages/slow-operations-logging.adoc
@@ -1,7 +1,6 @@
 = Slow Operations Logging
 :description: Tracing information on slow operations can be found in the logs as threshold logging, orphan logging, and other span metrics.
 :page-topic-type: howto
-:page-aliases: ROOT:slow-operations-logging.adoc
 
 [abstract]
 {description}

--- a/modules/howtos/pages/slow-operations-logging.adoc
+++ b/modules/howtos/pages/slow-operations-logging.adoc
@@ -1,7 +1,7 @@
 = Slow Operations Logging
 :description: Tracing information on slow operations can be found in the logs as threshold logging, orphan logging, and other span metrics.
 :page-topic-type: howto
-// :page-aliases: ROOT:
+:page-aliases: ROOT:slow-operations-logging.adoc
 
 [abstract]
 {description}

--- a/modules/howtos/pages/subdocument-operations.adoc
+++ b/modules/howtos/pages/subdocument-operations.adoc
@@ -4,7 +4,7 @@
 :page-topic-type: howto
 include::project-docs:partial$attributes.adoc[]
 :lang: Java
-:version: 3.0.10
+:version: 3.2.0
 :page-aliases: ROOT:sdk-xattr-example.adoc
 
 
@@ -28,36 +28,45 @@ In order to use Sub-Document operations you need to specify a _path_ indicating 
 The _path_ follows xref:#path-syntax[Path syntax].
 Considering the document:
 
-.customer123.json
+.hotel_1368.json
 [source,json]
 ----
 {
-  "name": "Douglas Reynholm",
-  "email": "douglas@reynholmindustries.com",
-  "addresses": {
-    "billing": {
-      "line1": "123 Any Street",
-      "line2": "Anytown",
-      "country": "United Kingdom"
-    },
-    "delivery": {
-      "line1": "123 Any Street",
-      "line2": "Anytown",
-      "country": "United Kingdom"
-    }
+  "title": "Ayr (Scotland)",
+  "name": "Enterkine House Hotel",
+  "address": "by Annbank. Ayrshire",
+  "directions": "5 miles off A77, follow B742 to Mossblown then Annbank",
+  "phone": "+44 1292 520580",
+  "tollfree": null,
+  "email": null,
+  "fax": null,
+  "url": "http://www.enterkine.com",
+  "checkin": "2.00pm",
+  "checkout": "11am",
+  "price": "from £100",
+  "geo": {
+    "lat": 55.48034590743372,
+    "lon": -4.51612114906311,
+    "accuracy": "ROOFTOP"
   },
-  "purchases": {
-    "complete": [
-      339, 976, 442, 666
-    ],
-    "abandoned": [
-      157, 42, 999
-    ]
-  }
+  "type": "hotel",
+  "id": 1368,
+  "country": "United Kingdom",
+  "city": "South Ayrshire",
+  "state": null,
+  "reviews": [],
+  "public_likes": ["Georgette Rutherford V", "Ms. Devante Bruen", "Anderson Schmidt", "Mr. Kareem Harvey", "Tessie Shields", "Floyd Bradtke III", "Maurice McDermott", "Michel Franecki", "Laila Ernser"],
+  "vacancy": true,
+  "description": "four star country house hotel situated in 350 acres of woodland estate yet only 10 mins from Prestwick ,Ayr and Troon. Award winning food by Paul Moffat and team",
+  "alias": null,
+  "pets_ok": false,
+  "free_breakfast": true,
+  "free_internet": false,
+  "free_parking": false
 }
 ----
 
-The paths `name`, `addresses.billing.country` and `purchases.complete[0]` are all valid paths.
+The paths `name`, `geo.lat` and `public_likes[0]` are all valid paths.
 
 == Retrieving
 
@@ -310,14 +319,14 @@ include::example$SubDocument.java[tag=cas,indent=0]
 
 == Durability
 
-Couchbase’s xref:concept-docs:durability-replication-failure-considerations.adoc#older-server-versions[traditional 'client verified' durability], using `PersistTo` and `ReplicateTo`, is still available, particularly for talking to Couchbase Server 6.0 and earlier:
+Couchbase’s xref:concept-docs:durability-replication-failure-considerations.adoc#older-server-versions[traditional 'client verified' durability], using `PersistTo` and `ReplicateTo`, is still available, particularly for talking to Couchbase Server 7.0 and earlier:
 
 [source,java]
 ----
 include::example$SubDocument.java[tag=old-durability,indent=0]
 ----
 
-In Couchbase Server 6.5 and up, this is built upon with xref:concept-docs:durability-replication-failure-considerations.adoc#durable-writes[Durable Writes], which uses the concept of majority to indicate the number of configured Data Service nodes to which commitment is required:
+In Couchbase Server 7.0 and up, this is built upon with xref:concept-docs:durability-replication-failure-considerations.adoc#durable-writes[Durable Writes], which uses the concept of majority to indicate the number of configured Data Service nodes to which commitment is required:
 
 [source,java]
 ----
@@ -397,7 +406,7 @@ NOTE: Currently, paths cannot exceed 1024 characters, and cannot be more than 32
 DJSON documents with more than 32 nested layers cannot be parsed, atttempting to do so will result in a`DocumentTooDeepException` exception.
 
 
-include::6.6@sdk:shared:partial$sdk-xattr-overview.adoc[tag=extended_attributes]
+include::7.0@sdk:shared:partial$sdk-xattr-overview.adoc[tag=extended_attributes]
 
 
 [source,java]

--- a/modules/howtos/pages/troubleshooting-cloud-connections.adoc
+++ b/modules/howtos/pages/troubleshooting-cloud-connections.adoc
@@ -1,1 +1,1 @@
-include::6.5@sdk:pages:partial$troubleshooting-cloud-connections.adoc[]
+include::7.0@sdk:pages:partial$troubleshooting-cloud-connections.adoc[]

--- a/modules/howtos/pages/view-queries-with-sdk.adoc
+++ b/modules/howtos/pages/view-queries-with-sdk.adoc
@@ -9,7 +9,7 @@
 
 WARNING: Although still maintained and supported for legacy use, Views date from the earliest days of Couchbase Server development, and as such are rarely the best choice over, say, xref:n1ql-queries-with-sdk.adoc[our Query service] for your application, see xref:concept-docs:data-services.adoc[our guide to choosing the right service].
 
-include::6.6@sdk:shared:partial$views.adoc[tag=views-intro]
+include::7.0@sdk:shared:partial$views.adoc[tag=views-intro]
 
 == Querying Views
 

--- a/modules/howtos/pages/working-with-collections.adoc
+++ b/modules/howtos/pages/working-with-collections.adoc
@@ -1,35 +1,29 @@
 = Working with the  Collections Developer Preview
-:description: Collections is introduced as a Developer Preview feature in Couchbase Server 6.5 & 6.6, and part of the forthcoming Server 7.0.
+:description: Collections is introduced as a Developer Preview feature in Couchbase Server 6.5 & 6.6, and fully supported in Server 7.0.
 :nav-title: Collections DP
 :content-type: howto
 :page-topic-type: howto
+:page-aliases: ROOT:working-with-collections.adoc
 
 [abstract]
 {description}
-The 3.0 API SDKs all work with Collections and Scopes.
+The 3.2 SDK will work with all features of Collections and Scopes.
 As a practical demonstration, we have a collections-enabled version of the Travel Sample application.
 
-The Developer Preview of the upcoming Collections feature in Couchbase Server is fully implemented in the 3.0 API versions of the Couchbase SDKs.
+The Collections feature in Couchbase Server 7.0 is fully implemented in the 3.2 API version of the Couchbase SDK.
 When working with other server versions, the default collection is used from the SDK.
-Here we show how to access individual collections in the Developer Preview version of Couchbase Server 6.6, with a collections-enabled version of our xref:hello-world:sample-application.adoc[Travel Sample application].
-User documents and flight documents are split into user and flight collections.
+Here we show how to access individual collections in Couchbase Server 7.0, with a collections-enabled version of our xref:hello-world:sample-application.adoc[Travel Sample application].
+User and flight documents are split into user and booking collections.
 Something that previously had to be done with key-value references to different types or categories of data.
 
 
 == Travel Sample app -- with Collections
 
-include::6.6@sdk:shared:partial$sample-application.adoc[tag=prereq]
-
-[WARNING]
-====
-Enabling Developer Preview should only be done on a development machine; 
-there is no upgrade path available from a DP-enabled Couchbase Server.
-====
-
+include::7.0@sdk:shared:partial$sample-application.adoc[tag=prereq]
 
 == Preparation
 
-Along with the xref:hello-world:start-using-sdk.adoc[Java SDK 3.1] and Couchbase Server, 
+Along with the xref:hello-world:start-using-sdk.adoc[Java SDK 3.2] and Couchbase Server,
 set up as described above, you will need `git` to fetch the travel sample application code:
 
 [source,console]

--- a/modules/howtos/pages/working-with-collections.adoc
+++ b/modules/howtos/pages/working-with-collections.adoc
@@ -1,9 +1,8 @@
-= Working with the  Collections Developer Preview
+= Working with Collections
 :description: Collections is introduced as a Developer Preview feature in Couchbase Server 6.5 & 6.6, and fully supported in Server 7.0.
-:nav-title: Collections DP
+:nav-title: Collections
 :content-type: howto
 :page-topic-type: howto
-:page-aliases: ROOT:working-with-collections.adoc
 
 [abstract]
 {description}

--- a/modules/project-docs/examples/Migrating.java
+++ b/modules/project-docs/examples/Migrating.java
@@ -37,6 +37,7 @@ import com.couchbase.client.core.error.InvalidArgumentException;
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.Collection;
+import com.couchbase.client.java.Scope;
 import com.couchbase.client.java.analytics.AnalyticsResult;
 import com.couchbase.client.java.codec.RawJsonTranscoder;
 import com.couchbase.client.java.env.ClusterEnvironment;
@@ -133,7 +134,8 @@ public class Migrating {
       // tag::simpleget[]
       Cluster cluster = Cluster.connect("127.0.0.1", "Administrator", "password");
       Bucket bucket = cluster.bucket("travel-sample");
-      Collection collection = bucket.defaultCollection();
+      Scope scope = bucket.scope("inventory");
+      Collection collection = scope.collection("airline");
 
       GetResult getResult = collection.get("airline_10");
 
@@ -143,7 +145,8 @@ public class Migrating {
 
     Cluster cluster = Cluster.connect("127.0.0.1", "Administrator", "password");
     Bucket bucket = cluster.bucket("travel-sample");
-    Collection collection = bucket.defaultCollection();
+    Scope scope = bucket.scope("inventory");
+    Collection collection = scope.collection("airport");
 
     {
       // tag::upsertandget[]
@@ -170,7 +173,7 @@ public class Migrating {
     {
       // tag::querysimple[]
       // SDK 3 simple query
-      QueryResult queryResult = cluster.query("select * from `travel-sample` limit 10");
+      QueryResult queryResult = cluster.query("select * from `travel-sample`.inventory.airport limit 10");
       for (JsonObject value : queryResult.rowsAsObject()) {
         // ...
       }
@@ -180,19 +183,19 @@ public class Migrating {
     {
       // tag::queryparameterized[]
       // SDK 3 named parameters
-      cluster.query("select * from `travel-sample` where type = $type",
-          queryOptions().parameters(JsonObject.create().put("type", "airport")));
+      cluster.query("select * from `travel-sample`.inventory.airport where airportname = $name",
+          queryOptions().parameters(JsonObject.create().put("name", "Calais Dunkerque")));
 
       // SDK 3 positional parameters
-      cluster.query("select * from `travel-sample` where type = $1",
-          queryOptions().parameters(JsonArray.from("airport")));
+      cluster.query("select * from `travel-sample`.inventory.airport where airportname = $1",
+          queryOptions().parameters(JsonArray.from("Calais Dunkerque")));
       // end::queryparameterized[]
     }
 
     {
       // tag::analyticssimple[]
       // SDK 3 simple analytics query
-      AnalyticsResult analyticsResult = cluster.analyticsQuery("select * from airports limit 10");
+      AnalyticsResult analyticsResult = cluster.analyticsQuery("select * from `travel-sample`.inventory.airport limit 10");
       for (JsonObject value : analyticsResult.rowsAsObject()) {
         // ...
       }
@@ -202,12 +205,12 @@ public class Migrating {
     {
       // tag::analyticsparameterized[]
       // SDK 3 named parameters for analytics
-      cluster.analyticsQuery("select * from `huge-dataset` where `type` = $type",
-          analyticsOptions().parameters(JsonObject.create().put("type", "airport")));
+      cluster.analyticsQuery("select * from `travel-sample`.inventory.airport where airportname = $name",
+          analyticsOptions().parameters(JsonObject.create().put("name", "Calais Dunkerque")));
 
       // SDK 3 positional parameters for analytics
-      cluster.analyticsQuery("select * from `huge-dataset` where `type` = $1",
-          analyticsOptions().parameters(JsonArray.from("airport")));
+      cluster.analyticsQuery("select * from `travel-sample`.inventory.airport where airportname = $1",
+          analyticsOptions().parameters(JsonArray.from("Calais Dunkerque")));
       // end::analyticsparameterized[]
     }
 
@@ -215,7 +218,7 @@ public class Migrating {
       // tag::searchsimple[]
       // SDK 3 search query
       SearchResult searchResult = cluster.searchQuery("travel-sample-index", SearchQuery.queryString("swanky"),
-          searchOptions().timeout(Duration.ofSeconds(2)).limit(5).fields("description", "type", "country"));
+          searchOptions().timeout(Duration.ofSeconds(2)).limit(5).fields("description", "type", "city"));
       for (SearchRow row : searchResult.rows()) {
         // ...
       }

--- a/modules/project-docs/examples/MigratingSDKCodeTo3n.java
+++ b/modules/project-docs/examples/MigratingSDKCodeTo3n.java
@@ -44,8 +44,8 @@ public class MigratingSDKCodeTo3n {
     cluster = Cluster.connect(connectionString,
         ClusterOptions.clusterOptions(username, password).environment(environment));
     bucket = cluster.bucket(bucketName);
-    scope = bucket.defaultScope();
-    collection = bucket.defaultCollection();
+    scope = bucket.scope("inventory");
+    collection = scope.collection("airline");
   }
 
   public void migrating_sdk_code_to_3_n_1() throws Exception {

--- a/modules/project-docs/examples/Transactions.java
+++ b/modules/project-docs/examples/Transactions.java
@@ -23,6 +23,7 @@ import java.util.logging.Logger;
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.Collection;
+import com.couchbase.client.java.Scope;
 import com.couchbase.client.java.json.JsonObject;
 import com.couchbase.client.java.kv.GetResult;
 import com.couchbase.transactions.TransactionResult;
@@ -34,8 +35,9 @@ import com.couchbase.transactions.error.TransactionFailed;
 
 class TransactionsDemo {
     private static final Cluster cluster = Cluster.connect("localhost", "Administrator", "password");
-    private static final Bucket bucket = cluster.bucket("default");
-    private static final Collection collection = bucket.defaultCollection();
+    private static final Bucket bucket = cluster.bucket("travel-sample");
+    private static final Scope scope = bucket.scope("inventory");
+    private static final Collection collection = scope.collection("airport");
     private static final Transactions transactions = Transactions.create(cluster);
 
     void demo_1_0_1_changes() {
@@ -88,7 +90,7 @@ class TransactionsDemo {
         // tag::query-basic[]
         TransactionResult result = transactions.run((ctx) -> {
             ctx.insert(collection, "doc-a", aContent);
-            ctx.query("INSERT INTO `default` VALUES ('doc-b', " + bContent + ")");
+            ctx.query("INSERT INTO `travel-sample`.inventory.airport VALUES ('doc-b', " + bContent + ")");
             ctx.insert(collection, "doc-c", cContent);
         });
         // end::query-basic[]

--- a/modules/project-docs/pages/compatibility.adoc
+++ b/modules/project-docs/pages/compatibility.adoc
@@ -7,7 +7,7 @@ Plus notes on Cloud, networks, and AWS Lambda.
 [abstract]
 {description}
 
-The 3.0 SDK requires Java 8 or later to be installed, earlier versions will not work. 
+The 3.2 SDK requires Java 8 or later to be installed, earlier versions will not work.
 _Java 11 is recommended_, which has various enhancements like lambda local variable type inference, profiling tools, and updated security features. 
 Most of the flavors available will do, although we may only provide support for OpenJDK and Oracle JDK going forward. 
 The Java SDK _has not been tested (and is not supported on) Java 12 or later_.

--- a/modules/project-docs/pages/distributed-transactions-java-release-notes.adoc
+++ b/modules/project-docs/pages/distributed-transactions-java-release-notes.adoc
@@ -12,7 +12,7 @@ This page features the release notes for that library -- for release notes, down
 
 == Using Distributed Transactions
 
-See the xref:6.5@server:learn:data/transactions.adoc[Distributed ACID Transactions concept doc] in the server documentation for details of how Couchbase implements transactions.
+See the xref:7.0@server:learn:data/transactions.adoc[Distributed ACID Transactions concept doc] in the server documentation for details of how Couchbase implements transactions.
 The xref:howtos:distributed-acid-transactions-from-the-sdk.adoc[Distributed Transactions HOWTO doc] walks you through all aspects of working with Distributed Transactions.
 
 

--- a/modules/project-docs/pages/get-involved.adoc
+++ b/modules/project-docs/pages/get-involved.adoc
@@ -7,4 +7,4 @@ Couchbase welcomes community contributions to the Java SDK.
 The https://github.com/couchbase/couchbase-java-client[Java SDK source code^] is available on GitHub.
 Please see the https://github.com/couchbase/couchbase-java-client/blob/master/CONTRIBUTING.md[CONTRIBUTING^] file for further information.
 
-include::6.5@sdk:shared:partial$contrib.adoc[tag=contrib]
+include::7.0@sdk:shared:partial$contrib.adoc[tag=contrib]

--- a/modules/project-docs/pages/metadoc-about-these-sdk-docs.adoc
+++ b/modules/project-docs/pages/metadoc-about-these-sdk-docs.adoc
@@ -1,1 +1,1 @@
-include::6.5@sdk:pages:partial$about.adoc[]
+include::7.0@sdk:pages:partial$about.adoc[]

--- a/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
+++ b/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
@@ -1,7 +1,7 @@
 = Migrating from SDK2 to SDK3 API
-:description: The 3.0 API breaks the existing 2.0 APIs in order to provide a number of improvements. \
+:description: The 3.x API breaks the existing 2.x APIs in order to provide a number of improvements. \
 Collections and Scopes are introduced.
-:nav-title: Migrating to Java SDK 3.0 API
+:nav-title: Migrating to Java SDK 3.x API
 :page-topic-type: concept
 :page-aliases: ROOT:migrate
 
@@ -12,10 +12,10 @@ Retry behaviour is more proactive, and lazy bootstrapping moves all error handli
 Individual behavior changes across services are explained here.
 
 
-include::6.5@sdk:shared:partial$migration.adoc[tag=intro]
+include::7.0@sdk:shared:partial$migration.adoc[tag=intro]
 
 
-include::6.5@sdk:shared:partial$migration.adoc[tag=terms]
+include::7.0@sdk:shared:partial$migration.adoc[tag=terms]
 
 As an example here is a KeyValue document fetch:
 
@@ -31,13 +31,13 @@ Compare this to a N1QL query:
 include::example$MigratingSDKCodeTo3n.java[tag=migrating_sdk_code_to_3_n_2,indent=0]
 ----
 
-include::6.5@sdk:shared:partial$migration.adoc[tag=terms2]
+include::7.0@sdk:shared:partial$migration.adoc[tag=terms2]
 
 
-include::6.5@sdk:shared:partial$migration.adoc[tag=new]
+include::7.0@sdk:shared:partial$migration.adoc[tag=new]
 
 
-include::6.5@sdk:shared:partial$migration.adoc[tag=lang]
+include::7.0@sdk:shared:partial$migration.adoc[tag=lang]
 
 ==  Installation and Configuration
 
@@ -168,7 +168,7 @@ Here is the SDK 3 equivalent:
 include::example$Migrating.java[tag=simpleget,indent=0]
 ----
 
-`Collections` will be generally available with an upcoming Couchbase Server release, but the SDK already encodes it in its API to be future-proof.
+`Collections` are generally available from Couchbase Server version 7.0, which the SDK is already compatible with.
 If you are using a Couchbase Server version which does not support `Collections`, always use the `defaultCollection()` method to access the KV API; it will map to the full bucket.
 
 IMPORTANT: You'll notice that `bucket(String)` returns immediately, even if the bucket resources are not completely opened. 
@@ -179,7 +179,7 @@ Please check the logs to see the cause of the timeout (in this case, you'll see 
 
 Also note, you will now find Query, Search, and Analytics at the `Cluster` level.
 This is where they logically belong.
-If you are using Couchbase Server 6.5 or later, you will be able to perform cluster-level queries even if no bucket is open. 
+If you are using Couchbase Server 6.5 or later, you will be able to perform cluster-level queries even if no bucket is open.
 If you are using an earlier version of the cluster you must open at least one bucket, otherwise cluster-level queries will fail.
 
 
@@ -500,8 +500,8 @@ Not only does it throw a `CouchbaseException`, it also tries to map it to a spec
 
 ==== DSL Deprecation
 
-The fluent API feature in SDK 2 was found not to scale well for larger queries, nor for SQL++.
-For these reasons it is not amongst the features carried over to SDK 3.0.
+The fluent API feature in SDK 2.x was found not to scale well for larger queries, nor for SQL++.
+For these reasons it is not amongst the features carried over to SDK 3.x.
 
 In most cases, a simple string statement is the best replacement.
 

--- a/modules/project-docs/pages/third-party-integrations.adoc
+++ b/modules/project-docs/pages/third-party-integrations.adoc
@@ -2,24 +2,24 @@
 :description: The Couchbase Java SDK is often used with unofficial and third party tools and applications to integrate into broader language and platform ecosystems, and across data lakes in heterogeneous environments.
 :navtitle: Integrations
 :page-topic-type: project-doc
-:page-aliases: 
+:page-aliases: ROOT:third-party-integrations.adoc
 
 [abstract]
 
 {description}
 
 
-include::6.6@sdk:shared:partial$integrations.adoc[tag=intro]
+include::7.0@sdk:shared:partial$integrations.adoc[tag=intro]
 
 
-include::6.6@sdk:shared:partial$integrations.adoc[tag=official]
+include::7.0@sdk:shared:partial$integrations.adoc[tag=official]
 
 The Couchbase Java SDK is a first class citizen in the https://spring.io/projects/spring-data-couchbase[Spring Data] world, and there are many examples of using the SDK with https://blog.couchbase.com/couchbase-spring-boot-spring-data/[Spring Boot] and Spring Data (and Spring Data JPA).
 
 Couchbase also supports integrating with xref:2.4@spark-connector:ROOT:java-api.adoc[Spark].
 
 
-include::6.6@sdk:shared:partial$integrations.adoc[tag=important]
+include::7.0@sdk:shared:partial$integrations.adoc[tag=important]
 
 Many dataflow tools integrate with Couchbase, including https://github.com/apache/nifi/tree/main/nifi-nar-bundles/nifi-couchbase-bundle[Apache NiFi], 
 https://wildfly-extras.github.io/wildfly-camel/#_camel_couchbase[Apache Camel],
@@ -27,7 +27,7 @@ and https://github.com/couchbaselabs/flink-connector-couchbase[Apache Flink].
 Why not make development easier, and use https://blog.couchbase.com/create-a-zeppelin-interpreter-for-couchbase/[Apache Zeppelin]?
 
 
-include::6.6@sdk:shared:partial$integrations.adoc[tag=other]
+include::7.0@sdk:shared:partial$integrations.adoc[tag=other]
 
 https://github.com/differentway/couchmove[Couchmove] is an open-source Java migration tool for Couchbase, inspired by Flyway.
 It can help you "track, manage and apply changes, in your Couchbase buckets."

--- a/modules/project-docs/pages/third-party-integrations.adoc
+++ b/modules/project-docs/pages/third-party-integrations.adoc
@@ -2,7 +2,6 @@
 :description: The Couchbase Java SDK is often used with unofficial and third party tools and applications to integrate into broader language and platform ecosystems, and across data lakes in heterogeneous environments.
 :navtitle: Integrations
 :page-topic-type: project-doc
-:page-aliases: ROOT:third-party-integrations.adoc
 
 [abstract]
 

--- a/modules/ref/examples/ClientSettingsExample.java
+++ b/modules/ref/examples/ClientSettingsExample.java
@@ -48,8 +48,8 @@ public class ClientSettingsExample {
     cluster = Cluster.connect(connectionString,
         ClusterOptions.clusterOptions(username, password).environment(environment));
     bucket = cluster.bucket(bucketName);
-    scope = bucket.defaultScope();
-    collection = bucket.defaultCollection();
+    scope = bucket.scope("inventory");
+    collection = scope.collection("airport");
   }
 
   public void client_settings_1() throws Exception {

--- a/modules/ref/examples/DataStructuresExample.java
+++ b/modules/ref/examples/DataStructuresExample.java
@@ -56,8 +56,8 @@ public class DataStructuresExample {
     cluster = Cluster.connect(connectionString,
         ClusterOptions.clusterOptions(username, password).environment(environment));
     bucket = cluster.bucket(bucketName);
-    scope = bucket.defaultScope();
-    collection = bucket.defaultCollection();
+    scope = bucket.scope("tenant_agent_00");
+    collection = scope.collection("users");
     // tag::data_structures_0[]
     map = new CouchbaseMap("mapId", collection, String.class, MapOptions.mapOptions());
     arrayList = new CouchbaseArrayList("arrayListId", collection, String.class, ArrayListOptions.arrayListOptions());

--- a/modules/ref/pages/client-settings.adoc
+++ b/modules/ref/pages/client-settings.adoc
@@ -610,4 +610,4 @@ You are responsible for stopping it after it is no longer needed.
 
 // section on wide area network support
 
-include::6.5@sdk:shared:partial$client-settings-wide-network.adoc[]
+include::7.0@sdk:shared:partial$client-settings-wide-network.adoc[]

--- a/modules/ref/pages/error-codes.adoc
+++ b/modules/ref/pages/error-codes.adoc
@@ -6,39 +6,39 @@
 [abstract]
 {description}
 
-include::6.5@sdk:shared:partial$error-ref.adoc[tag=intro]
+include::7.0@sdk:shared:partial$error-ref.adoc[tag=intro]
 
 == Shared Error Definitions 
 
-include::6.5@sdk:shared:partial$error-ref.adoc[tag=shared]
+include::7.0@sdk:shared:partial$error-ref.adoc[tag=shared]
 
 
 == KeyValue Error Definitions
-include::6.5@sdk:shared:partial$error-ref.adoc[tag=kv]
+include::7.0@sdk:shared:partial$error-ref.adoc[tag=kv]
 
 
 == Query Error Definitions
-include::6.5@sdk:shared:partial$error-ref.adoc[tag=query]
+include::7.0@sdk:shared:partial$error-ref.adoc[tag=query]
 
 
 == Analytics Error Definitions
-include::6.5@sdk:shared:partial$error-ref.adoc[tag=analytics]
+include::7.0@sdk:shared:partial$error-ref.adoc[tag=analytics]
 
 
 == Search Error Definition
-include::6.5@sdk:shared:partial$error-ref.adoc[tag=search]
+include::7.0@sdk:shared:partial$error-ref.adoc[tag=search]
 
 
 == View Error Definitions
-include::6.5@sdk:shared:partial$error-ref.adoc[tag=views]
+include::7.0@sdk:shared:partial$error-ref.adoc[tag=views]
 
 
 == Management API Error Definitions
-include::6.5@sdk:shared:partial$error-ref.adoc[tag=mgmnt]
+include::7.0@sdk:shared:partial$error-ref.adoc[tag=mgmnt]
 
 
 == Field-Level Encryption Error Definitions
-include::6.5@sdk:shared:partial$error-ref.adoc[tag=fle]
+include::7.0@sdk:shared:partial$error-ref.adoc[tag=fle]
 
 
 ////
@@ -52,7 +52,7 @@ This range is reserved for sdk-specific error codes which are not standardized, 
 
 
 == Connecting to Cloud
-include::6.5@sdk:shared:partial$error-ref.adoc[tag=cloud]
+include::7.0@sdk:shared:partial$error-ref.adoc[tag=cloud]
 
 
 .DNS SRV lookup failed

--- a/modules/ref/pages/glossary.adoc
+++ b/modules/ref/pages/glossary.adoc
@@ -1,1 +1,1 @@
-include::6.5@sdk:pages:partial$glossary.adoc[]
+include::7.0@sdk:pages:partial$glossary.adoc[]

--- a/modules/ref/pages/travel-app-data-model.adoc
+++ b/modules/ref/pages/travel-app-data-model.adoc
@@ -1,4 +1,4 @@
 = Travel App Data Model
 :page-topic-type: reference
 
-include::6.5@sdk:pages:partial$travel-app-data-model.adoc[tag=model]
+include::7.0@sdk:pages:partial$travel-app-data-model.adoc[tag=model]

--- a/modules/test/scripts/init-couchbase/init-buckets.sh
+++ b/modules/test/scripts/init-couchbase/init-buckets.sh
@@ -30,6 +30,13 @@ echo "cbimport travel-sample..."
     -b travel-sample \
     -d file:///opt/couchbase/samples/travel-sample.zip
 
+echo "create airports dataset"
+curl --fail -v -u ${CB_USER}:${CB_PSWD} -H "Content-Type: application/json" -d '{
+    "statement": "CREATE DATASET airports ON `travel-sample` WHERE `type`=\"airport\";",
+    "pretty":true,
+    "client_context_id":"test"
+}' http://${CB_HOST}:8095/analytics/service
+
 echo "create scoped airport dataset"
 curl --fail -v -u ${CB_USER}:${CB_PSWD} -H "Content-Type: application/json" -d '{
     "statement": "ALTER COLLECTION `travel-sample`.`inventory`.`airport` ENABLE ANALYTICS;",

--- a/modules/test/scripts/init-couchbase/init-buckets.sh
+++ b/modules/test/scripts/init-couchbase/init-buckets.sh
@@ -30,13 +30,6 @@ echo "cbimport travel-sample..."
     -b travel-sample \
     -d file:///opt/couchbase/samples/travel-sample.zip
 
-echo "create airports dataset"
-curl --fail -v -u ${CB_USER}:${CB_PSWD} -H "Content-Type: application/json" -d '{
-    "statement": "CREATE DATASET airports ON `travel-sample` WHERE `type`=\"airport\";",
-    "pretty":true,
-    "client_context_id":"test"
-}' http://${CB_HOST}:8095/analytics/service
-
 echo "create scoped airport dataset"
 curl --fail -v -u ${CB_USER}:${CB_PSWD} -H "Content-Type: application/json" -d '{
     "statement": "ALTER COLLECTION `travel-sample`.`inventory`.`airport` ENABLE ANALYTICS;",

--- a/modules/test/scripts/init-couchbase/travel-sample-index.json
+++ b/modules/test/scripts/init-couchbase/travel-sample-index.json
@@ -1,70 +1,107 @@
 {
-  "name": "travel-sample-index",
   "type": "fulltext-index",
+  "name": "travel-sample-index",
+  "sourceType": "gocbcore",
+  "sourceName": "travel-sample",
+  "planParams": {
+    "maxPartitionsPerPIndex": 1024,
+    "indexPartitions": 1
+  },
   "params": {
     "doc_config": {
       "docid_prefix_delim": "",
       "docid_regexp": "",
-      "mode": "type_field",
+      "mode": "scope.collection.type_field",
       "type_field": "type"
     },
     "mapping": {
+      "analysis": {},
       "default_analyzer": "standard",
       "default_datetime_parser": "dateTimeOptional",
       "default_field": "_all",
       "default_mapping": {
-        "dynamic": false,
-        "enabled": true,
-        "properties": {
-          "description": {
-            "enabled": true,
-            "dynamic": false,
-            "fields": [
-              {
-                "docvalues": true,
-                "include_in_all": true,
-                "include_term_vectors": true,
-                "index": true,
-                "name": "description",
-                "store": true,
-                "type": "text"
-              }
-            ]
-          },
-          "type": {
-            "enabled": true,
-            "dynamic": false,
-            "fields": [
-              {
-                "docvalues": true,
-                "include_in_all": true,
-                "include_term_vectors": true,
-                "index": true,
-                "name": "type",
-                "store": true,
-                "type": "text"
-              }
-            ]
-          }
-        }
+        "dynamic": true,
+        "enabled": false
       },
       "default_type": "_default",
-      "docvalues_dynamic": true,
+      "docvalues_dynamic": false,
       "index_dynamic": true,
       "store_dynamic": false,
-      "type_field": "_type"
+      "type_field": "_type",
+      "types": {
+        "inventory.airline": {
+          "dynamic": true,
+          "enabled": true
+        },
+        "inventory.airport": {
+          "dynamic": true,
+          "enabled": true
+        },
+        "inventory.hotel": {
+          "dynamic": false,
+          "enabled": true,
+          "properties": {
+            "city": {
+              "dynamic": false,
+              "enabled": true,
+              "fields": [
+                {
+                  "docvalues": true,
+                  "include_in_all": true,
+                  "include_term_vectors": true,
+                  "index": true,
+                  "name": "city",
+                  "store": true,
+                  "type": "text"
+                }
+              ]
+            },
+            "description": {
+              "dynamic": false,
+              "enabled": true,
+              "fields": [
+                {
+                  "docvalues": true,
+                  "include_in_all": true,
+                  "include_term_vectors": true,
+                  "index": true,
+                  "name": "description",
+                  "store": true,
+                  "type": "text"
+                }
+              ]
+            },
+            "type": {
+              "dynamic": false,
+              "enabled": true,
+              "fields": [
+                {
+                  "docvalues": true,
+                  "include_in_all": true,
+                  "include_term_vectors": true,
+                  "index": true,
+                  "name": "type",
+                  "store": true,
+                  "type": "text"
+                }
+              ]
+            }
+          }
+        },
+        "inventory.landmark": {
+          "dynamic": true,
+          "enabled": true
+        },
+        "inventory.route": {
+          "dynamic": true,
+          "enabled": true
+        }
+      }
     },
     "store": {
       "indexType": "scorch",
       "segmentVersion": 15
     }
   },
-  "sourceType": "gocbcore",
-  "sourceName": "travel-sample",
-  "sourceParams": {},
-  "planParams": {
-    "maxPartitionsPerPIndex": 1024,
-    "indexPartitions": 1,
-    "numReplicas": 0
-  }
+  "sourceParams": {}
 }

--- a/modules/test/test-concept-docs.bats
+++ b/modules/test/test-concept-docs.bats
@@ -1,0 +1,38 @@
+#!./test/libs/bats/bin/bats
+
+load 'test/test_helper.bash'
+
+@test "[concept-docs] - BucketsAndClustersExample.java" {
+    runExample BucketsAndClustersExample
+    assert_success
+}
+
+@test "[concept-docs] - CollectionsExample.java" {
+    runExample CollectionsExample
+    assert_success
+}
+
+@test "[concept-docs] - CompressionExample.java" {
+    runExample CompressionExample
+    assert_success
+}
+
+@test "[concept-docs] - DataModelExample.java" {
+    runExample DataModelExample
+    assert_success
+}
+
+@test "[concept-docs] - HealthCheckConcepts.java" {
+    runExample HealthCheckConcepts
+    assert_success
+}
+
+@test "[concept-docs] - N1qlQueryExample.java" {
+    runExample N1qlQueryExample
+    assert_success
+}
+
+@test "[concept-docs] - XattrExample.java" {
+    runExample XattrExample
+    assert_success
+}

--- a/modules/test/test-hello-world.bats
+++ b/modules/test/test-hello-world.bats
@@ -13,3 +13,9 @@ load 'test/test_helper.bash'
     assert_output --partial "mike"
     assert_output --partial "[{\"greeting\":\"Hello World\"}]"
 }
+
+@test "[hello-world] - Overview.java" {
+    runExample Overview
+    assert_success
+    assert_output --partial "RESULT: bar"
+}


### PR DESCRIPTION
[DOC-7867](https://issues.couchbase.com/browse/DOC-7867), [JCBC-1755](https://issues.couchbase.com/browse/JCBC-1755)

This PR will:

* Update all sample code to use named scopes and collections instead of defaults.
* Remove any mentions of Developer Preview
* Update Antora references of server 6.5/6.6 to 7.0
* Update references of SDK 3.1 to 3.2 where necessary.
* Add missing bats tests for `concept-docs` examples (I had totally missed these for some reason 😞)

Please note because of how big the change is, I've split the commits by doc folder so that you can look at each change separately.

The final commit is simply updating the github workflow files with the 3.2 branch so automation can run.

**Note**: The code sample tests will fail as we are using named scopes and collections for everything now, which we expect since the SDK is not compatible with the official server 7.0-beta image. I have tested them locally and they do pass, so once merged they will also run against the latest internal server build and should go green then.