### PR TITLE
Automation improvements for Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,20 +1,11 @@
-name: Build Code Samples 
+name: Build Code Samples
 
 on:
   push:
-    branches: [release/3.2]
-    paths:
-      - 'modules/test/*'
-      - 'modules/Makefile'
-      - '**/*.java'
-      - '**/pom.xml'
+    branches: [ release/3.* ]
   pull_request:
-    branches: [release/3.2]
-    paths:
-      - 'modules/test/*'
-      - 'modules/Makefile'
-      - '**/*.java'
-      - '**/pom.xml'
+    branches: [ release/3.* ]
+
 env:
   JAVA_VERSION: 15
 
@@ -29,13 +20,43 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      # Because the job is a "required" status check, GitHub will block merging
+      # if the file filters don't apply to the changeset.
+      # We use this Github action to skip these steps when the changes made don't match the required
+      # file filters. By doing this the status check can be marked as "successful" and users can merge the PR.
+      # See https://github.community/t/feature-request-conditional-required-checks/16761/23 for some background.
+      - name: Check file changes
+        uses: getsentry/paths-filter@v2
+        id: changes
+        with:
+          token: ${{ github.token }}
+          filters: .github/workflows/file-filters.yml
+
       - name: Set up Java
         uses: actions/setup-java@v1
+        if: steps.changes.outputs.filters == 'true'
         with:
           java-version: ${{ env.JAVA_VERSION }} # The JDK version to make available on the path.
           java-package: jdk # (jre, jdk, or jdk+fx) - defaults to jdk
           architecture: x64 # (x64 or x86) - defaults to x64
 
       - name: Build code samples
+        if: steps.changes.outputs.filters == 'true'
         run: make build
         working-directory: ${{ env.working-directory }}
+
+      - name: Notify slack on failure
+        # We run this step only on the default branch(release/3.2)
+        # because secrets are not accessible on PRs from forks.
+        # Therefore, this notification will only happen when a PR is merged.
+        if:  failure() && github.ref == 'refs/heads/test-branch'
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          author_name: ":octocat: SDK Automation Failure"
+          text: ":no_entry: Oh noes! The commit has broken the build...please verify :paddlin:"
+          fields: repo,workflow,job,commit,author
+          mention: here
+          if_mention: failure
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/file-filters.yml
+++ b/.github/workflows/file-filters.yml
@@ -1,0 +1,5 @@
+filters:
+  - 'modules/test/*'
+  - 'modules/Makefile'
+  - '**/*.java'
+  - '**/pom.xml'

--- a/.github/workflows/test-dev.yml
+++ b/.github/workflows/test-dev.yml
@@ -2,13 +2,8 @@ name: Test Code Samples (Dev)
 
 on:
   push:
-    branches: [release/3.2]
-    paths:
-      - 'modules/test/*'
-      - 'modules/Makefile'
-      - '**/*.java'
-      - '**/pom.xml'
-      
+    branches: [ release/3.* ]
+
 env:
   REGISTRY: registry.gitlab.com/cb-vanilla/server
   CB_EDITION: 7.0.0
@@ -25,7 +20,20 @@ jobs:
       - name: Checkout actions
         uses: actions/checkout@v2
 
+      # Because the job is a "required" status check, GitHub will block merging
+      # if the file filters don't apply to the changeset.
+      # We use this Github action to skip these steps when the changes made don't match the required
+      # file filters. By doing this the status check can be marked as "successful" and users can merge the PR.
+      # See https://github.community/t/feature-request-conditional-required-checks/16761/23 for some background.
+      - name: Check file changes
+        uses: getsentry/paths-filter@v2
+        id: changes
+        with:
+          token: ${{ github.token }}
+          filters: .github/workflows/file-filters.yml
+
       - name: Docker Login
+        if: steps.changes.outputs.filters == 'true'
         uses: docker/login-action@v1
         with:
           registry: ${{ env.REGISTRY }}
@@ -33,17 +41,33 @@ jobs:
           password: ${{ secrets.DOCKER_PSWD }}
 
       - name: Build Couchbase Docker image
+        if: steps.changes.outputs.filters == 'true'
         run: CB_EDITION=${{ env.REGISTRY }}:${{ env.CB_EDITION }} CB_BUILD=${{ env.CB_BUILD }} make cb-build
         working-directory: ${{ env.working-directory }}
 
       - name: Run Couchbase Server+SDK container
