### PR TITLE
Removing 'type' field following review. Not a recommended practice.

### DIFF
--- a/modules/student/examples/InsertCourses.java
+++ b/modules/student/examples/InsertCourses.java
@@ -30,8 +30,7 @@ public class InsertCourses {
         JsonObject course = JsonObject.create()
                 .put("course-name", name)
                 .put("faculty", faculty)
-                .put("credit-points", creditPoints)
-                .put("type", "course");
+                .put("credit-points", creditPoints);
 
         collection.upsert(id, course);
 

--- a/modules/student/examples/InsertStudent.java
+++ b/modules/student/examples/InsertStudent.java
@@ -24,8 +24,8 @@ public class InsertStudent {
                 .put("name", "Hilary Smith")
                 .put("date-of-birth",
                         LocalDate.of(1980, 12, 21)
-                                .format(DateTimeFormatter.ISO_DATE))    // <.>
-                .put("type", "student");    // <.>
+                                .format(DateTimeFormatter.ISO_DATE));   // <.>
+
 
         student_records.upsert("000001", hilary);    // <.>
 


### PR DESCRIPTION
Removing the 'type' field from the example code. Now we have collections there's no need to attach a type to a document.