### PR TITLE
1.2.3 release

### DIFF
--- a/modules/howtos/examples/TransactionsExample.java
+++ b/modules/howtos/examples/TransactionsExample.java
@@ -102,7 +102,7 @@ public class TransactionsExample {
         try {
             transactions.run((ctx) -> {
                 // 'ctx' is an AttemptContext, which permits getting, inserting,
-                // removing and replacing documents, performing SQL++ queries, and committing or
+                // removing and replacing documents, performing N1QL queries, and committing or
                 // rolling back the transaction.
 
                 // ... Your transaction logic here ...
@@ -193,13 +193,13 @@ public class TransactionsExample {
                 TransactionGetResult docC = ctx.get(collection, "doc-c");
                 ctx.remove(docC);
 
-                // Performing a SELECT SQL++ query against a scope:
+                // Performing a SELECT N1QL query against a scope:
                 QueryResult qr = ctx.query(inventory, "SELECT * FROM hotel WHERE country = $1",
                         TransactionQueryOptions.queryOptions()
                                 .parameters(JsonArray.from("United Kingdom")));
                 List<JsonObject> rows = qr.rowsAs(JsonObject.class);
 
-                // Performing an UPDATE SQL++ query on multiple documents, in the `inventory` scope:
+                // Performing an UPDATE N1QL query on multiple documents, in the `inventory` scope:
                 ctx.query(inventory, "UPDATE route SET airlineid = $1 WHERE airline = $2",
                         TransactionQueryOptions.queryOptions()
                                 .parameters(JsonArray.from("airline_137", "AF")));
@@ -243,7 +243,7 @@ public class TransactionsExample {
                     .then(ctx.get(collection.reactive(), "doc-c"))
                         .flatMap(doc -> ctx.remove(doc))
 
-                    // Performing a SELECT SQL++ query, in the `inventory` scope:
+                    // Performing a SELECT N1QL query, in the `inventory` scope:
                     .then(ctx.query(inventory, "SELECT * FROM hotel WHERE country = $1",
                             TransactionQueryOptions.queryOptions()
                                     .parameters(JsonArray.from("United Kingdom"))))
@@ -253,7 +253,7 @@ public class TransactionsExample {
                                 // the application would do something with each row here
                             }))
 
-                    // Performing an UPDATE SQL++ query on multiple documents, in the `inventory` scope:
+                    // Performing an UPDATE N1QL query on multiple documents, in the `inventory` scope:
                     .then(ctx.query(inventory, "UPDATE route SET airlineid = $1 WHERE airline = $2",
                             TransactionQueryOptions.queryOptions()
                                     .parameters(JsonArray.from("airline_137", "AF"))))
@@ -735,7 +735,7 @@ public class TransactionsExample {
     }
 
     static void querySingle() {
-        String bulkLoadStatement = null; // a bulk-loading SQL++ statement.  Left out of example per DOC-9630.
+        String bulkLoadStatement = null; // a bulk-loading N1QL statement.  Left out of example per DOC-9630.
 
         // tag::querySingle[]
         try {

--- a/modules/howtos/examples/TransactionsExample.java
+++ b/modules/howtos/examples/TransactionsExample.java
@@ -102,7 +102,7 @@ public class TransactionsExample {
         try {
             transactions.run((ctx) -> {
                 // 'ctx' is an AttemptContext, which permits getting, inserting,
-                // removing and replacing documents, performing N1QL queries, and committing or
+                // removing and replacing documents, performing SQL++ queries, and committing or
                 // rolling back the transaction.
 
                 // ... Your transaction logic here ...
@@ -193,13 +193,13 @@ public class TransactionsExample {
                 TransactionGetResult docC = ctx.get(collection, "doc-c");
                 ctx.remove(docC);
 
-                // Performing a SELECT N1QL query against a scope:
+                // Performing a SELECT SQL++ query against a scope:
                 QueryResult qr = ctx.query(inventory, "SELECT * FROM hotel WHERE country = $1",
                         TransactionQueryOptions.queryOptions()
                                 .parameters(JsonArray.from("United Kingdom")));
                 List<JsonObject> rows = qr.rowsAs(JsonObject.class);
 
-                // Performing an UPDATE N1QL query on multiple documents, in the `inventory` scope:
+                // Performing an UPDATE SQL++ query on multiple documents, in the `inventory` scope:
                 ctx.query(inventory, "UPDATE route SET airlineid = $1 WHERE airline = $2",
                         TransactionQueryOptions.queryOptions()
                                 .parameters(JsonArray.from("airline_137", "AF")));
@@ -243,7 +243,7 @@ public class TransactionsExample {
                     .then(ctx.get(collection.reactive(), "doc-c"))
                         .flatMap(doc -> ctx.remove(doc))
 
-                    // Performing a SELECT N1QL query, in the `inventory` scope:
+                    // Performing a SELECT SQL++ query, in the `inventory` scope:
                     .then(ctx.query(inventory, "SELECT * FROM hotel WHERE country = $1",
                             TransactionQueryOptions.queryOptions()
                                     .parameters(JsonArray.from("United Kingdom"))))
@@ -253,7 +253,7 @@ public class TransactionsExample {
                                 // the application would do something with each row here
                             }))
 
-                    // Performing an UPDATE N1QL query on multiple documents, in the `inventory` scope:
+                    // Performing an UPDATE SQL++ query on multiple documents, in the `inventory` scope:
                     .then(ctx.query(inventory, "UPDATE route SET airlineid = $1 WHERE airline = $2",
                             TransactionQueryOptions.queryOptions()
                                     .parameters(JsonArray.from("airline_137", "AF"))))
@@ -594,49 +594,21 @@ public class TransactionsExample {
     static void concurrentOps() {
         // tag::concurrentOps[]
         List<String> docIds = Arrays.asList("doc1", "doc2", "doc3", "doc4", "doc5");
-
         ReactiveCollection coll = collection.reactive();
+        int concurrency = 100; // This many operations will be in-flight at once
 
         TransactionResult result = transactions.reactive((ctx) -> {
-
-            // Tracks whether all operations were successful
-            AtomicBoolean allOpsSucceeded = new AtomicBoolean(true);
-
-            // The first mutation must be done in serial, as it also creates a metadata
-            // entry
-            return ctx.get(coll, docIds.get(0)).flatMap(doc -> {
-                JsonObject content = doc.contentAsObject();
-                content.put("value", "updated");
-                return ctx.replace(doc, content);
-            })
-
-                    // Do all other docs in parallel
-                    .thenMany(Flux.fromIterable(docIds.subList(1, docIds.size()))
-                            .flatMap(docId -> ctx.get(coll, docId).flatMap(doc -> {
+            return Flux.fromIterable(docIds)
+                    .parallel(concurrency)
+                    .runOn(Schedulers.boundedElastic())
+                    .concatMap(docId -> ctx.get(collection.reactive(), docId)
+                            .flatMap(doc -> {
                                 JsonObject content = doc.contentAsObject();
                                 content.put("value", "updated");
                                 return ctx.replace(doc, content);
-                            }).onErrorResume(err -> {
-                                allOpsSucceeded.set(false);
-                                // App should replace this with logging
-                                err.printStackTrace();
-
-                                // Allow other ops to finish
-                                return Mono.empty();
-                            }),
-
-                                    // Run these in parallel
-                                    docIds.size())
-
-            // The commit or rollback must also be done in serial
-            ).then(Mono.defer(() -> {
-                // Commit iff all ops succeeded
-                if (allOpsSucceeded.get()) {
-                    return ctx.commit();
-                } else {
-                    throw new RuntimeException("Retry the transaction");
-                }
-            }));
+                            }))
+                    .sequential()
+                    .then();
         }).block();
         // end::concurrentOps[]
     }
@@ -763,9 +735,9 @@ public class TransactionsExample {
     }
 
     static void querySingle() {
-        // tag::querySingle[]
-        String bulkLoadStatement = null; // a bulk-loading N1QL statement
+        String bulkLoadStatement = null; // a bulk-loading SQL++ statement.  Left out of example per DOC-9630.
 
+        // tag::querySingle[]
         try {
             SingleQueryTransactionResult result = transactions.query(bulkLoadStatement);
 

--- a/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
+++ b/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
@@ -29,14 +29,14 @@ include::7.0@sdk:shared:partial$acid-transactions.adoc[tag=requirements]
 
 Couchbase transactions require no additional components or services to be configured. 
 Simply add the transactions library into your project.
-The latest version, as of November 2021, is 1.2.2.
+The latest version, as of February 2022, is 1.2.3.
 
 With Gradle this can be accomplished by modifying these sections of your build.gradle file like so:
 
 [source,gradle]
 ----
 dependencies {
-    compile group: 'com.couchbase.client', name: 'couchbase-transactions', version: '1.2.2'
+    compile group: 'com.couchbase.client', name: 'couchbase-transactions', version: '1.2.3'
 }
 ----
 
@@ -47,7 +47,7 @@ Or with Maven:
 <dependency>
     <groupId>com.couchbase.client</groupId>
     <artifactId>couchbase-transactions</artifactId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
 </dependency>
 ----
 
@@ -210,8 +210,8 @@ include::example$TransactionsExample.java[tag=getReadOwnWrites,indent=0]
 
 include::7.0@sdk:shared:partial$acid-transactions.adoc[tag=query-intro]
 
-=== Using N1QL
-If you already use N1QL from the Java SDK, then its use in transactions is very similar.
+=== Using SQL++
+If you already use SQL++ from the Java SDK, then its use in transactions is very similar.
 it returns the same `QueryResult` you are used to, and takes most of the same options.
 
 You must take care to write `ctx.query()` inside the lambda however, rather than `cluster.query()` or `scope.query()`.
@@ -247,7 +247,7 @@ include::example$TransactionsExample.java[tag=queryExamplesComplex,indent=0]
 ----
 
 === Read Your Own Writes
-As with Key-Value operations, N1QL queries support Read Your Own Writes.
+As with Key-Value operations, SQL++ queries support Read Your Own Writes.
 
 This example shows INSERTing a document and then SELECTing it again.
 
@@ -259,7 +259,7 @@ include::example$TransactionsExample.java[tag=queryInsert,indent=0]
 Other transactions, and other non-transactional actors, will not be able to see this staged insert yet.
 <2> But the SELECT can, as we are reading a mutation staged inside the same transaction.
 
-=== Mixing Key-Value and N1QL
+=== Mixing Key-Value and SQL++
 Key-Value operations and queries can be freely intermixed, and will interact with each other as you would expect.
 
 In this example we insert a document with Key-Value, and read it with a SELECT.
@@ -480,18 +480,13 @@ If you have an existing OpenTelemetry span you can easily convert it to a Couchb
 include::example$TransactionsExample.java[tag=tracing-wrapped,indent=0]
 ----
 
-== Concurrent Operations with the Async API
+== Concurrent Operations
+The reactive API allows operations to be performed concurrently inside a transaction, which can assist performance.
 
-The async API allows operations to be performed concurrently inside a transaction, which can assist performance.
-There are two rules the application needs to follow:
+Any users of the reactive API are very strongly advised to use at minimum the 1.2.3 release of the transactions library.
+Prior to this there were specific rules the application had to follow to get thread-safe results, and these rules can be found in the https://docs.couchbase.com/java-sdk/3.1/howtos/distributed-acid-transactions-from-the-sdk.html#concurrent-operations-with-the-async-api[previous version of this document].
 
-* The first mutation must be performed alone, in serial.
-This is because the first mutation also triggers the creation of metadata for the transaction.
-* All concurrent operations must be allowed to complete fully, so the transaction library can track which operations need to be rolled back in the event of failure.
-This means the application must 'swallow' the error, but record that an error occurred, and then at the end of the concurrent operations, if an error occurred, throw an error to cause the transaction to retry.
-
-These rules are demonstrated here:
-
+An example of performing parallel operations using the reactive API:
 [source,java]
 ----
 include::example$TransactionsExample.java[tag=concurrentOps,indent=0]

--- a/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
+++ b/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
@@ -210,8 +210,8 @@ include::example$TransactionsExample.java[tag=getReadOwnWrites,indent=0]
 
 include::7.0@sdk:shared:partial$acid-transactions.adoc[tag=query-intro]
 
-=== Using SQL++
-If you already use SQL++ from the Java SDK, then its use in transactions is very similar.
+=== Using N1QL
+If you already use N1QL from the Java SDK, then its use in transactions is very similar.
 it returns the same `QueryResult` you are used to, and takes most of the same options.
 
 You must take care to write `ctx.query()` inside the lambda however, rather than `cluster.query()` or `scope.query()`.
@@ -247,7 +247,7 @@ include::example$TransactionsExample.java[tag=queryExamplesComplex,indent=0]
 ----
 
 === Read Your Own Writes
-As with Key-Value operations, SQL++ queries support Read Your Own Writes.
+As with Key-Value operations, N1QL queries support Read Your Own Writes.
 
 This example shows INSERTing a document and then SELECTing it again.
 
@@ -259,7 +259,7 @@ include::example$TransactionsExample.java[tag=queryInsert,indent=0]
 Other transactions, and other non-transactional actors, will not be able to see this staged insert yet.
 <2> But the SELECT can, as we are reading a mutation staged inside the same transaction.
 
-=== Mixing Key-Value and SQL++
+=== Mixing Key-Value and N1QL
 Key-Value operations and queries can be freely intermixed, and will interact with each other as you would expect.
 
 In this example we insert a document with Key-Value, and read it with a SELECT.

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.couchbase.client</groupId>
             <artifactId>couchbase-transactions</artifactId>
-            <version>1.2.2</version>
+            <version>1.2.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/modules/project-docs/pages/distributed-transactions-java-release-notes.adoc
+++ b/modules/project-docs/pages/distributed-transactions-java-release-notes.adoc
@@ -39,7 +39,7 @@ Performance: the thread-safe logging list has been replaced with a faster altern
 
 === Bug Fixes
 * https://issues.couchbase.com/browse/TXNJ-447[TXNJ-447]:
-Deferred commit no longer fails with a NullPointerException.
+Deferred commit no longer fails with a `NullPointerException`.
 * https://issues.couchbase.com/browse/TXNJ-452[TXNJ-452],
 https://issues.couchbase.com/browse/TXNJ-460[TXNJ-460],
 https://issues.couchbase.com/browse/TXNJ-461[TXNJ-461],
@@ -48,7 +48,7 @@ https://issues.couchbase.com/browse/TXNJ-465[TXNJ-465]:
 Multiple fixes to the reactive version of `ctx.query()`, particularly around error handling.
 Any users of this API should upgrade immediately.
 * https://issues.couchbase.com/browse/TXNJ-455[TXNJ-455]:
-Avoid ErrorCallbackNotImplemented errors during cleanup shutdown when metadata collections were in use.
+Avoid `ErrorCallbackNotImplemented` errors during cleanup shutdown when metadata collections were in use.
 * https://issues.couchbase.com/browse/TXNJ-467[TXNJ-467]:
 The single query transaction is completely rewritten, and now performs the `tximplicit` optimisation as expected.
 

--- a/modules/project-docs/pages/distributed-transactions-java-release-notes.adoc
+++ b/modules/project-docs/pages/distributed-transactions-java-release-notes.adoc
@@ -15,28 +15,42 @@ This page features the release notes for that library -- for release notes, down
 See the xref:7.0@server:learn:data/transactions.adoc[Distributed ACID Transactions concept doc] in the server documentation for details of how Couchbase implements transactions.
 The xref:howtos:distributed-acid-transactions-from-the-sdk.adoc[Distributed Transactions HOWTO doc] walks you through all aspects of working with Distributed Transactions.
 
+== Distributed Transactions Java 1.2.3 (15 February 2022)
 
-== Distributed Transactions Java 1.2.2 (29 October 2021)
+This release has been tested with Couchbase Java SDK version 3.2.5 and requires version 3.1.5 or higher.
 
-This release has been tested with Couchbase Java SDK version 3.2.2 and requires version 3.1.5 or higher.
+https://docs.couchbase.com/sdk-api/couchbase-transactions-java-1.2.3/[JavaDocs]
 
-https://docs.couchbase.com/sdk-api/couchbase-transactions-java-1.2.2/[JavaDocs]
+The headline change in this release is that the library's thread safety has been signficantly improved.
+Prior to this release the library was thread-safe, but had to be used in a specific documented way to be so.
+Now those restrictions have been removed, and the documentation has been updated to reflect it.
 
-=== Interface Changes
-Some interfaces that were in `@Stability.Volatile` or `@Stability.Uncommitted` have been modified:
-
-* https://issues.couchbase.com/browse/TXNJ-442[TXNJ-442]:
-`ReactiveQueryStatementTransactionResult` has been been renamed to `ReactiveSingleQueryTransactionResult`, consistent with the blocking API.
-This new interface added in 1.2.1 is marked at @Stability.Uncommitted, indicating that breakages - though unusual - are possible.
-* https://issues.couchbase.com/browse/TXNJ-445[TXNJ-445]:
-An overload `Mono<ReactiveQueryResult> query(final ReactiveScope scope, final String statement)` was added, to be consistent with the blocking API.
+=== Improvements
+* https://issues.couchbase.com/browse/TXNJ-258[TXNJ-258],
+https://issues.couchbase.com/browse/TXNJ-326[TXNJ-326],
+https://issues.couchbase.com/browse/TXNJ-252[TXNJ-252],
+https://issues.couchbase.com/browse/TXNJ-454[TXNJ-454]:
+Multiple improvements to thread safety, described above.
+* https://issues.couchbase.com/browse/TXNJ-368[TXNJ-368]:
+The application's lambda is now run on a dedicated Reactive scheduler.
+This will help to prevent issues if the lambda runs a blocking non-Couchbase operation (which it should not do).
+* https://issues.couchbase.com/browse/TXNJ-453[TXNJ-453]:
+Performance: the thread-safe logging list has been replaced with a faster alternative.
 
 === Bug Fixes
-* https://issues.couchbase.com/browse/TXNJ-436[TXNJ-436],
-https://issues.couchbase.com/browse/TXNJ-446[TXNJ-446]:
-Rollback and commit now consistently set `isDone` in queryMode, preventing implicit commit.
-* https://issues.couchbase.com/browse/TXNJ-444[TXNJ-444]:
-Fixed an incorrectly formatted error message that was causing a `MissingFormatArgumentException`.
+* https://issues.couchbase.com/browse/TXNJ-447[TXNJ-447]:
+Deferred commit no longer fails with a NullPointerException.
+* https://issues.couchbase.com/browse/TXNJ-452[TXNJ-452],
+https://issues.couchbase.com/browse/TXNJ-460[TXNJ-460],
+https://issues.couchbase.com/browse/TXNJ-461[TXNJ-461],
+https://issues.couchbase.com/browse/TXNJ-464[TXNJ-464],
+https://issues.couchbase.com/browse/TXNJ-465[TXNJ-465]:
+Multiple fixes to the reactive version of `ctx.query()`, particularly around error handling.
+Any users of this API should upgrade immediately.
+* https://issues.couchbase.com/browse/TXNJ-455[TXNJ-455]:
+Avoid ErrorCallbackNotImplemented errors during cleanup shutdown when metadata collections were in use.
+* https://issues.couchbase.com/browse/TXNJ-467[TXNJ-467]:
+The single query transaction is completely rewritten, and now performs the `tximplicit` optimisation as expected.
 
 
 == Distributed Transactions Java 1.2.2 (29 October 2021)


### PR DESCRIPTION
In addition:
* Fixing DOC-9630.
* As per DOC-9630, N1QL is now SQL++.
* Removing a duplicate entry for the 1.2.2 release.