### PR TITLE
DOC-9209: Fix AsciiDoc tag markup

### DIFF
--- a/modules/hello-world/examples/IndexHelloWorld.java
+++ b/modules/hello-world/examples/IndexHelloWorld.java
@@ -51,7 +51,7 @@ public class IndexHelloWorld {
 
     {
       System.out.println("\n[secondary]");
-      // tag::secondary[
+      // tag::secondary[]
       cluster.queryIndexes().createIndex(
         "travel-sample", 
         "index_name",
@@ -63,7 +63,7 @@ public class IndexHelloWorld {
 
     {
       System.out.println("\n[composite]");
-      // tag::composite[
+      // tag::composite[]
       cluster.queryIndexes().createIndex(
         "travel-sample", 
         "index_travel_info", 


### PR DESCRIPTION
Add closing square brackets for `secondary` and `composite` tagged areas