### PR TITLE
Simplify how custom ports are specified when connecting to the cluster.

### DIFF
--- a/modules/howtos/examples/managing_connections.java
+++ b/modules/howtos/examples/managing_connections.java
@@ -14,21 +14,14 @@
  * limitations under the License.
  */
 
-import java.time.Duration;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Optional;
-import java.util.Set;
-
-import com.couchbase.client.core.env.Authenticator;
-import com.couchbase.client.core.env.PasswordAuthenticator;
-import com.couchbase.client.core.env.SeedNode;
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.ClusterOptions;
 import com.couchbase.client.java.Collection;
 import com.couchbase.client.java.Scope;
 import com.couchbase.client.java.env.ClusterEnvironment;
+
+import java.time.Duration;
 
 public class managing_connections {
 
@@ -53,15 +46,18 @@ public class managing_connections {
 
 	public void managing_connections_5() throws Exception { // file: howtos/pages/managing-connections.adoc line: 125
 		// tag::managing_connections_5[]
-		int customKvPort = 1234;
-		int customManagerPort = 2345;
-		Set<SeedNode> seedNodes = new HashSet<>(
-				Arrays.asList(SeedNode.create("127.0.0.1", Optional.of(customKvPort), Optional.of(customManagerPort))));
-
-		Authenticator authenticator = PasswordAuthenticator.create(username, password);
-		ClusterOptions options = ClusterOptions.clusterOptions(authenticator);
-		Cluster cluster = Cluster.connect(seedNodes, options);
+		int customKvPort = 1234; // default is 11210 (or 11207 for TLS)
+		String connectionString = "127.0.0.1:" + customKvPort;
+		Cluster cluster = Cluster.connect(connectionString, username, password);
 		// end::managing_connections_5[]
+	}
+
+	public void managing_connections_6() throws Exception { // file: howtos/pages/managing-connections.adoc line: 125
+		// tag::managing_connections_6[]
+		int customManagerPort = 2345; // default is 8091 (or 18091 for TLS)
+		String connectionString = "127.0.0.1:" + customManagerPort + "=manager";
+		Cluster cluster = Cluster.connect(connectionString, username, password);
+		// end::managing_connections_6[]
 	}
 
 	public void managing_connections_8() throws Exception { // file: howtos/pages/managing-connections.adoc line: 242

--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -117,13 +117,19 @@ A node configured in this way will advertise two addresses: one for connecting f
 // todo link to https://docs.couchbase.com/server/7.0/cli/cbcli/couchbase-cli-setting-alternate-address.html
 
 On the client side, the externally visible ports must be used when connecting.
-If the external ports are not the default, you can specify custom ports using the overloaded `Cluster.connect()` method that takes a set of `SeedNode` objects instead of a connection string.
+If the external ports are not the default, you can specify custom ports in the connection string when calling `Cluster.connect()`.
 
-// todo use the include (and uncomment in ManageingConnections.java) after next client snapshot is published
-// include::example$ManagingConnections.java[tag=seednodes,indent=0]
 [source,java]
 ----
 include::example$managing_connections.java[tag=managing_connections_5,indent=0]
+----
+
+For nodes that do not have the KV service, you can connect using a custom manager port instead.
+Notice how `=manager` appears after the port number, identifying it as a manager port:
+
+[source,java]
+----
+include::example$managing_connections.java[tag=managing_connections_6,indent=0]
 ----
 
 TIP: In a deployment that uses multi-dimensional scaling, a custom KV port is only applicable for nodes running the KV service.


### PR DESCRIPTION
Building SeedNodes is cumbersome, and no longer required in 3.2.

Update the docs to show the new way of specifying custom ports.