+        if: steps.changes.outputs.filters == 'true'
         run: make cb-start
         working-directory: ${{ env.working-directory }}
 
       - name: Test code samples
-        run: make tests 
+        if: steps.changes.outputs.filters == 'true'
+        run: make tests
         working-directory: ${{ env.working-directory }}
-      
+
       - name: Cleanup
+        if: steps.changes.outputs.filters == 'true'
         run: make cb-stop
         working-directory: ${{ env.working-directory }}
+
+      - name: Notify slack on failure
+        if: failure()
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          author_name: Docs Bot Automation
+          fields: repo,workflow,job,commit,author
+          mention: here
+          if_mention: failure
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/test-ga.yml
+++ b/.github/workflows/test-ga.yml
@@ -2,19 +2,9 @@ name: Test Code Samples (GA)
 
 on:
   push:
-    branches: [release/3.2]
-    paths:
-      - 'modules/test/*'
-      - 'modules/Makefile'
-      - '**/*.java'
-      - '**/pom.xml'
+    branches: [ release/3.* ]
   pull_request:
-    branches: [release/3.2]
-    paths:
-      - 'modules/test/*'
-      - 'modules/Makefile'
-      - '**/*.java'
-      - '**/pom.xml'
+    branches: [ release/3.* ]
 
 jobs:
   test:
@@ -27,18 +17,49 @@ jobs:
       - name: Checkout actions
         uses: actions/checkout@v2
 
+      # Because the job is a "required" status check, GitHub will block merging
+      # if the file filters don't apply to the changeset.
+      # We use this Github action to skip these steps when the changes made don't match the required
+      # file filters. By doing this the status check can be marked as "successful" and users can merge the PR.
+      # See https://github.community/t/feature-request-conditional-required-checks/16761/23 for some background.
+      - name: Check file changes
+        uses: getsentry/paths-filter@v2
+        id: changes
+        with:
+          token: ${{ github.token }}
+          filters: .github/workflows/file-filters.yml
+
       - name: Build Couchbase Docker image
+        if: steps.changes.outputs.filters == 'true'
         run: make cb-build
         working-directory: ${{ env.working-directory }}
 
       - name: Run Couchbase Server+SDK container
+        if: steps.changes.outputs.filters == 'true'
         run: make cb-start
         working-directory: ${{ env.working-directory }}
 
       - name: Test code samples
-        run: make tests 
+        if: steps.changes.outputs.filters == 'true'
+        run: make tests
         working-directory: ${{ env.working-directory }}
-      
+
       - name: Cleanup
+        if: steps.changes.outputs.filters == 'true'
         run: make cb-stop
         working-directory: ${{ env.working-directory }}
+
+      - name: Notify slack on failure
+        # We run this step only on the default branch(release/3.2)
+        # because secrets are not accessible on PRs from forks.
+        # Therefore, this notification will only happen when a PR is merged.
+        if: failure() && github.ref == 'refs/heads/release/3.2'
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          author_name: Docs Bot Automation
+          fields: repo,workflow,job,commit,author
+          mention: here
+          if_mention: failure
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build
 
-CB_EDITION ?=couchbase/server:enterprise-7.0.0
-CB_BUILD ?=beta
+CB_EDITION ?=couchbase/server:enterprise
+CB_BUILD ?=7.0.0
 LOCAL_IMAGE_NAME=cb7-sdk3-java-ub20
 
 TEST_NAME=""

--- a/modules/test/Dockerfile
+++ b/modules/test/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE=ubuntu:20.04
 
-ARG CB_EDITION=couchbase/server:enterprise-7.0.0
-ARG CB_BUILD=beta
+ARG CB_EDITION=couchbase/server:enterprise
+ARG CB_BUILD=7.0.0
 ARG CB_IMAGE=$CB_EDITION-$CB_BUILD
 
 ARG CB_CLIENT_OS=ubuntu2004


### PR DESCRIPTION
This PR adds the following automation updates:

- Send slack notification to #docs-automation when a workflow fails on the **default** branch (i.e release/3.2)
- Update couchbase server version to 7.0.0 GA for testing
- Mark `build` and `test` workflows as successful if the PR changes don't actually require any automation to run (i.e changing an .adoc file).  Previously the workflows just wouldn't run, which makes sense, however this doesn't work with Github branch protection as there is no option for conditional status checks. Github will always expect those checks to run.
To mitigate this, we skip the steps in the workflow and mark it as successful, allowing us to merge the PR with no issue.