### PR TITLE
Remove outstanding Developer Preview references

### DIFF
--- a/modules/howtos/examples/Metrics.java
+++ b/modules/howtos/examples/Metrics.java
@@ -15,13 +15,6 @@ public class Metrics {
   public static void main(String... args) throws Exception {
 
     {
-      // tag::metrics-enable[]
-      CoreEnvironment environment = CoreEnvironment.builder()
-          .aggregatingMeterConfig(AggregatingMeterConfig.enabled(true)).build();
-      // end::metrics-enable[]
-    }
-
-    {
       // tag::metrics-enable-custom[]
       CoreEnvironment environment = CoreEnvironment.builder()
           .aggregatingMeterConfig(AggregatingMeterConfig.enabled(true).emitInterval(Duration.ofSeconds(30))).build();

--- a/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
+++ b/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
@@ -393,9 +393,8 @@ include::example$TransactionsExample.java[tag=full-logging,indent=0]
 
 
 == Tracing
-[.status]#Developer Preview#
 
-The 1.1.6 release introduces support, at a Developer Preview level, for OpenTelemetry and OpenTracing.
+The 1.1.6 release introduces support for OpenTelemetry and OpenTracing.
 
 If the underlying Couchbase Java SDK is configured for OpenTelemetry or OpenTracing, then transaction spans will now be output automatically.
 

--- a/modules/howtos/pages/observability-metrics.adoc
+++ b/modules/howtos/pages/observability-metrics.adoc
@@ -1,6 +1,5 @@
 = Observability Metrics Reporting
 :description: Individual request tracing presents a very specific (though isolated) view of the system.
-:page-status: Developer Preview
 :page-topic-type: howto
 
 [abstract]
@@ -22,15 +21,8 @@ Right now only the first category is implemented by the SDK, more are planned.
 
 
 == The Default AggregatingMeter
-[.status]#Developer Preview#
 
 The default implementation aggregates and logs request and response metrics.
-Since the feature is in developer preview, you need to manually enable it on the environment:
-
-[source,java]
-----
-include::example$Metrics.java[tag=metrics-enable,indent=0]
-----
 
 By default the metrics will be emitted every 10 minutes, but you can customize the emit interval as well:
 
@@ -93,7 +85,6 @@ The following table shows the currently available properties:
 
 
 == OpenTelemetry Integration
-[.status]#Developer Preview#
 
 The SDK supports plugging in any `OpenTelemetry` metrics consumer instead of using the default `AggregatingMeter`.
 To do this, first you need to add an additional dependency to your application:
@@ -145,7 +136,6 @@ Each metric contains tags that allow you to group them in different ways, includ
 
 
 == Micrometer Integration
-[.status]#Developer Preview#
 
 In addition to OpenTelemetry, we also provide a module so you can hook up the SDK metrics to Micrometer. 
 

--- a/modules/howtos/pages/observability-tracing.adoc
+++ b/modules/howtos/pages/observability-tracing.adoc
@@ -69,7 +69,6 @@ More information will be provided as we get closer to stabilization.
 
 
 == OpenTelemetry Integration
-[.status]#Developer Preview#
 
 The built-in tracer is great if you do not have a centralized monitoring system, but if you already plug into the OpenTelemetry ecosystem we want to make sure to provide first-class support.
 
@@ -132,7 +131,6 @@ GetResult result = collection.get(
 
 
 == OpenTracing Integration
-[.status]#Developer Preview#
 
 In addition to OpenTelemetry, we also provide support for OpenTracing for legacy systems which have not yet migrated to OpenTelemetry. 
 Note that we still recommend to migrate eventually since OpenTracing has been sunsetted.

--- a/modules/howtos/pages/provisioning-cluster-resources.adoc
+++ b/modules/howtos/pages/provisioning-cluster-resources.adoc
@@ -99,7 +99,6 @@ The `Flush` operation may fail if the bucket does not have flush enabled, in tha
 
 
 == Collection Management
-[.status]#Developer Preview#
 
 The CollectionManager interface may be used to create and delete scopes and collections from the Couchbase cluster.
 It is instantiated through the `Bucket.collections()` method.

--- a/modules/howtos/pages/sdk-authentication.adoc
+++ b/modules/howtos/pages/sdk-authentication.adoc
@@ -43,7 +43,7 @@ include::7.0@sdk:shared:partial$auth-overview.adoc[tag=cert-auth]
 
 == Authenticating the Java Client by Certificate
 
-For sample procedures whereby certificates can be generated and deployed, see xref:6.5@server:manage:manage-security/manage-certificates.adoc[Manage Certificates].
+For sample procedures whereby certificates can be generated and deployed, see xref:7.0@server:manage:manage-security/manage-certificates.adoc[Manage Certificates].
 The rest of this document assumes that the processes there, or something similar, have been followed.
 That is, a cluster certificate has been created and installed on the server, a client certificate has been created, and it is stored in a JVM keystore along with the cluster's certificate.
 


### PR DESCRIPTION
Removes any outstanding mentions of `Developer Preview` and `[.status]#Developer Preview#` tags.