### PR TITLE
Transactions 1.1.8 requires Java SDK 3.1.5 due to a breaking change

### DIFF
--- a/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
+++ b/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
@@ -23,7 +23,7 @@ Javadocs are available https://docs.couchbase.com/sdk-api/couchbase-transactions
 == Requirements
 
 * Couchbase Server 6.6.1 or above.
-* Couchbase Java client 3.1.5 or above.  It is recommended to follow the transitive dependency for the transactions library from Maven.
+* Couchbase Java client 3.1.5.  It is recommended to follow the transitive dependency for the transactions library from Maven.
 include::6.5@sdk:shared:partial$acid-transactions.adoc[tag=requirements]
 
 

--- a/modules/project-docs/pages/distributed-transactions-java-release-notes.adoc
+++ b/modules/project-docs/pages/distributed-transactions-java-release-notes.adoc
@@ -18,7 +18,7 @@ The xref:howtos:distributed-acid-transactions-from-the-sdk.adoc[Distributed Tran
 
 == Distributed Transactions Java 1.1.8 (26 May 2021)
 
-This release has been tested with Couchbase Java SDK version 3.1.5 and requires that version as a minimum.
+This release has been tested with Couchbase Java SDK version 3.1.5 and requires exactly that version (higher versions of the Java SDK are not compatible).
 
 https://docs.couchbase.com/sdk-api/couchbase-transactions-java-1.1.8/[JavaDocs]
 


### PR DESCRIPTION
…n the SDK