### PR TITLE
DOC-9567 - Add scoped index management examples

### DIFF
--- a/modules/howtos/examples/ProvisioningResourcesBuckets.java
+++ b/modules/howtos/examples/ProvisioningResourcesBuckets.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2022 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import com.couchbase.client.core.error.BucketExistsException;
+import com.couchbase.client.java.Cluster;
+import com.couchbase.client.java.manager.bucket.BucketManager;
+import com.couchbase.client.java.manager.bucket.BucketSettings;
+import com.couchbase.client.java.manager.bucket.BucketType;
+import com.couchbase.client.java.manager.bucket.ConflictResolutionType;
+
+public class ProvisioningResourcesBuckets {
+	public static void main(String[] args) {
+		// tag::creatingbucketmgr[]
+		Cluster cluster = Cluster.connect("localhost", "Administrator", "password");
+		BucketManager bucketMgr = cluster.buckets();
+		// end::creatingbucketmgr[]
+
+		{
+			System.out.println("[createBucket]");
+
+			// tag::createBucket[]
+			try {
+				BucketSettings bucketSettings = BucketSettings.create("hello")
+						.flushEnabled(false)
+						.replicaIndexes(true)
+						.ramQuotaMB(150)
+						.numReplicas(1)
+						.bucketType(BucketType.COUCHBASE)
+						.conflictResolutionType(ConflictResolutionType.SEQUENCE_NUMBER);
+
+				bucketMgr.createBucket(bucketSettings);
+			} catch (BucketExistsException e) {
+				System.out.println("Bucket already exists");
+			}
+			// end::createBucket[]
+		}
+
+		{
+			System.out.println("[updateBucket]");
+
+			// tag::updateBucket[]
+			BucketSettings settings = bucketMgr.getBucket("hello");
+			settings.flushEnabled(true);
+
+			bucketMgr.updateBucket(settings);
+			// end::updateBucket[]
+		}
+		{
+			System.out.println("[flushBucket]");
+
+			// tag::flushBucket[]
+			bucketMgr.flushBucket("hello");
+			// end::flushBucket[]
+		}
+		{
+			System.out.println("[removeBucket]");
+
+			// tag::removeBucket[]
+			bucketMgr.dropBucket("hello");
+			// end::removeBucket[]
+		}
+	}
+}

--- a/modules/howtos/examples/ProvisioningResourcesViews.java
+++ b/modules/howtos/examples/ProvisioningResourcesViews.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2022 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import java.util.HashMap;
+import java.util.Map;
+import com.couchbase.client.java.Bucket;
+import com.couchbase.client.java.Cluster;
+import com.couchbase.client.java.manager.view.DesignDocument;
+import com.couchbase.client.java.manager.view.View;
+import com.couchbase.client.java.manager.view.ViewIndexManager;
+import com.couchbase.client.java.view.DesignDocumentNamespace;
+
+public class ProvisioningResourcesViews {
+	public static void main(String[] args) {
+		// tag::viewmgr[]
+		Cluster cluster = Cluster.connect("localhost", "Administrator", "password");
+		Bucket bucket = cluster.bucket("travel-sample");
+		ViewIndexManager viewMgr = bucket.viewIndexes();
+		// end::viewmgr[]
+
+		{
+			// tag::createView[]
+			Map<String, View> views = new HashMap<>();
+			views.put(
+				"by_country",
+				new View("function (doc, meta) { if (doc.type == 'landmark') { emit([doc.country, doc.city], null); } }")
+			);
+			views.put(
+				"by_activity",
+				new View(
+					"function (doc, meta) { if (doc.type == 'landmark') { emit([doc.country, doc.city], null); } }",
+					"_count")
+			);
+
+			DesignDocument designDocument = new DesignDocument("landmarks", views);
+			viewMgr.upsertDesignDocument(designDocument, DesignDocumentNamespace.DEVELOPMENT);
+			// end::createView[]
+		}
+
+		{
+			// tag::getView[]
+			DesignDocument designDocument = viewMgr.getDesignDocument("landmarks", DesignDocumentNamespace.DEVELOPMENT);
+			System.out.print(designDocument);
+			// end::getView[]
+		}
+
+
+		{
+			// tag::publishView[]
+			viewMgr.publishDesignDocument("landmarks");
+			// end::publishView[]
+		}
+
+		{
+			// tag::removeView[]
+			viewMgr.dropDesignDocument("landmarks", DesignDocumentNamespace.PRODUCTION);
+			// end::removeView[]
+		}
+	}
+}

