### PR TITLE
Improve optimstic locking example

### DIFF
--- a/modules/howtos/examples/KvOperations.java
+++ b/modules/howtos/examples/KvOperations.java
@@ -128,10 +128,11 @@ public class KvOperations {
       String id = "my-document";
       collection.upsert(id, JsonObject.create().put("initial", true));
 
-      GetResult found = collection.get(id);
-      JsonObject content = found.contentAsObject();
-      content.put("modified", true).put("initial", false);
       while (true) {
+        GetResult found = collection.get(id);
+        JsonObject content = found.contentAsObject();
+        content.put("modified", true).put("initial", false);
+
         try {
           collection.replace(id, content, replaceOptions().cas(found.cas()));
           break; // if successful, break out of the retry loop


### PR DESCRIPTION
Model a correct optimistic retry loop by getting the document inside the loop. If the replace failed due to CAS mismatch, read the document again to get a fresh CAS and see changes from the other actor.