### PR TITLE
DOC-8027: Json Subdoc Limits

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -5,6 +5,7 @@
 
 .Working with Data
 * xref:howtos:kv-operations.adoc[Key Value Operations]
+* xref:howtos:json.adoc[JSON]
 * xref:howtos:subdocument-operations.adoc[Sub-Document Operations]
 //  ** xref:howtos:sdk-xattr-example.adoc[Extended Attributes]
 * xref:howtos:n1ql-queries-with-sdk.adoc[Query]

--- a/modules/howtos/pages/json.adoc
+++ b/modules/howtos/pages/json.adoc
@@ -285,7 +285,7 @@ include::example$Json.java[tags=subdoc-object-json,indent=0]
 ----
 
 NOTE: Currently, paths cannot exceed 1024 characters, and cannot be more than 32 levels deep.
-DJSON documents with more than 32 nested layers cannot be parsed, atttempting to do so will result in a`DocumentTooDeepException` exception.
+DJSON documents with more than 32 nested layers cannot be parsed, atttempting to do so will result in a `DocumentTooDeepException` exception.
 
 
 == Identifying the type of arbitrary JSON

--- a/modules/howtos/pages/json.adoc
+++ b/modules/howtos/pages/json.adoc
@@ -284,6 +284,9 @@ include::example$Json.java[tags=subdoc-object,indent=0]
 include::example$Json.java[tags=subdoc-object-json,indent=0]
 ----
 
+NOTE: Currently, paths cannot exceed 1024 characters, and cannot be more than 32 levels deep.
+DJSON documents with more than 32 nested layers cannot be parsed, atttempting to do so will result in a`DocumentTooDeepException` exception.
+
 
 == Identifying the type of arbitrary JSON
 


### PR DESCRIPTION
These are already mentioned on subdocument-operations.adoc
but now adding to json.adoc.

(Also adding json.adoc to nav...)