--- a/modules/howtos/examples/QueryIndexManagerExample.java
+++ b/modules/howtos/examples/QueryIndexManagerExample.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2022 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import java.time.Duration;
+import java.util.Arrays;
+import com.couchbase.client.core.error.IndexExistsException;
+import com.couchbase.client.java.Cluster;
+import com.couchbase.client.java.manager.query.BuildQueryIndexOptions;
+import com.couchbase.client.java.manager.query.CreatePrimaryQueryIndexOptions;
+import com.couchbase.client.java.manager.query.CreateQueryIndexOptions;
+import com.couchbase.client.java.manager.query.DropPrimaryQueryIndexOptions;
+import com.couchbase.client.java.manager.query.DropQueryIndexOptions;
+import com.couchbase.client.java.manager.query.QueryIndexManager;
+import com.couchbase.client.java.manager.query.WatchQueryIndexesOptions;
+
+public class QueryIndexManagerExample {
+
+	public static void main(String... args) {
+		// tag::creating-index-mgr[]
+		Cluster cluster = Cluster.connect("localhost", "Administrator", "password");
+		QueryIndexManager queryIndexMgr = cluster.queryIndexes();
+		// end::creating-index-mgr[]
+
+		{
+			System.out.println("[primary]");
+
+			// tag::primary[]
+			CreatePrimaryQueryIndexOptions opts = CreatePrimaryQueryIndexOptions.createPrimaryQueryIndexOptions()
+					.scopeName("tenant_agent_01")
+					.collectionName("users")
+					// Set this if you wish to use a custom name
+					// .indexName("custom_name") 
+					.ignoreIfExists(true);
+
+			queryIndexMgr.createPrimaryIndex("travel-sample", opts);
+			// end::primary[]
+		}
+
+		{
+			System.out.println("[secondary]");
+
+			// tag::secondary[]
+			try {
+				CreateQueryIndexOptions opts = CreateQueryIndexOptions.createQueryIndexOptions()
+						.scopeName("tenant_agent_01")
+						.collectionName("users");
+
+				queryIndexMgr.createIndex("travel-sample", "tenant_agent_01_users_email",
+						Arrays.asList("preferred_email"), opts);
+			} catch (IndexExistsException e) {
+				System.out.println("Index already exists");
+			}
+			// end::secondary[]
+		}
+
+		{
+			System.out.println("[defer-indexes]");
+
+			// tag::defer-indexes[]
+			try {
+				// Create a deferred index
+				CreateQueryIndexOptions createOpts = CreateQueryIndexOptions.createQueryIndexOptions()
+						.scopeName("tenant_agent_01")
+						.collectionName("users")
+						.deferred(true);
+
+				queryIndexMgr.createIndex("travel-sample", "tenant_agent_01_users_phone",
+						Arrays.asList("preferred_phone"), createOpts);
+
+				// Build any deferred indexes within `travel-sample`.tenant_agent_01.users
+				BuildQueryIndexOptions deferredOpts = BuildQueryIndexOptions.buildDeferredQueryIndexesOptions()
+						.scopeName("tenant_agent_01")
+						.collectionName("users");
+
+				queryIndexMgr.buildDeferredIndexes("travel-sample", deferredOpts);
+
+				// Wait for indexes to come online
+				WatchQueryIndexesOptions watchOpts = WatchQueryIndexesOptions.watchQueryIndexesOptions()
+						.scopeName("tenant_agent_01")
+						.collectionName("users");
+
+				queryIndexMgr.watchIndexes("travel-sample", Arrays.asList("tenant_agent_01_users_phone"), 
+						Duration.ofSeconds(60), watchOpts);
+
+			} catch (IndexExistsException e) {
+				System.out.println("Index already exists");
+			}
+			// end::defer-indexes[]
+		}
+
+		{
+			System.out.println("[drop-primary-or-secondary-index]");
+
+			// tag::drop-primary-or-secondary-index[]
+			DropPrimaryQueryIndexOptions primaryIndexOpts = DropPrimaryQueryIndexOptions.dropPrimaryQueryIndexOptions()
+					.scopeName("tenant_agent_01")
+					.collectionName("users");	
+
+			queryIndexMgr.dropPrimaryIndex("travel-sample", primaryIndexOpts);
+
+			// Drop a secondary index
+			DropQueryIndexOptions indexOpts = DropQueryIndexOptions.dropQueryIndexOptions()
+					.scopeName("tenant_agent_01")
+					.collectionName("users");	
+
+			queryIndexMgr.dropIndex("travel-sample", "tenant_agent_01_users_email", indexOpts);
+			// end::drop-primary-or-secondary-index[]
+		}
+	}
+}

