### PR TITLE
Minor 3.2 fixes

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -17,7 +17,7 @@
 * xref:howtos:concurrent-document-mutations.adoc[Concurrent Document Mutations]
 * xref:howtos:distributed-acid-transactions-from-the-sdk.adoc[Distributed ACID Transactions]
 * xref:howtos:transcoders-nonjson.adoc[Transcoders & Non-JSON]
-* xref:howtos:working-with-collections.adoc[Working with Collections DP]
+* xref:howtos:working-with-collections.adoc[Working with Collections]
 
 .Managing Couchbase
 * xref:howtos:managing-connections.adoc[Managing Connections]

--- a/modules/concept-docs/examples/CollectionsExample.java
+++ b/modules/concept-docs/examples/CollectionsExample.java
@@ -46,7 +46,7 @@ public class CollectionsExample {
   private void createCollection(String name) {
     collectionMgr = bucket.collections();
 
-    // create flights collection in default scope
+    // create a collection in the default scope
     CollectionSpec spec = CollectionSpec.create(name, "_default");
     collectionMgr.createCollection(spec);
   }

--- a/modules/concept-docs/examples/DocumentsExample.java
+++ b/modules/concept-docs/examples/DocumentsExample.java
@@ -1,0 +1,81 @@
+import com.couchbase.client.java.Bucket;
+import com.couchbase.client.java.Cluster;
+import com.couchbase.client.java.Collection;
+import com.couchbase.client.java.Scope;
+import com.couchbase.client.java.kv.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class DocumentsExample {
+
+    public static void main(String[] args) {
+
+        Cluster cluster = Cluster.connect("localhost", "Administrator", "password");
+
+        Bucket bucket = cluster.bucket("travel-sample");
+        Scope scope = bucket.scope("inventory");
+        Collection collection = scope.collection("airline");
+
+        {
+            System.out.println("Example - [mutate-in]");
+            // tag::mutate-in[]
+            List<MutateInSpec> spec = Collections.singletonList(
+                    MutateInSpec.upsert("msrp", 18.00)
+            );
+            collection.mutateIn("airline_10", spec);
+            // end::mutate-in[]
+        }
+
+        {
+            System.out.println("Example - [lookup-in]");
+            // tag::lookup-in[]
+            Collection usersCollection = bucket.scope("tenant_agent_00").collection("users");
+            List<LookupInSpec> spec = Arrays.asList(
+                    LookupInSpec.get("credit_cards[0].type"),
+                    LookupInSpec.get("credit_cards[0].expiration")
+            );
+            usersCollection.lookupIn("1", spec);
+            // end::lookup-in[]
+        }
+
+        {
+            System.out.println("Example - [counters]");
+            // tag::counters[]
+            String counterDocId = "counter-doc";
+            // Increment by 1, creating doc if needed.
+            // By using `.incrementOptions().initial(1)` we set the starting count(non-negative) to 1 if the document needs to be created.
+            // If it already exists, the count will increase by 1.
+            collection.binary().increment(counterDocId, IncrementOptions.incrementOptions().initial(1));
+            // Decrement by 1
+            collection.binary().decrement(counterDocId);
+            // Decrement by 5
+            collection.binary().decrement(counterDocId, DecrementOptions.decrementOptions().delta(5));
+            // end::counters[]
+        }
+
+        {
+            System.out.println("Example - [counter-increment]");
+            // tag::counter-increment[]
+            GetResult getResult = collection.get("counter-doc");
+            int value = getResult.contentAs(Integer.class);
+            int incrementAmnt = 5;
+
+            if (shouldIncrementAmnt(value)) {
+                collection.replace(
+                        "counter-doc",
+                        value + incrementAmnt,
+                        ReplaceOptions.replaceOptions().cas(getResult.cas())
+                );
+            }
+            // end::counter-increment[]
+            System.out.println("RESULT: " + value+incrementAmnt);
+        }
+    }
+
+    private static boolean shouldIncrementAmnt(int value) {
+        System.out.println("Current value: " + value);
+        return value == 0;
+    }
+}

--- a/modules/concept-docs/pages/collections.adoc
+++ b/modules/concept-docs/pages/collections.adoc
@@ -7,7 +7,8 @@
 {description}
 
 The Collections feature in Couchbase Server is fully implemented in the 3.2 API version of the Couchbase SDK.
-Information on _Collections_ can be found in the xref:7.0@server:developer-preview:collections/collections-overview.adoc[server docs].
+
+Information on _Collections_ can be found in the xref:7.0@server:learn:data:scopes-and-collections.adoc[server docs].
 
 == Using Collections & Scopes
 
@@ -27,5 +28,4 @@ include::example$CollectionsExample.java[tag=collections_2,indent=0]
 
 == Further Reading  
 
-* Please see the xref:7.0@server:learn:data:scopes-and-collections.adoc[Collections Overview documents] in the Server docs.
-* To see Collections in action, take a look at our xref:howtos:working-with-collections.adoc[Collections-enabled Travel Sample page].
+To see Collections in action, take a look at our xref:howtos:working-with-collections.adoc[Collections-enabled Travel Sample page].

--- a/modules/concept-docs/pages/documents.adoc
+++ b/modules/concept-docs/pages/documents.adoc
@@ -2,8 +2,7 @@
 :description: Couchbase supports CRUD operations, various data structures, and binary documents.
 :nav-title: Documents & Doc Ops
 :page-topic-type: concept
-//:page-aliases: ROOT:core-operations.adoc
-:page-aliases: ROOT:documents.adoc,ROOT:documents-basics.adoc,ROOT:documents-atomic.adoc,7.0@server:developer-guide:expiry.adoc,7.0@server:developer-guide:creating-documents.adoc
+:page-aliases: ROOT:documents.adoc,ROOT:documents-basics.adoc,ROOT:documents-atomic.adoc,7.0@server:developer-guide:expiry.adoc,7.0@server:developer-guide:creating-documents.adoc,ROOT:core-operations.adoc
 
 [abstract]
 {description}
@@ -34,13 +33,13 @@ include::7.0@sdk:shared:partial$documents.adoc[tag=document]
 
 == Primitive Key-Value Operations
 
-[source,python]
+[source,java]
 ----
-upsert(docid, document)
-insert(docid, document)
-replace(docid, document)
-get(docid)
-remove(docid)
+upsert(String docid, Object document)
+insert(String docid, Object document)
+replace(String docid, Object document)
+get(String docid)
+remove(String docid)
 ----
 
 include::7.0@sdk:shared:partial$documents.adoc[tag=crud-overview]
@@ -51,16 +50,16 @@ include::7.0@sdk:shared:partial$documents.adoc[tag=store-update]
 ====
 If you wish to only modify certain parts of a document, you can use xref:subdocument-operations.adoc[sub-document] operations which operate on specific subsets of documents:
 
-[source,python]
+[source,java,indent=0]
 ----
-collection.mutate_in("customer123", [SD.upsert("fax", "311-555-0151")])
+include::example$DocumentsExample.java[tag=mutate-in]
 ----
 
 or xref:7.0@server:n1ql:n1ql-language-reference/update.adoc[N1QL UPDATE] to update documents based on specific query criteria:
 
 [source,sql]
 ----
-update `default` SET sale_price = msrp * 0.75 WHERE msrp < 19.95;
+update `travel-sample`.inventory.airline SET sale_price = msrp * 0.75 WHERE msrp < 19.95;
 ----
 ====
 
@@ -68,37 +67,30 @@ include::7.0@sdk:shared:partial$documents.adoc[tag=get_generic]
 
 [source,sql]
 ----
-SELECT * FROM default USE KEYS ["docid"];
+SELECT * FROM `travel-sample`.inventory.airport USE KEYS ["airport_1254"];
 ----
 
 or
 
 [source,sql]
 ----
-SELECT * FROM default WHERE META(default).id = "docid";
+SELECT * FROM `travel-sample`.inventory.airport WHERE META().id = "airport_1254";
 ----
 
 You can also retrieve _parts_ of documents using xref:subdocument-operations.adoc[sub-document operations], by specifying one or more sections of the document to be retrieved
 
-[source,python]
+[source,java,indent=0]
 ----
-name, email = cb.retrieve_in('user:kingarthur', 'contact.name', 'contact.email')
+include::example$DocumentsExample.java[tag=lookup-in]
 ----
 
 // Counters
 
 include::7.0@sdk:shared:partial$documents.adoc[tag=counters1]
 
-[source,java]
+[source,java,indent=0]
 ----
-String counterDocId = "counter-doc";
-// Increment by 1, creating doc if needed
-collection.binary().increment(counterDocId);
-// Decrement by 1
-collection.binary().decrement(counterDocId);
-// Decrement by 5
-collection.binary().decrement(counterDocId,
-DecrementOptions.decrementOptions().delta(5));
+include::example$DocumentsExample.java[tag=counters]
 ----
 
 You can simplify by importing `decrementOptions()` statically:
@@ -110,13 +102,9 @@ collection.binary().decrement(counterDocId, decrementOptions().delta(5));
 
 include::7.0@sdk:shared:partial$documents.adoc[tag=counters2]
 
-[source,python]
+[source,java,indent=0]
 ----
-# Python example:
-rv = cb.get('counter_id')
-value, cas = rv.value, rv.cas
-if should_increment_value(value):
-  cb.upsert('counter_id', value + increment_amount, cas=cas)
+include::example$DocumentsExample.java[tag=counter-increment]
 ----
 
 include::7.0@sdk:shared:partial$documents.adoc[tag=counters3]

--- a/modules/concept-docs/pages/n1ql-query.adoc
+++ b/modules/concept-docs/pages/n1ql-query.adoc
@@ -124,9 +124,9 @@ and allows optimization on a case-by-case basis.
 
 == Collections and Scopes, and the Query Context
 
-From the _beta version of the next Couchbase Server release, 7.0β_ the xref:7.0@server:learn:data/scopes-and-collections.adoc[Collections] feature lets you logically group similar documents into Collections.
+From Couchbase Server release 7.0 the xref:7.0@server:learn:data/scopes-and-collections.adoc[Collections] feature lets you logically group similar documents into Collections.
 
-You can query collections in N1QL, by referring to an fully qualified keyspace.
+You can query collections in N1QL, by referring to a fully qualified keyspace.
 For example, to list the documents in the `airline` collection in the `inventory` scope:
 
 [source,n1ql]

--- a/modules/howtos/pages/provisioning-cluster-resources.adoc
+++ b/modules/howtos/pages/provisioning-cluster-resources.adoc
@@ -132,6 +132,7 @@ Finally, you can drop unneeded collections and scopes:
 include::example$CollectionManagerExample.java[tag=drop-collection,indent=0]
 
 include::example$CollectionManagerExample.java[tag=drop-scope,indent=0]
+
 ----
 
 Note that you require at least the https://docs.couchbase.com/server/7.0/learn/security/roles.html#bucket-admin[Bucket Admin] privilege to create or drop a Scope.
@@ -144,6 +145,7 @@ You can create users with the appropriate RBAC programmatically:
 include::example$CollectionManagerExample.java[tag=bucketAdmin, indent=0]
 
 include::example$CollectionManagerExample.java[tag=scopeAdmin, indent=0]
+
 ----
 
 == Index Management

--- a/modules/test/test-concept-docs.bats
+++ b/modules/test/test-concept-docs.bats
@@ -36,3 +36,8 @@ load 'test/test_helper.bash'
     runExample XattrExample
     assert_success
 }
+
+@test "[concept-docs] - DocumentsExample.java" {
+    runExample DocumentsExample
+    assert_success
+}


### PR DESCRIPTION
Some fixes I missed when updating Java SDK 3.2 docs:

- Extract examples into java class for`documents.adoc` and remove python example.
- Remove DP(Developer Preview) in root nav for `working-with-collections.adoc`
- Remove outstanding beta reference
- Fix weird issue with multiple includes(see example snippets under collection-management): 
https://docs-staging.couchbase.com/java-sdk/current/howtos/provisioning-cluster-resources.html#collection-management  