--- a/modules/howtos/pages/provisioning-cluster-resources.adoc
+++ b/modules/howtos/pages/provisioning-cluster-resources.adoc
@@ -59,7 +59,7 @@ Here is the list of parameters available:
 |====
 | Name | Description | Can be updated
 | `name string` | The name of the bucket, required for creation. | false
-| `flushEnabled boolean` | Enables flushing to be performed on this bucket (see the <<java-flushing>> section below). | true
+| `flushEnabled boolean` | Enables flushing to be performed on this bucket (see the <<Flushing Buckets>> section below). | true
 | `replicaIndexes boolean` | Whether or not to replicate indexes. | false
 | `ramQuotaMB uint64` | How much memory should each node use for the bucket, required for creation. | true
 | `numReplicas` int | The number of replicas to use for the bucket. | true
@@ -91,7 +91,6 @@ Once you no longer need to use the bucket, you can remove it:
 include::example$ProvisioningResourcesBuckets.java[tag=removeBucket,indent=0]
 ----
 
-[#java-flushing]
 === Flushing Buckets
 
 include::{version-server}@sdk:shared:partial$flush-info-pars.adoc[tag=flush-intro]

--- a/modules/howtos/pages/provisioning-cluster-resources.adoc
+++ b/modules/howtos/pages/provisioning-cluster-resources.adoc
@@ -11,7 +11,11 @@
 :analytics-api-reference: pass:q[AnalyticsIndexManager -- https://docs.couchbase.com/sdk-api/couchbase-java-client/com/couchbase/client/java/Cluster.html#analyticsIndexes()[`Cluster.analyticsIndexes()`]]
 :search-api-reference: pass:q[SearchIndexManager -- https://docs.couchbase.com/sdk-api/couchbase-java-client/com/couchbase/client/java/Cluster.html#searchIndexes()[`Cluster.searchIndexes()`]]
 :collection-api-reference: pass:q[CollectionManager -- https://docs.couchbase.com/sdk-api/couchbase-java-client/com/couchbase/client/java/Bucket.html#collections()[`Bucket.collections()`]]
-:view-api-reference: pass:q[ ViewIndexManager -- https://docs.couchbase.com/sdk-api/couchbase-java-client/com/couchbase/client/java/Bucket.html#viewIndexes()[`Bucket.viewIndexes()`]]
+:view-api-reference: pass:q[ViewIndexManager -- https://docs.couchbase.com/sdk-api/couchbase-java-client/com/couchbase/client/java/Bucket.html#viewIndexes()[`Bucket.viewIndexes()`]]
+
+// one-view-update-warning common partial 
+:upsertDesignDocument: pass:q[`upsertDesignDocument` method]
+:getDesignDocument: pass:q[`getDesignDocument`]
 
 include::project-docs:partial$attributes.adoc[]
 
@@ -225,42 +229,40 @@ include::{version-server}@sdk:shared:partial$flush-info-pars.adoc[tag=view-manag
 In the SDK, design documents are represented by the `DesignDocument` and `View` objects.
 All operations on design documents are performed on the `ViewIndexManager` instance:
 
-////
-[source,java,indent=0]
+[source,java]
 ----
-include::devguide:example$go/provisioning-resources-views.go[tag=viewmgr]
+include::example$ProvisioningResourcesViews.java[tag=viewmgr,indent=0]
 ----
 
 The following example upserts a design document with two views:
 
-[source,java,indent=0]
+[source,java]
 ----
-include::devguide:example$go/provisioning-resources-views.go[tag=createView]
+include::example$ProvisioningResourcesViews.java[tag=createView,indent=0]
 ----
 
-include::7.0@sdk:shared:partial$flush-info-pars.adoc[tag=one-view-update-warning]
+include::{version-server}@sdk:shared:partial$flush-info-pars.adoc[tag=one-view-update-warning]
 
-Note the use of `DesignDocumentNamespaceDevelopment`, the other option is `DesignDocumentNamespaceProduction`.
+Note the use of `DesignDocumentNamespace.DEVELOPMENT`, the other option is `DesignDocumentNamespace.PRODUCTION`.
 This parameter specifies whether the design document should be created as development, or as production -- with the former running over only a small fraction of the documents.
 
 Now that we've created a design document we can fetch it:
 
-[source,java,indent=0]
+[source,java]
 ----
-include::devguide:example$go/provisioning-resources-views.go[tag=getView]
+include::example$ProvisioningResourcesViews.java[tag=getView,indent=0]
 ----
 
-We've created the design document using `DesignDocumentNamespaceDevelopment` and now want to push it to production, we can do this with:
+We've created the design document using `DesignDocumentNamespace.DEVELOPMENT` and now want to push it to production, we can do this with:
 
-[source,java,indent=0]
+[source,java]
 ----
-include::devguide:example$go/provisioning-resources-views.go[tag=publishView]
+include::example$ProvisioningResourcesViews.java[tag=publishView,indent=0]
 ----
 
 To remove this design document:
 
-[source,java,indent=0]
+[source,java]
 ----
-include::devguide:example$go/provisioning-resources-views.go[tag=removeView]
+include::example$ProvisioningResourcesViews.java[tag=removeView,indent=0]
 ----
-////

--- a/modules/howtos/pages/provisioning-cluster-resources.adoc
+++ b/modules/howtos/pages/provisioning-cluster-resources.adoc
@@ -2,6 +2,7 @@
 :description: Provisioning cluster resources is managed at the collection or bucket level, depending upon the service affected.
 :navtitle: Provisioning Cluster Resources
 :page-aliases: ROOT:managing-clusters.adoc
+:page-toclevels: 2
 
 // API refs
 :bucket-api-reference: pass:q[BucketManager -- https://docs.couchbase.com/sdk-api/couchbase-java-client/com/couchbase/client/java/Cluster.html#buckets()[`Cluster.buckets()`]]

--- a/modules/howtos/pages/provisioning-cluster-resources.adoc
+++ b/modules/howtos/pages/provisioning-cluster-resources.adoc
@@ -36,7 +36,7 @@ Management operations in the SDK may be performed through several interfaces dep
 NOTE: When using a Couchbase version earlier than 6.5, you must create a valid Bucket connection using `Cluster.bucket(name)` before you can use cluster level managers.
 
 
-== Creating and Removing Buckets
+== Bucket Management
 
 The `BucketManager` interface may be used to create and delete buckets from the Couchbase cluster.
 It is instantiated through the `Cluster.buckets()` method.
@@ -88,7 +88,7 @@ include::example$ProvisioningResourcesBuckets.java[tag=removeBucket,indent=0]
 ----
 
 [#java-flushing]
-== Flushing Buckets
+=== Flushing Buckets
 
 include::{version-server}@sdk:shared:partial$flush-info-pars.adoc[tag=flush-intro]
 
@@ -159,6 +159,11 @@ include::{version-server}@sdk:shared:partial$flush-info-pars.adoc[tag=index-mana
 
 The `QueryIndexManager` interface contains the means for managing indexes used for queries.
 It can be instantiated through the `Cluster.queryIndexes()` method.
+
+[source,java]
+----
+include::example$QueryIndexManagerExample.java[tag=creating-index-mgr,indent=0]
+----
 
 include::{version-server}@sdk:shared:partial$flush-info-pars.adoc[tag=query-index-manager-intro]
 

--- a/modules/howtos/pages/provisioning-cluster-resources.adoc
+++ b/modules/howtos/pages/provisioning-cluster-resources.adoc
@@ -213,7 +213,7 @@ include::example$QueryIndexManagerExample.java[tag=drop-primary-or-secondary-ind
 
 // * Search - note & link to FTS page & API?
 
-== View Management
+== Views Management
 
 include::{version-server}@sdk:shared:partial$flush-info-pars.adoc[tag=view-management]
 

--- a/modules/howtos/pages/provisioning-cluster-resources.adoc
+++ b/modules/howtos/pages/provisioning-cluster-resources.adoc
@@ -3,100 +3,102 @@
 :navtitle: Provisioning Cluster Resources
 :page-aliases: ROOT:managing-clusters.adoc
 
+// API refs
+:bucket-api-reference: pass:q[BucketManager -- https://docs.couchbase.com/sdk-api/couchbase-java-client/com/couchbase/client/java/Cluster.html#buckets()[`Cluster.buckets()`]]
+:user-api-reference: pass:q[UserManager -- https://docs.couchbase.com/sdk-api/couchbase-java-client/com/couchbase/client/java/Cluster.html#users()[`Cluster.users()`]]
+:query-api-reference: pass:q[QueryIndexManager -- https://docs.couchbase.com/sdk-api/couchbase-java-client/com/couchbase/client/java/Cluster.html#queryIndexes()[`Cluster.queryIndexes()`]]
+:analytics-api-reference: pass:q[AnalyticsIndexManager -- https://docs.couchbase.com/sdk-api/couchbase-java-client/com/couchbase/client/java/Cluster.html#analyticsIndexes()[`Cluster.analyticsIndexes()`]]
+:search-api-reference: pass:q[SearchIndexManager -- https://docs.couchbase.com/sdk-api/couchbase-java-client/com/couchbase/client/java/Cluster.html#searchIndexes()[`Cluster.searchIndexes()`]]
+:collection-api-reference: pass:q[CollectionManager -- https://docs.couchbase.com/sdk-api/couchbase-java-client/com/couchbase/client/java/Bucket.html#collections()[`Bucket.collections()`]]
+:view-api-reference: pass:q[ ViewIndexManager -- https://docs.couchbase.com/sdk-api/couchbase-java-client/com/couchbase/client/java/Bucket.html#viewIndexes()[`Bucket.viewIndexes()`]]
+
+include::project-docs:partial$attributes.adoc[]
+
 [abstract]
 {description}
 Common use cases are outlined here, less common use cases are covered in the https://pkg.go.dev/github.com/couchbase/gocb/v2?tab=doc[API docs].
 
-include::7.0@sdk:shared:partial$flush-info-pars.adoc[tag=management-intro]
+include::{version-server}@sdk:shared:partial$flush-info-pars.adoc[tag=management-intro]
 
 The Java SDK also comes with some convenience functionality for common Couchbase management requests.
 
 Management operations in the SDK may be performed through several interfaces depending on the object:
 
-* BucketManager -- `Cluster.Buckets()`
-* UserManager -- `Cluster.Users()`
-* QueryIndexManager -- `Cluster.QueryIndexes()`
-* AnalyticsIndexManager -- `Cluster.AnalyticsIndexes()`
-* SearchIndexManager -- `Cluster.SearchIndexes()`
-* CollectionManager -- `Bucket.Collections()`
-* ViewIndexManager -- `Bucket.ViewIndexes()`.
+* {bucket-api-reference}
+* {user-api-reference}
+* {query-api-reference} 
+* {analytics-api-reference}
+* {search-api-reference}
+* {collection-api-reference}
+* {view-api-reference}
 
-NOTE: When using a Couchbase version earlier than 6.5, you must create a valid Bucket connection using `cluster.Bucket(name)` before you can use cluster level managers.
+NOTE: When using a Couchbase version earlier than 6.5, you must create a valid Bucket connection using `Cluster.bucket(name)` before you can use cluster level managers.
 
 
 == Creating and Removing Buckets
 
-The `ClusterManager` interface may be used to create and delete buckets from the Couchbase cluster.
-It is instantiated through the `Cluster.Buckets()` method.
-Refer to https://docs.couchbase.com/sdk-api/couchbase-java-client/com/couchbase/client/java/Bucket.html[the API `Bucket` documentation] --
-and to its https://docs.couchbase.com/sdk-api/couchbase-java-client/com/couchbase/client/java/AsyncBucket.html[Async counterpart] --
-for further details.
+The `BucketManager` interface may be used to create and delete buckets from the Couchbase cluster.
+It is instantiated through the `Cluster.buckets()` method.
 
-////
-[source,golang,indent=0]
+[source,java]
 ----
-include::devguide:example$go/provisioning-resources-buckets.go[tag=creatingbucketmgr]
+include::example$ProvisioningResourcesBuckets.java[tag=creatingbucketmgr,indent=0]
 ----
-////
 
-The `CreateBucketSettings` and `BucketSettings` structs are used for creating and updating buckets, `BucketSettings` is also used for exposing information about existing buckets.
+The `BucketSettings` object is used for creating or updating buckets, and for exposing information about existing buckets.
 
-include::7.0@sdk:shared:partial$flush-info-pars.adoc[tag=update-bucket-warning]
+include::{version-server}@sdk:shared:partial$flush-info-pars.adoc[tag=update-bucket-warning]
 
-////
 Here is the list of parameters available:
 
 |====
 | Name | Description | Can be updated
-| `Name string` | The name of the bucket, required for creation. | false
-| `FlushEnabled boolean` | Enables flushing to be performed on this bucket (see the <<go-flushing>> section below). | true
-| `ReplicaIndexDisabled boolean` | Whether or not to replicate indexes. | false
-| `RAMQuotaMB uint64` | How much memory should each node use for the bucket, required for creation. | true
-| `NumReplicas uint32` | The number of replicas to use for the bucket. | true
-| `BucketType BucketType` | The type of the bucket, required for creation. | false
-| `EvictionPolicy EvictionPolicyType` | The type of the eviction to use for the bucket, defaults to `valueOnly`. | true (note: changing will cause the bucket to restart causing temporary inaccessibility)
-| `MaxTTL time.Duration` | The default maximum time-to-live to apply to documents in the bucket. (note: This option is only available for Couchbase and Ephemeral buckets in Couchbase Enterprise Edition.) | true
-| `CompressionMode CompressionMode` | The compression mode to apply to documents in the bucket. (note: This option is only available for Couchbase and Ephemeral buckets in Couchbase Enterprise Edition.) | true
-| `ConflictResolutionType ConflictResolutionType` | The conflict resolution type to apply to conflicts on the bucket, defaults to `seqno` | false
+| `name string` | The name of the bucket, required for creation. | false
+| `flushEnabled boolean` | Enables flushing to be performed on this bucket (see the <<java-flushing>> section below). | true
+| `replicaIndexes boolean` | Whether or not to replicate indexes. | false
+| `ramQuotaMB uint64` | How much memory should each node use for the bucket, required for creation. | true
+| `numReplicas` int | The number of replicas to use for the bucket. | true
+| `bucketType BucketType` | The type of the bucket, required for creation. | false
+| `evictionPolicy EvictionPolicyType` | The type of the eviction to use for the bucket, defaults to `VALUE_ONLY`. | true (note: changing will cause the bucket to restart causing temporary inaccessibility)
+| `maxExpiry time.Duration` | The default maximum time-to-live to apply to documents in the bucket. (note: This option is only available for Couchbase and Ephemeral buckets in Couchbase Enterprise Edition.) | true
+| `compressionMode CompressionMode` | The compression mode to apply to documents in the bucket. (note: This option is only available for Couchbase and Ephemeral buckets in Couchbase Enterprise Edition.) | true
+| `conflictResolutionType ConflictResolutionType` | The conflict resolution type to apply to conflicts on the bucket, defaults to `SEQUENCE_NUMBER` | false
 |====
 
 The following example creates a "hello" bucket:
 
-[source,golang,indent=0]
+[source,java]
 ----
-include::devguide:example$go/provisioning-resources-buckets.go[tag=createBucket]
+include::example$ProvisioningResourcesBuckets.java[tag=createBucket,indent=0]
 ----
 
 We can now get this bucket and update it to enable Flush:
 
-[source,golang,indent=0]
+[source,java]
 ----
-include::devguide:example$go/provisioning-resources-buckets.go[tag=updateBucket]
+include::example$ProvisioningResourcesBuckets.java[tag=updateBucket,indent=0]
 ----
 
 Once you no longer need to use the bucket, you can remove it:
 
-[source,golang,indent=0]
+[source,java]
 ----
-include::devguide:example$go/provisioning-resources-buckets.go[tag=removeBucket]
+include::example$ProvisioningResourcesBuckets.java[tag=removeBucket,indent=0]
 ----
-////
 
-[#go-flushing]
+[#java-flushing]
 == Flushing Buckets
 
-include::7.0@sdk:shared:partial$flush-info-pars.adoc[tag=flush-intro]
+include::{version-server}@sdk:shared:partial$flush-info-pars.adoc[tag=flush-intro]
 
-You can flush a bucket in the SDK by using the `FlushBucketOptions` -- see the https://docs.couchbase.com/sdk-api/couchbase-java-client/com/couchbase/client/java/manager/bucket/FlushBucketOptions.html[API docs].
-////
-[source,golang,indent=0]
+You can flush a bucket in the SDK by using the `flushBucket` method:
+
+[source,java]
 ----
-include::devguide:example$go/provisioning-resources-buckets.go[tag=flushBucket]
+include::example$ProvisioningResourcesBuckets.java[tag=flushBucket,indent=0]
 ----
 
-The `Flush` operation may fail if the bucket does not have flush enabled, in that case it will return an `ErrBucketNotFlushable`.
-////
-
+The `Flush` operation may fail if the bucket does not have flush enabled, in that case it will return a `BucketNotFlushableException`.
 
 == Collection Management
 
@@ -150,34 +152,82 @@ include::example$CollectionManagerExample.java[tag=scopeAdmin, indent=0]
 
 == Index Management
 
-In general,you will rarely need to work with Index Managers from the SDK.
-For those occasions when you do, please see the relevant API docs:
+include::{version-server}@sdk:shared:partial$flush-info-pars.adoc[tag=index-management-intro]
 
-* QueryIndexManager -- https://docs.couchbase.com/sdk-api/couchbase-java-client/com/couchbase/client/java/manager/query/QueryIndexManager.html[`QueryIndexManager(AsyncQueryIndexManager async)`];
-* AnalyticsIndexManager -- https://docs.couchbase.com/sdk-api/couchbase-java-client/com/couchbase/client/java/manager/analytics/AnalyticsIndexManager.html[`AnalyticsIndexManager(Cluster cluster)`];
-* SearchIndexManager -- https://docs.couchbase.com/sdk-api/couchbase-java-client/com/couchbase/client/java/manager/search/SearchIndexManager.html[`SearchIndexManager(AsyncSearchIndexManager asyncIndexManager)`];
-* ViewIndexManager -- https://docs.couchbase.com/sdk-api/couchbase-java-client/com/couchbase/client/java/manager/view/ViewIndexManager.html[`ViewIndexManager(AsyncViewIndexManager async)`].
+=== QueryIndexManager
 
-// * Query
+The `QueryIndexManager` interface contains the means for managing indexes used for queries.
+It can be instantiated through the `Cluster.queryIndexes()` method.
+
+include::{version-server}@sdk:shared:partial$flush-info-pars.adoc[tag=query-index-manager-intro]
+
+The example below shows how to create a simple primary index, restricted to a named scope and collection, by calling the `createPrimaryIndex()` method.
+Note that you cannot provide a named scope or collection separately, both must be set for the `QueryIndexManager` to create an index on the relevant keyspace path. 
+
+.Creating a primary index
+
+[source,java]
+----
+include::example$QueryIndexManagerExample.java[tag=primary,indent=0]
+----
+
+When a primary index name is not specified, the SDK will create the index as `#primary` by default.
+However, if you wish to provide a custom name, you can simply set an `indexName` property in the `CreatePrimaryQueryIndexOptions` object.
+
+You may have noticed that the example also sets the `ignoreIfExists` boolean flag. 
+When set to `true`, this optional argument ensures that an exception is not thrown if an index under the same name already exists.
+
+Creating a _secondary_ index follows a similar approach, with some minor differences:
+
+.Creating a secondary index
+
+[source,java]
+----
+include::example$QueryIndexManagerExample.java[tag=secondary,indent=0]
+----
+
+The `createIndex()` method requires an index name to be provided, along with the fields to create the index on.
+Like the _primary_ index, you can restrict a _secondary_ index to a named scope and collection by passing some options.
+
+Indexes can easily take a long time to build if they contain a lot of documents.
+In these situations, it is more ideal to build indexes in the background.
+To achieve this we can use the `deferred` boolean option, and set it to `true`.
+
+.Deferring index creation
+
+[source,java]
+----
+include::example$QueryIndexManagerExample.java[tag=defer-indexes,indent=0]
+----
+
+To delete a query index you can use the `dropIndex()` or `dropPrimaryIndex()` methods. 
+Which one you use depends on the type of query index you wish to drop from the database.
+
+.Deleting an index
+
+[source,java]
+----
+include::example$QueryIndexManagerExample.java[tag=drop-primary-or-secondary-index,indent=0]
+----
 
 // * Search - note & link to FTS page & API?
 
 == View Management
 
-include::7.0@sdk:shared:partial$flush-info-pars.adoc[tag=view-management]
+include::{version-server}@sdk:shared:partial$flush-info-pars.adoc[tag=view-management]
 
-In the SDK, design documents are represented by the `DesignDocument` and `View` structs.
+In the SDK, design documents are represented by the `DesignDocument` and `View` objects.
 All operations on design documents are performed on the `ViewIndexManager` instance:
 
 ////
-[source,golang,indent=0]
+[source,java,indent=0]
 ----
 include::devguide:example$go/provisioning-resources-views.go[tag=viewmgr]
 ----
 
 The following example upserts a design document with two views:
 
-[source,golang,indent=0]
+[source,java,indent=0]
 ----
 include::devguide:example$go/provisioning-resources-views.go[tag=createView]
 ----
@@ -189,21 +239,21 @@ This parameter specifies whether the design document should be created as develo
 
 Now that we've created a design document we can fetch it:
 
-[source,golang,indent=0]
+[source,java,indent=0]
 ----
 include::devguide:example$go/provisioning-resources-views.go[tag=getView]
 ----
 
 We've created the design document using `DesignDocumentNamespaceDevelopment` and now want to push it to production, we can do this with:
 
-[source,golang,indent=0]
+[source,java,indent=0]
 ----
 include::devguide:example$go/provisioning-resources-views.go[tag=publishView]
 ----
 
 To remove this design document:
 
-[source,golang,indent=0]
+[source,java,indent=0]
 ----
 include::devguide:example$go/provisioning-resources-views.go[tag=removeView]
 ----

--- a/modules/test/test-howtos.bats
+++ b/modules/test/test-howtos.bats
@@ -154,3 +154,8 @@ load 'test_helper'
     runExample ProvisioningResourcesBuckets
     assert_success
 }
+
+@test "[howtos] - ProvisioningResourcesViews.java" {
+    runExample ProvisioningResourcesViews
+    assert_success
+}

--- a/modules/test/test-howtos.bats
+++ b/modules/test/test-howtos.bats
@@ -145,8 +145,8 @@ load 'test_helper'
     assert_output --partial "Got debug info as well"
 }
 
-@test "[howtos] - QueryIndexManager.java" {
-    runExample QueryIndexManager
+@test "[howtos] - QueryIndexManagerExample.java" {
+    runExample QueryIndexManagerExample
     assert_success
 }
 

--- a/modules/test/test-howtos.bats
+++ b/modules/test/test-howtos.bats
@@ -13,68 +13,68 @@ load 'test_helper'
 }
 
 @test "[howtos] - Auth.java" {
-    runExample Auth 
+    runExample Auth
     assert_success
 }
 
 @test "[howtos] - Cas.java" {
-    runExample Cas 
+    runExample Cas
     assert_success
 }
 
 @test "[howtos] - CollectingInformationAndLogging.java" {
-    runExample CollectingInformationAndLogging 
+    runExample CollectingInformationAndLogging
     assert_success
 }
 
 @test "[howtos] - CollectionManagerExample.java" {
-    runExample CollectionManagerExample 
+    runExample CollectionManagerExample
     assert_success
 }
 
 @test "[howtos] - EncryptingUsingSDK.java" {
     skip "Example requires a keystore, needs further investigation."
 
-    runExample EncryptingUsingSDK 
+    runExample EncryptingUsingSDK
     assert_success
 }
 
 @test "[howtos] - ErrorHandling.java" {
     skip "Need further investigation on how to check expected exceptions."
 
-    runExample ErrorHandling 
+    runExample ErrorHandling
     assert_success
 }
 
 @test "[howtos] - HealthCheck.java" {
-    runExample HealthCheck 
+    runExample HealthCheck
     assert_success
 }
 
 @test "[howtos] - Import.java" {
-    runExample Import 
+    runExample Import
     assert_success
 }
 
 @test "[howtos] - Json.java" {
-    runExample Json 
+    runExample Json
     assert_success
 }
 
 @test "[howtos] - KvOperations.java" {
-    runExample KvOperations 
+    runExample KvOperations
     assert_success
 }
 
 @test "[howtos] - managing_connections.java" {
-    runExample managing_connections 
+    runExample managing_connections
     assert_success
 }
 
 @test "[howtos] - ManagingConnections.java" {
     skip "Example requires certificates and multiple nodes, unable to test."
 
-    runExample ManagingConnections 
+    runExample ManagingConnections
     assert_success
 }
 
@@ -86,7 +86,7 @@ load 'test_helper'
 }
 
 @test "[howtos] - Queries.java" {
-    runExample Queries 
+    runExample Queries
     assert_success
 }
 
@@ -137,10 +137,20 @@ load 'test_helper'
 }
 
 @test "[howtos] - Views.java" {
-    runExample Views 
+    runExample Views
     assert_success
 
     # example tag: views-meta
     assert_output --partial "Got total rows: 4"
     assert_output --partial "Got debug info as well"
+}
+
+@test "[howtos] - QueryIndexManager.java" {
+    runExample QueryIndexManager
+    assert_success
+}
+
+@test "[howtos] - ProvisioningResourcesBuckets.java" {
+    runExample ProvisioningResourcesBuckets
+    assert_success
 }


### PR DESCRIPTION
- Use changes made in this sdk-common PR:
  https://github.com/couchbase/docs-sdk-common/pull/47

- Add Index management examples with scopes and collections (new in 3.3)

- Fill in examples that were missing/commented out, apart from Views.
  Let me know if I should add some views examples in though,
  I just thought we generally don't want to mention too much about them in the docs,
  assuming that they will be gone in some distant future...
  **UPDATE:** Views examples added!