### PR TITLE
Updating transactions documentation for SDK integration in 3.3

### DIFF
--- a/modules/hello-world/pages/overview.adoc
+++ b/modules/hello-world/pages/overview.adoc
@@ -71,7 +71,7 @@ xref:howtos:n1ql-queries-with-sdk.adoc[Query];
 xref:howtos:full-text-searching-with-sdk.adoc[Search]; 
 xref:howtos:analytics-using-sdk.adoc[Analytics]; 
 xref:howtos:view-queries-with-sdk.adoc[Views] -- 
-and the xref:howtos:subdocument-operations.adoc[Sub-Document API].
+and the xref:howtos:subdocument-operations.adoc[Sub-Document] and xref:howtos:distributed-acid-transactions-from-the-sdk.adoc[transaction] APIs.
 
 [.column]
 ====== {empty}

--- a/modules/howtos/examples/TransactionsExample.java
+++ b/modules/howtos/examples/TransactionsExample.java
@@ -15,58 +15,57 @@
  */
 
 // tag::imports[]
-import java.time.Duration;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Logger;
 
-import com.couchbase.client.core.cnc.Event;
-import com.couchbase.client.core.cnc.RequestSpan;
+import com.couchbase.client.core.error.CouchbaseException;
+import com.couchbase.client.core.error.DocumentNotFoundException;
+import com.couchbase.client.core.msg.kv.DurabilityLevel;
+import com.couchbase.client.core.transactions.events.IllegalDocumentStateEvent;
+import com.couchbase.client.core.transactions.events.TransactionCleanupAttemptEvent;
+import com.couchbase.client.core.transactions.events.TransactionCleanupEndRunEvent;
+import com.couchbase.client.core.transactions.events.TransactionEvent;
+import com.couchbase.client.core.transactions.log.CoreTransactionLogMessage;
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
+import com.couchbase.client.java.ClusterOptions;
 import com.couchbase.client.java.Collection;
-import com.couchbase.client.java.Scope;
-import com.couchbase.client.java.ReactiveCollection;
 import com.couchbase.client.java.ReactiveScope;
 import com.couchbase.client.java.Scope;
+import com.couchbase.client.java.env.ClusterEnvironment;
 import com.couchbase.client.java.json.JsonArray;
 import com.couchbase.client.java.json.JsonObject;
-import com.couchbase.client.java.kv.GetResult;
 import com.couchbase.client.java.query.QueryOptions;
 import com.couchbase.client.java.query.QueryProfile;
-import com.couchbase.client.java.query.QueryResult;
 import com.couchbase.client.java.query.QueryScanConsistency;
+import com.couchbase.client.java.transactions.TransactionKeyspace;
+import com.couchbase.client.java.transactions.TransactionQueryOptions;
+import com.couchbase.client.java.transactions.TransactionQueryResult;
+import com.couchbase.client.java.transactions.TransactionResult;
+import com.couchbase.client.java.transactions.config.TransactionsCleanupConfig;
+import com.couchbase.client.java.transactions.config.TransactionsConfig;
+import com.couchbase.client.java.transactions.config.TransactionsQueryConfig;
+import com.couchbase.client.java.transactions.error.TransactionCommitAmbiguousException;
+import com.couchbase.client.java.transactions.error.TransactionFailedException;
+import com.couchbase.client.java.transactions.log.TransactionLogMessage;
 import com.couchbase.client.tracing.opentelemetry.OpenTelemetryRequestSpan;
-import com.couchbase.transactions.SingleQueryTransactionResult;
-import com.couchbase.transactions.TransactionDurabilityLevel;
-import com.couchbase.transactions.TransactionGetResult;
-import com.couchbase.transactions.TransactionQueryOptions;
-import com.couchbase.transactions.TransactionResult;
-import com.couchbase.transactions.Transactions;
-import com.couchbase.transactions.config.PerTransactionConfigBuilder;
-import com.couchbase.transactions.config.SingleQueryTransactionConfigBuilder;
-import com.couchbase.transactions.config.TransactionConfigBuilder;
-import com.couchbase.transactions.deferred.TransactionSerializedContext;
-import com.couchbase.transactions.error.TransactionCommitAmbiguous;
-import com.couchbase.transactions.error.TransactionFailed;
-import com.couchbase.transactions.log.IllegalDocumentState;
-import com.couchbase.transactions.log.LogDefer;
-import com.couchbase.transactions.log.TransactionCleanupAttempt;
-import com.couchbase.transactions.log.TransactionCleanupEndRunEvent;
-
 import io.opentelemetry.api.trace.Span;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Logger;
+
+import static com.couchbase.client.java.transactions.config.SingleQueryTransactionOptions.singleQueryTransactionOptions;
+import static com.couchbase.client.java.transactions.config.TransactionOptions.transactionOptions;
+
 // end::imports[]
 
 public class TransactionsExample {
+    static Logger logger = Logger.getLogger(TransactionsExample.class.getName());
     static Cluster cluster;
     static Collection collection;
-    static Transactions transactions;
 
     public static void main(String... args) {
         // tag::init[]
@@ -75,88 +74,113 @@ public class TransactionsExample {
         Bucket bucket = cluster.bucket("travel-sample");
         Scope scope = bucket.scope("inventory");
         Collection collection = scope.collection("airport");
-
-        // Create the single Transactions object
-        Transactions transactions = Transactions.create(cluster);
         // end::init[]
 
         TransactionsExample.cluster = cluster;
         TransactionsExample.collection = collection;
-        TransactionsExample.transactions = transactions;
 
         queryExamples();
     }
 
     static void config() {
         // tag::config[]
-        Transactions transactions = Transactions.create(cluster,
-                TransactionConfigBuilder.create().durabilityLevel(TransactionDurabilityLevel.PERSIST_TO_MAJORITY)
-                        // tag::config_warn[]
-                        .logOnFailure(true, Event.Severity.WARN)
-                        // end::config_warn[]
-                        .build());
+        var env = ClusterEnvironment.builder()
+                .transactionsConfig(TransactionsConfig.durabilityLevel(DurabilityLevel.PERSIST_TO_MAJORITY)
+                        .cleanupConfig(TransactionsCleanupConfig.cleanupWindow(Duration.ofSeconds(30)))
+                        .queryConfig(TransactionsQueryConfig.scanConsistency(QueryScanConsistency.NOT_BOUNDED)))
+                .build();
+
+        var cluster = Cluster.connect("localhost", ClusterOptions.clusterOptions("username", "password")
+                .environment(env));
+
+        // Use the cluster
+        // ...
+
+        // Shutdown
+        cluster.disconnect();
+        env.shutdown();
         // end::config[]
+    }
+
+    static void configEasy() {
+        // tag::config-easy[]
+        var cluster = Cluster.connect("localhost", ClusterOptions.clusterOptions("username", "password")
+                .environment(env -> env.transactionsConfig(TransactionsConfig
+                        .durabilityLevel(DurabilityLevel.PERSIST_TO_MAJORITY)
+                        .cleanupConfig(TransactionsCleanupConfig
+                                .cleanupWindow(Duration.ofSeconds(30)))
+                        .queryConfig(TransactionsQueryConfig
+                                .scanConsistency(QueryScanConsistency.NOT_BOUNDED)))));
+        // Use the cluster
+        // ...
+
+        // Shutdown
+        cluster.disconnect();
+        // end::config-easy[]
+    }
+
+    static void createSimple() {
+        var doc1Content = JsonObject.create();
+        var doc2Content = JsonObject.create();
+
+        // tag::create-simple[]
+        cluster.transactions().run((ctx) -> {
+            ctx.insert(collection, "doc1", doc1Content);
+
+            var doc2 = ctx.get(collection, "doc2");
+            ctx.replace(doc2, doc2Content);
+        });
+        // end::create-simple[]
     }
 
     static void create() {
         // tag::create[]
         try {
-            transactions.run((ctx) -> {
-                // 'ctx' is an AttemptContext, which permits getting, inserting,
+            cluster.transactions().run((ctx) -> {
+                // 'ctx' is a TransactionAttemptContext, which permits getting, inserting,
                 // removing and replacing documents, performing N1QL queries, and committing or
                 // rolling back the transaction.
 
                 // ... Your transaction logic here ...
 
-                // This call is optional - if you leave it off, the transaction
-                // will be committed anyway.
-                ctx.commit();
+                // If the lambda succeeds, the transaction is automatically committed.
             });
             // tag::logging[]
-        } catch (TransactionCommitAmbiguous e) {
-            // The application will of course want to use its own logging rather
-            // than System.err
-            System.err.println("Transaction possibly committed");
-
-            for (LogDefer err : e.result().log().logs()) {
-                System.err.println(err.toString());
-            }
-        } catch (TransactionFailed e) {
-            System.err.println("Transaction did not reach commit point");
-
-            for (LogDefer err : e.result().log().logs()) {
-                System.err.println(err.toString());
-            }
+        } catch (TransactionCommitAmbiguousException e) {
+            throw logCommitAmbiguousError(e);
+        } catch (TransactionFailedException e) {
+            throw logFailure(e);
         }
         // end::logging[]
         // end::create[]
     }
 
+    static void loggingSucccess() {
+        // tag::logging-success[]
+        var result = cluster.transactions().run((ctx) -> {
+            // Your transaction logic
+        });
+
+        result.logs().forEach(message -> logger.info(message.toString()));
+        // end::logging-success[]
+    }
+
     static void createReactive() {
         // tag::createReactive[]
-        Mono<TransactionResult> result = transactions.reactive().run((ctx) -> {
-            // 'ctx' is an AttemptContextReactive, providing asynchronous versions of the
-            // AttemptContext methods
-
-            return
+        Mono<TransactionResult> result = cluster.reactive().transactions().run((ctx) -> {
+            // 'ctx' is a TransactionAttemptContextReactive, providing asynchronous versions of the
+            // TransactionAttemptContext methods.
 
             // Your transaction logic here: as an example, get and remove a doc
-            ctx.get(collection.reactive(), "document-id").flatMap(doc -> ctx.remove(doc))
+            return ctx.get(collection.reactive(), "document-id")
 
-                    // The commit call is optional - if you leave it off,
-                    // the transaction will be committed anyway.
-                    .then(ctx.commit());
+                    .flatMap(doc -> ctx.remove(doc));
             // tag::async_logging[]
         }).doOnError(err -> {
-            if (err instanceof TransactionCommitAmbiguous) {
-                System.err.println("Transaction possibly committed: ");
-            } else {
-                System.err.println("Transaction failed: ");
-            }
-
-            for (LogDefer e : ((TransactionFailed) err).result().log().logs()) {
-                // System.err is used for example, log failures to your own logging system
-                System.err.println(err.toString());
+            if (err instanceof TransactionCommitAmbiguousException) {
+                throw logCommitAmbiguousError((TransactionCommitAmbiguousException) err);
+            } else if (err instanceof TransactionFailedException) {
+                throw logFailure((TransactionFailedException) err);
             }
         });
         // end::async_logging[]
@@ -172,54 +196,38 @@ public class TransactionsExample {
         Scope inventory = cluster.bucket("travel-sample").scope("inventory");
 
         try {
-            TransactionResult result = transactions.run((ctx) -> {
+            var result = cluster.transactions().run((ctx) -> {
                 // Inserting a doc:
                 ctx.insert(collection, "doc-a", JsonObject.create());
 
                 // Getting documents:
-                // Use ctx.getOptional if the document may or may not exist
-                Optional<TransactionGetResult> docOpt = ctx.getOptional(collection, "doc-a");
-
-                // Use ctx.get if the document should exist, and the transaction
-                // will fail if it does not
-                TransactionGetResult docA = ctx.get(collection, "doc-a");
+                var docA = ctx.get(collection, "doc-a");
 
                 // Replacing a doc:
-                TransactionGetResult docB = ctx.get(collection, "doc-b");
-                JsonObject content = docB.contentAs(JsonObject.class);
+                var docB = ctx.get(collection, "doc-b");
+                var content = docB.contentAs(JsonObject.class);
                 content.put("transactions", "are awesome");
                 ctx.replace(docB, content);
 
                 // Removing a doc:
-                TransactionGetResult docC = ctx.get(collection, "doc-c");
+                var docC = ctx.get(collection, "doc-c");
                 ctx.remove(docC);
 
                 // Performing a SELECT N1QL query against a scope:
-                QueryResult qr = ctx.query(inventory, "SELECT * FROM hotel WHERE country = $1",
+                var qr = ctx.query(inventory, "SELECT * FROM hotel WHERE country = $1",
                         TransactionQueryOptions.queryOptions()
                                 .parameters(JsonArray.from("United Kingdom")));
-                List<JsonObject> rows = qr.rowsAs(JsonObject.class);
+                var rows = qr.rowsAs(JsonObject.class);
 
                 // Performing an UPDATE N1QL query on multiple documents, in the `inventory` scope:
                 ctx.query(inventory, "UPDATE route SET airlineid = $1 WHERE airline = $2",
                         TransactionQueryOptions.queryOptions()
                                 .parameters(JsonArray.from("airline_137", "AF")));
-
-                // Committing (the ctx.commit() call is optional)
-                ctx.commit();
             });
-        } catch (TransactionCommitAmbiguous e) {
-            System.err.println("Transaction possibly committed");
-
-            for (LogDefer err : e.result().log().logs()) {
-                System.err.println(err.toString());
-            }
-        } catch (TransactionFailed e) {
-            System.err.println("Transaction did not reach commit point");
-
-            for (LogDefer err : e.result().log().logs()) {
-                System.err.println(err.toString());
-            }
+        } catch (TransactionCommitAmbiguousException e) {
+            throw logCommitAmbiguousError(e);
+        } catch (TransactionFailedException e) {
+            throw logFailure(e);
         }
         // end::examples[]
     }
@@ -228,14 +236,13 @@ public class TransactionsExample {
         // tag::examplesReactive[]
         ReactiveScope inventory = cluster.bucket("travel-sample").scope("inventory").reactive();
 
-        Mono<TransactionResult> result = transactions.reactive().run((ctx) -> {
-            return
+        Mono<TransactionResult> result = cluster.reactive().transactions().run((ctx) -> {
             // Inserting a doc:
-            ctx.insert(collection.reactive(), "doc-a", JsonObject.create())
+            return ctx.insert(collection.reactive(), "doc-a", JsonObject.create())
 
                     // Getting and replacing a doc:
                     .then(ctx.get(collection.reactive(), "doc-b")).flatMap(docB -> {
-                        JsonObject content = docB.contentAs(JsonObject.class);
+                        var content = docB.contentAs(JsonObject.class);
                         content.put("transactions", "are awesome");
                         return ctx.replace(docB, content);
                     })
@@ -249,28 +256,21 @@ public class TransactionsExample {
                             TransactionQueryOptions.queryOptions()
                                     .parameters(JsonArray.from("United Kingdom"))))
 
-                    .doOnNext(queryResult -> queryResult.rowsAs(JsonObject.class)
-                            .doOnNext(row -> {
-                                // the application would do something with each row here
-                            }))
+                    .flatMap(queryResult -> {
+                        var rows = queryResult.rowsAs(JsonObject.class);
+                        // The application would do something with the rows here.
+                        return Mono.empty();
+                    })
 
                     // Performing an UPDATE N1QL query on multiple documents, in the `inventory` scope:
                     .then(ctx.query(inventory, "UPDATE route SET airlineid = $1 WHERE airline = $2",
                             TransactionQueryOptions.queryOptions()
-                                    .parameters(JsonArray.from("airline_137", "AF"))))
-
-                    .then(ctx.commit());
-
+                                    .parameters(JsonArray.from("airline_137", "AF"))));
         }).doOnError(err -> {
-            if (err instanceof TransactionCommitAmbiguous) {
-                System.err.println("Transaction possibly committed: ");
-            } else {
-                System.err.println("Transaction failed: ");
-            }
-
-            for (LogDefer e : ((TransactionFailed) err).result().log().logs()) {
-                // System.err is used for example, log failures to your own logging system
-                System.err.println(err.toString());
+            if (err instanceof TransactionCommitAmbiguousException) {
+                throw logCommitAmbiguousError((TransactionCommitAmbiguousException) err);
+            } else if (err instanceof TransactionFailedException) {
+                throw logFailure((TransactionFailedException) err);
             }
         });
 
@@ -283,53 +283,60 @@ public class TransactionsExample {
 
     static void insert() {
         // tag::insert[]
-        transactions.reactive().run((ctx) -> {
-            return ctx.insert(collection.reactive(), "docId", JsonObject.create()).then();
-        }).block();
+        cluster.transactions().run((ctx) -> {
+            String docId = "docId";
+
+            ctx.insert(collection, docId, JsonObject.create());
+        });
         // end::insert[]
     }
 
     static void insertReactive() {
         // tag::insertReactive[]
-        transactions.run((ctx) -> {
-            String docId = "docId";
-
-            ctx.insert(collection, docId, JsonObject.create());
-
-        });
+        cluster.reactive().transactions().run((ctx) -> {
+            return ctx.insert(collection.reactive(), "docId", JsonObject.create());
+        }).block();
         // end::insertReactive[]
+    }
+
+    static void getCatch() {
+        // tag::get-catch[]
+        cluster.transactions().run((ctx) -> {
+            try {
+                var doc = ctx.get(collection, "a-doc");
+            }
+            catch (DocumentNotFoundException err) {
+                // The application can continue the transaction here if needed, or take alternative action
+            }
+        });
+        // end::get-catch[]
     }
 
     static void get() {
         // tag::get[]
-        transactions.run((ctx) -> {
-            String docId = "a-doc";
-
-            Optional<TransactionGetResult> docOpt = ctx.getOptional(collection, docId);
-            TransactionGetResult doc = ctx.get(collection, docId);
+        cluster.transactions().run((ctx) -> {
+            var doc = ctx.get(collection, "a-doc");
         });
         // end::get[]
     }
 
     static void getReadOwnWrites() {
         // tag::getReadOwnWrites[]
-        transactions.run((ctx) -> {
+        cluster.transactions().run((ctx) -> {
             String docId = "docId";
 
             ctx.insert(collection, docId, JsonObject.create());
 
-            Optional<TransactionGetResult> doc = ctx.getOptional(collection, docId);
-
-            assert (doc.isPresent());
+            var doc = ctx.get(collection, docId);
         });
         // end::getReadOwnWrites[]
     }
 
     static void replace() {
         // tag::replace[]
-        transactions.run((ctx) -> {
-            TransactionGetResult doc = ctx.get(collection, "doc-id");
-            JsonObject content = doc.contentAs(JsonObject.class);
+        cluster.transactions().run((ctx) -> {
+            var doc = ctx.get(collection, "doc-id");
+            var content = doc.contentAs(JsonObject.class);
             content.put("transactions", "are awesome");
             ctx.replace(doc, content);
         });
@@ -338,20 +345,20 @@ public class TransactionsExample {
 
     static void replaceReactive() {
         // tag::replaceReactive[]
-        transactions.reactive().run((ctx) -> {
+        cluster.reactive().transactions().run((ctx) -> {
             return ctx.get(collection.reactive(), "doc-id").flatMap(doc -> {
-                JsonObject content = doc.contentAs(JsonObject.class);
+                var content = doc.contentAs(JsonObject.class);
                 content.put("transactions", "are awesome");
                 return ctx.replace(doc, content);
-            }).then(ctx.commit());
+            });
         });
         // end::replaceReactive[]
     }
 
     static void remove() {
         // tag::remove[]
-        transactions.run((ctx) -> {
-            TransactionGetResult doc = ctx.get(collection, "doc-id");
+        cluster.transactions().run((ctx) -> {
+            var doc = ctx.get(collection, "doc-id");
             ctx.remove(doc);
         });
         // end::remove[]
@@ -359,26 +366,11 @@ public class TransactionsExample {
 
     static void removeReactive() {
         // tag::removeReactive[]
-        transactions.reactive().run((ctx) -> {
-            return ctx.get(collection.reactive(), "anotherDoc").flatMap(doc -> ctx.remove(doc));
+        cluster.reactive().transactions().run((ctx) -> {
+            return ctx.get(collection.reactive(), "anotherDoc")
+                    .flatMap(doc -> ctx.remove(doc));
         });
         // end::removeReactive[]
-    }
-
-    static void commit() {
-        // tag::commit[]
-        Mono<TransactionResult> result = transactions.reactive().run((ctx) -> {
-            return ctx.get(collection.reactive(), "anotherDoc").flatMap(doc -> {
-                JsonObject content = doc.contentAs(JsonObject.class);
-                content.put("transactions", "are awesome");
-                return ctx.replace(doc, content);
-            }).then();
-        });
-        // end::commit[]
-    }
-
-    static Transactions getTransactions() {
-        return transactions;
     }
 
     static int calculateLevelForExperience(int experience) {
@@ -387,20 +379,17 @@ public class TransactionsExample {
 
     // tag::full[]
     public void playerHitsMonster(int damage, String playerId, String monsterId) {
-        Transactions transactions = getTransactions();
-
         try {
-            transactions.run((ctx) -> {
-                TransactionGetResult monsterDoc = ctx.get(collection, monsterId);
-                TransactionGetResult playerDoc = ctx.get(collection, playerId);
+            cluster.transactions().run((ctx) -> {
+                var monsterDoc = ctx.get(collection, monsterId);
+                var playerDoc = ctx.get(collection, playerId);
 
                 int monsterHitpoints = monsterDoc.contentAs(JsonObject.class).getInt("hitpoints");
                 int monsterNewHitpoints = monsterHitpoints - damage;
 
                 if (monsterNewHitpoints <= 0) {
                     // Monster is killed. The remove is just for demoing, and a more realistic
-                    // example would set a
-                    // "dead" flag or similar.
+                    // example would set a "dead" flag or similar.
                     ctx.remove(monsterDoc);
 
                     // The player earns experience for killing the monster
@@ -410,7 +399,7 @@ public class TransactionsExample {
                     int playerNewExperience = playerExperience + experienceForKillingMonster;
                     int playerNewLevel = calculateLevelForExperience(playerNewExperience);
 
-                    JsonObject playerContent = playerDoc.contentAs(JsonObject.class);
+                    var playerContent = playerDoc.contentAs(JsonObject.class);
 
                     playerContent.put("experience", playerNewExperience);
                     playerContent.put("level", playerNewLevel);
@@ -418,19 +407,16 @@ public class TransactionsExample {
                     ctx.replace(playerDoc, playerContent);
                 } else {
                     // Monster is damaged but still alive
-                    JsonObject monsterContent = monsterDoc.contentAs(JsonObject.class);
+                    var monsterContent = monsterDoc.contentAs(JsonObject.class);
                     monsterContent.put("hitpoints", monsterNewHitpoints);
 
                     ctx.replace(monsterDoc, monsterContent);
                 }
             });
-        } catch (TransactionFailed e) {
-            // The operation failed. Both the monster and the player will be untouched.
-
-            // Situations that can cause this would include either the monster
-            // or player not existing (as get is used), or a persistent
-            // failure to be able to commit the transaction, for example on
-            // prolonged node failure.
+        } catch (TransactionCommitAmbiguousException e) {
+            throw logCommitAmbiguousError(e);
+        } catch (TransactionFailedException e) {
+            throw logFailure(e);
         }
     }
     // end::full[]
@@ -438,36 +424,26 @@ public class TransactionsExample {
     static void concurrency() {
         // tag::concurrency[]
         cluster.environment().eventBus().subscribe(event -> {
-            if (event instanceof IllegalDocumentState) {
+            if (event instanceof IllegalDocumentStateEvent) {
                 // log this event for review
+                log(((TransactionEvent) event).logs());
             }
         });
         // end::concurrency[]
     }
 
+    private static void log(List<CoreTransactionLogMessage> logs) {
+        // Application can write to their logs here
+    }
+
     static void cleanupEvents() {
         // tag::cleanup-events[]
         cluster.environment().eventBus().subscribe(event -> {
-            if (event instanceof TransactionCleanupAttempt || event instanceof TransactionCleanupEndRunEvent) {
-                // log this event
+            if (event instanceof TransactionCleanupAttemptEvent || event instanceof TransactionCleanupEndRunEvent) {
+                log(((TransactionEvent) event).logs());
             }
         });
         // end::cleanup-events[]
-    }
-
-    static void rollback() {
-        final int costOfItem = 10;
-
-        // tag::rollback[]
-        transactions.run((ctx) -> {
-            TransactionGetResult customer = ctx.get(collection, "customer-name");
-
-            if (customer.contentAsObject().getInt("balance") < costOfItem) {
-                ctx.rollback();
-            }
-            // else continue transaction
-        });
-        // end::rollback[]
     }
 
     static void rollbackCause() {
@@ -478,133 +454,70 @@ public class TransactionsExample {
         }
 
         try {
-            transactions.run((ctx) -> {
-                TransactionGetResult customer = ctx.get(collection, "customer-name");
+            cluster.transactions().run((ctx) -> {
+                var customer = ctx.get(collection, "customer-name");
 
                 if (customer.contentAsObject().getInt("balance") < costOfItem) {
                     throw new BalanceInsufficient();
                 }
                 // else continue transaction
             });
-        } catch (TransactionCommitAmbiguous e) {
+        } catch (TransactionCommitAmbiguousException e) {
             // This exception can only be thrown at the commit point, after the
             // BalanceInsufficient logic has been passed, so there is no need to
             // check getCause here.
-            System.err.println("Transaction possibly committed");
-            for (LogDefer err : e.result().log().logs()) {
-                System.err.println(err.toString());
-            }
-        } catch (TransactionFailed e) {
+            throw logCommitAmbiguousError(e);
+        } catch (TransactionFailedException e) {
             if (e.getCause() instanceof BalanceInsufficient) {
                 // Re-raise the error
                 throw (RuntimeException) e.getCause();
             } else {
-                System.err.println("Transaction did not reach commit point");
-
-                for (LogDefer err : e.result().log().logs()) {
-                    System.err.println(err.toString());
-                }
+                throw logFailure(e);
             }
         }
         // end::rollback-cause[]
     }
 
-    static void deferredCommit1() {
-
-        // tag::defer1[]
-        try {
-            TransactionResult result = transactions.run((ctx) -> {
-                JsonObject initial = JsonObject.create().put("val", 1);
-                ctx.insert(collection, "a-doc-id", initial);
-
-                // Defer means don't do a commit right now. `serialized` in the result will be
-                // present.
-                ctx.defer();
-            });
-
-            // Available because ctx.defer() was called
-            assert (result.serialized().isPresent());
-
-            TransactionSerializedContext serialized = result.serialized().get();
-
-            // This is going to store a serialized form of the transaction to pass around
-            byte[] encoded = serialized.encodeAsBytes();
-
-        } catch (TransactionFailed e) {
-            // System.err is used for example, log failures to your own logging system
-            System.err.println("Transaction did not reach commit point");
-
-            for (LogDefer err : e.result().log().logs()) {
-                System.err.println(err.toString());
-            }
-        }
-        // end::defer1[]
-    }
-
-    static void deferredCommit2(byte[] encoded) {
-        // tag::defer2[]
-        TransactionSerializedContext serialized = TransactionSerializedContext.createFrom(encoded);
-
-        try {
-            TransactionResult result = transactions.commit(serialized);
-
-        } catch (TransactionFailed e) {
-            // System.err is used for example, log failures to your own logging system
-            System.err.println("Transaction did not reach commit point");
-
-            for (LogDefer err : e.result().log().logs()) {
-                System.err.println(err.toString());
-            }
-        }
-        // end::defer2[]
-    }
-
-    static void deferredRollback(byte[] encoded) {
-        // tag::defer3[]
-        TransactionSerializedContext serialized = TransactionSerializedContext.createFrom(encoded);
-
-        try {
-            TransactionResult result = transactions.rollback(serialized);
-
-        } catch (TransactionFailed e) {
-            // System.err is used for example, log failures to your own logging system
-            System.err.println("Transaction did not reach commit point");
-
-            for (LogDefer err : e.result().log().logs()) {
-                System.err.println(err.toString());
-            }
-        }
-        // end::defer3[]
-    }
-
-    static void configExpiration(byte[] encoded) {
+    static void configExpiration() {
         // tag::config-expiration[]
-        Transactions transactions = Transactions.create(cluster,
-                TransactionConfigBuilder.create().expirationTime(Duration.ofSeconds(120)).build());
+        var cluster = Cluster.connect("localhost", ClusterOptions.clusterOptions("username", "password")
+                .environment(env -> env.transactionsConfig(TransactionsConfig.timeout(Duration.ofSeconds(120)))));
         // end::config-expiration[]
     }
 
-    static void configCleanup(byte[] encoded) {
+    static void configExpirationPer() {
+        // tag::config-expiration-per[]
+        cluster.transactions().run((ctx) -> {
+            // Your transaction logic
+        }, transactionOptions().timeout(Duration.ofSeconds(60)));
+        // end::config-expiration-per[]
+    }
+
+    static void configCleanup() {
+        var keyspace = TransactionKeyspace.create("bucketName", "scopeName", "collectionName");
+
         // tag::config-cleanup[]
-        Transactions transactions = Transactions.create(cluster,
-                TransactionConfigBuilder.create().cleanupClientAttempts(false).cleanupLostAttempts(false)
-                        .cleanupWindow(Duration.ofSeconds(120)).build());
+        var cluster = Cluster.connect("localhost", ClusterOptions.clusterOptions("username", "password")
+                .environment(env -> env.transactionsConfig(TransactionsConfig.cleanupConfig(TransactionsCleanupConfig
+                        .cleanupClientAttempts(true)
+                        .cleanupLostAttempts(true)
+                        .cleanupWindow(Duration.ofSeconds(120))
+                        .addCollections(List.of(keyspace))))));
         // end::config-cleanup[]
     }
 
     static void concurrentOps() {
         // tag::concurrentOps[]
         List<String> docIds = Arrays.asList("doc1", "doc2", "doc3", "doc4", "doc5");
-        ReactiveCollection coll = collection.reactive();
         int concurrency = 100; // This many operations will be in-flight at once
 
-        TransactionResult result = transactions.reactive((ctx) -> {
+        var result = cluster.reactive().transactions().run((ctx) -> {
             return Flux.fromIterable(docIds)
                     .parallel(concurrency)
                     .runOn(Schedulers.boundedElastic())
                     .concatMap(docId -> ctx.get(collection.reactive(), docId)
                             .flatMap(doc -> {
-                                JsonObject content = doc.contentAsObject();
+                                var content = doc.contentAsObject();
                                 content.put("value", "updated");
                                 return ctx.replace(doc, content);
                             }))
@@ -617,7 +530,7 @@ public class TransactionsExample {
     static void completeErrorHandling() {
         // tag::full-error-handling[]
         try {
-            TransactionResult result = transactions.run((ctx) -> {
+            var result = cluster.transactions().run((ctx) -> {
                 // ... transactional code here ...
             });
 
@@ -630,48 +543,21 @@ public class TransactionsExample {
                 // still working to complete the commit.)
                 // The next step is application-dependent.
             }
-        } catch (TransactionCommitAmbiguous err) {
-            // The transaction may or may not have reached commit point
-            System.err.println("Transaction returned TransactionCommitAmbiguous and may have succeeded, logs:");
-
-            // Of course, the application will want to use its own logging rather
-            // than System.err
-            err.result().log().logs().forEach(log -> System.err.println(log.toString()));
-        } catch (TransactionFailed err) {
-            // The transaction definitely did not reach commit point
-            System.err.println("Transaction failed with TransactionFailed, logs:");
-            err.result().log().logs().forEach(log -> System.err.println(log.toString()));
+        } catch (TransactionCommitAmbiguousException e) {
+            throw logCommitAmbiguousError(e);
+        } catch (TransactionFailedException e) {
+            throw logFailure(e);
         }
         // end::full-error-handling[]
     }
 
-    static void completeLogging() {
-        // tag::full-logging[]
-        final Logger LOGGER = Logger.getLogger("transactions");
-
-        try {
-            TransactionResult result = transactions.run((ctx) -> {
-                // ... transactional code here ...
-            });
-        } catch (TransactionCommitAmbiguous err) {
-            // The transaction may or may not have reached commit point
-            LOGGER.info("Transaction returned TransactionCommitAmbiguous and" + " may have succeeded, logs:");
-            err.result().log().logs().forEach(log -> LOGGER.info(log.toString()));
-        } catch (TransactionFailed err) {
-            // The transaction definitely did not reach commit point
-            LOGGER.info("Transaction failed with TransactionFailed, logs:");
-            err.result().log().logs().forEach(log -> LOGGER.info(log.toString()));
-        }
-        // end::full-logging[]
-    }
-
     static void queryExamples() {
         // tag::queryExamplesSelect[]
-        transactions.run((ctx) -> {
-            String st = "SELECT * FROM `travel-sample`.inventory.hotel WHERE country = $1";
-            QueryResult qr = ctx.query(st, TransactionQueryOptions.queryOptions()
+        cluster.transactions().run((ctx) -> {
+            var st = "SELECT * FROM `travel-sample`.inventory.hotel WHERE country = $1";
+            var qr = ctx.query(st, TransactionQueryOptions.queryOptions()
                     .parameters(JsonArray.from("United Kingdom")));
-            List<JsonObject> rows = qr.rowsAs(JsonObject.class);
+            var rows = qr.rowsAs(JsonObject.class);
         });
         // end::queryExamplesSelect[]
 
@@ -679,11 +565,11 @@ public class TransactionsExample {
         Bucket travelSample = cluster.bucket("travel-sample");
         Scope inventory = travelSample.scope("inventory");
 
-        transactions.run((ctx) -> {
-            QueryResult qr = ctx.query(inventory, "SELECT * FROM hotel WHERE country = $1",
+        cluster.transactions().run((ctx) -> {
+            var qr = ctx.query(inventory, "SELECT * FROM hotel WHERE country = $1",
                     TransactionQueryOptions.queryOptions()
                             .parameters(JsonArray.from("United States")));
-            List<JsonObject> rows = qr.rowsAs(JsonObject.class);
+            var rows = qr.rowsAs(JsonObject.class);
         });
         // end::queryExamplesSelectScope[]
 
@@ -691,8 +577,8 @@ public class TransactionsExample {
         String hotelChain = "http://marriot%";
         String country = "United States";
 
-        transactions.run((ctx) -> {
-            QueryResult qr = ctx.query(inventory, "UPDATE hotel SET price = $1 WHERE url LIKE $2 AND country = $3",
+        cluster.transactions().run((ctx) -> {
+            var qr = ctx.query(inventory, "UPDATE hotel SET price = $1 WHERE url LIKE $2 AND country = $3",
                     TransactionQueryOptions.queryOptions()
                             .parameters(JsonArray.from(99.99, hotelChain, country)));
             assert(qr.metaData().metrics().get().mutationCount() == 1);
@@ -700,9 +586,9 @@ public class TransactionsExample {
         // end::queryExamplesUpdate[]
 
         // tag::queryExamplesComplex[]
-        transactions.run((ctx) -> {
+        cluster.transactions().run((ctx) -> {
             // Find all hotels of the chain
-            QueryResult qr = ctx.query(inventory, "SELECT reviews FROM hotel WHERE url LIKE $1 AND country = $2",
+            var qr = ctx.query(inventory, "SELECT reviews FROM hotel WHERE url LIKE $1 AND country = $2",
                     TransactionQueryOptions.queryOptions()
                             .parameters(JsonArray.from(hotelChain, country)));
 
@@ -718,18 +604,18 @@ public class TransactionsExample {
         // end::queryExamplesComplex[]
     }
 
-    static double priceFromRecentReviews(QueryResult qr) {
+    static double priceFromRecentReviews(TransactionQueryResult qr) {
         return 1.0;
     }
 
     static void queryInsert() {
         // tag::queryInsert[]
-        transactions.run((ctx) -> {
+        cluster.transactions().run((ctx) -> {
             ctx.query("INSERT INTO `default` VALUES ('doc', {'hello':'world'})");  // <1>
 
             // Performing a 'Read Your Own Write'
-            String st = "SELECT `default`.* FROM `default` WHERE META().id = 'doc'"; // <2>
-            QueryResult qr = ctx.query(st);
+            var st = "SELECT `default`.* FROM `default` WHERE META().id = 'doc'"; // <2>
+            var qr = ctx.query(st);
             assert(qr.metaData().metrics().get().resultCount() == 1);
         });
         // end::queryInsert[]
@@ -740,22 +626,43 @@ public class TransactionsExample {
 
         // tag::querySingle[]
         try {
-            SingleQueryTransactionResult result = transactions.query(bulkLoadStatement);
-
-            QueryResult queryResult = result.queryResult();
-        } catch (TransactionCommitAmbiguous e) {
-            System.err.println("Transaction possibly committed");
-            for (LogDefer err : e.result().log().logs()) {
-                System.err.println(err.toString());
-            }
-        } catch (TransactionFailed e) {
-            System.err.println("Transaction did not reach commit point");
-            for (LogDefer err : e.result().log().logs()) {
-                System.err.println(err.toString());
-            }
+            var result = cluster.query(bulkLoadStatement, QueryOptions.queryOptions().asTransaction());
+        } catch (TransactionCommitAmbiguousException e) {
+            throw logCommitAmbiguousError(e);
+        } catch (TransactionFailedException e) {
+            throw logFailure(e);
+        } catch (CouchbaseException e) {
+            // Any standard query errors can be raised here too, such as ParsingFailureException.  In these cases the
+            // transaction definitely did not reach commit point.
+            logger.warning("Transaction did not reach commit point");
+            throw e;
         }
         // end::querySingle[]
     }
+
+    // tag::logger[]
+    public static RuntimeException logCommitAmbiguousError(TransactionCommitAmbiguousException err) {
+        // This example will intentionally not compile: the application needs to use
+        // its own logging system to replace `logger`.
+        logger.warning("Transaction possibly reached the commit point");
+
+        for (TransactionLogMessage msg : err.logs()) {
+            logger.warning(msg.toString());
+        }
+
+        return err;
+    }
+
+    public static RuntimeException logFailure(TransactionFailedException err) {
+        logger.warning("Transaction did not reach commit point");
+
+        for (TransactionLogMessage msg : err.logs()) {
+            logger.warning(msg.toString());
+        }
+
+        return err;
+    }
+    // end::logger[]
 
     static void querySingleScoped() {
         String bulkLoadStatement = null /* your statement here */;
@@ -764,7 +671,7 @@ public class TransactionsExample {
         Bucket travelSample = cluster.bucket("travel-sample");
         Scope inventory = travelSample.scope("inventory");
 
-        transactions.query(inventory, bulkLoadStatement);
+        inventory.query(bulkLoadStatement, QueryOptions.queryOptions().asTransaction());
         // end::querySingleScoped[]
     }
 
@@ -772,21 +679,22 @@ public class TransactionsExample {
         String bulkLoadStatement = null; /* your statement here */
 
         // tag::querySingleConfigured[]
-        transactions.query(bulkLoadStatement, SingleQueryTransactionConfigBuilder.create()
-            // Single query transactions will often want to increase the default timeout
-            .expirationTime(Duration.ofSeconds(360))
-            .build());
+        cluster.query(bulkLoadStatement, QueryOptions.queryOptions()
+                // Single query transactions will often want to increase the default timeout
+                .timeout(Duration.ofSeconds(360))
+                .asTransaction(singleQueryTransactionOptions()
+                        .durabilityLevel(DurabilityLevel.PERSIST_TO_MAJORITY)));
         // end::querySingleConfigured[]
     }
 
     static void queryRyow() {
         // tag::queryRyow[]
-        transactions.run((ctx) -> {
+        cluster.transactions().run((ctx) -> {
             ctx.insert(collection, "doc", JsonObject.create().put("hello", "world")); // <1>
 
             // Performing a 'Read Your Own Write'
-            String st = "SELECT `default`.* FROM `default` WHERE META().id = 'doc'"; // <2>
-            QueryResult qr = ctx.query(st);
+            var st = "SELECT `default`.* FROM `default` WHERE META().id = 'doc'"; // <2>
+            var qr = ctx.query(st);
             assert(qr.metaData().metrics().get().resultCount() == 1);
         });
         // end::queryRyow[]
@@ -794,7 +702,7 @@ public class TransactionsExample {
 
     static void queryOptions() {
         // tag::queryOptions[]
-        transactions.run((ctx) -> {
+        cluster.transactions().run((ctx) -> {
             ctx.query("INSERT INTO `default` VALUES ('doc', {'hello':'world'})",
                     TransactionQueryOptions.queryOptions().profile(QueryProfile.TIMINGS));
         });
@@ -803,30 +711,39 @@ public class TransactionsExample {
 
     static void customMetadata() {
         // tag::custom-metadata[]
-        Collection metadataCollection = null; // this is a Collection opened by your code earlier
-        Transactions transactions = Transactions.create(cluster,
-                TransactionConfigBuilder.create().metadataCollection(metadataCollection));
+        var keyspace = TransactionKeyspace.create("bucketName", "scopeName", "collectionName");
+
+        var cluster = Cluster.connect("localhost", ClusterOptions.clusterOptions("username", "password")
+                .environment(env -> env.transactionsConfig(TransactionsConfig.metadataCollection(keyspace))));
         // end::custom-metadata[]
+    }
+
+    static void customMetadataPer() {
+        // tag::custom-metadata-per[]
+        cluster.transactions().run((ctx) -> {
+            // Your transaction logic
+        }, transactionOptions().metadataCollection(collection));
+        // end::custom-metadata-per[]
     }
 
     static void tracing() {
         // #tag::tracing[]
-        RequestSpan span = cluster.environment().requestTracer().requestSpan("your-span-name", null);
+        var span = cluster.environment().requestTracer().requestSpan("your-span-name", null);
 
-        transactions.run((ctx) -> {
+        cluster.transactions().run((ctx) -> {
             // your transaction
-        }, PerTransactionConfigBuilder.create().parentSpan(span).build());
+        }, transactionOptions().parentSpan(span));
         // #end::tracing[]
     }
 
     static void tracingWrapped() {
         // #tag::tracing-wrapped[]
-        Span span = Span.current(); // this is a span created by your code earlier
-        RequestSpan wrapped = OpenTelemetryRequestSpan.wrap(span);
+        var span = Span.current(); // this is a span created by your code earlier
+        var wrapped = OpenTelemetryRequestSpan.wrap(span);
 
-        transactions.run((ctx) -> {
+        cluster.transactions().run((ctx) -> {
             // your transaction
-        }, PerTransactionConfigBuilder.create().parentSpan(wrapped).build());
+        }, transactionOptions().parentSpan(wrapped));
         // #end::tracing-wrapped[]
     }
 

--- a/modules/howtos/examples/TransactionsMigration.java
+++ b/modules/howtos/examples/TransactionsMigration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Couchbase, Inc.
+ * Copyright (c) 2022 Couchbase, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/howtos/examples/TransactionsMigration.java
+++ b/modules/howtos/examples/TransactionsMigration.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2020 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// tag::imports[]
+
+import com.couchbase.client.core.msg.kv.DurabilityLevel;
+import com.couchbase.client.java.Bucket;
+import com.couchbase.client.java.Cluster;
+import com.couchbase.client.java.ClusterOptions;
+import com.couchbase.client.java.Collection;
+import com.couchbase.client.java.Scope;
+import com.couchbase.client.java.query.QueryResult;
+import com.couchbase.client.java.transactions.TransactionKeyspace;
+import com.couchbase.client.java.transactions.config.TransactionsCleanupConfig;
+import com.couchbase.client.java.transactions.config.TransactionsConfig;
+import com.couchbase.client.java.transactions.error.TransactionCommitAmbiguousException;
+import com.couchbase.client.java.transactions.error.TransactionFailedException;
+
+import java.time.Duration;
+import java.util.logging.Logger;
+
+import static com.couchbase.client.java.query.QueryOptions.queryOptions;
+import static com.couchbase.client.java.transactions.config.SingleQueryTransactionOptions.singleQueryTransactionOptions;
+
+// end::imports[]
+
+public class TransactionsMigration {
+    static Logger logger = Logger.getLogger(TransactionsMigration.class.getName());
+    static Cluster cluster;
+    static Collection collection;
+
+    public static void main(String... args) {
+        // tag::init[]
+        // Initialize the Couchbase cluster
+        Cluster cluster = Cluster.connect("localhost", "username", "password");
+        Bucket bucket = cluster.bucket("travel-sample");
+        Scope scope = bucket.scope("inventory");
+        Collection collection = scope.collection("airport");
+        // end::init[]
+
+        TransactionsMigration.cluster = cluster;
+        TransactionsMigration.collection = collection;
+    }
+
+    static void access() {
+        // tag::access[]
+        cluster.transactions().run((ctx) -> {
+            // Your transaction logic.
+        });
+        // end::access[]
+    }
+
+    static void config() {
+        // tag::config[]
+        var keyspace = TransactionKeyspace.create("bucketName", "scopeName", "collectionName");
+
+        var cluster = Cluster.connect("localhost", ClusterOptions.clusterOptions("username", "password")
+                .environment(env -> env.transactionsConfig(TransactionsConfig
+                        .durabilityLevel(DurabilityLevel.PERSIST_TO_MAJORITY)
+                        .metadataCollection(keyspace))));
+        // end::config[]
+    }
+
+    static void singleQuery() {
+        // tag::single-query[]
+        QueryResult qr = cluster.query("INSERT...", queryOptions().asTransaction());
+        // end::single-query[]
+    }
+
+    static void singleQueryConfig() {
+        // tag::single-query-config[]
+        QueryResult qr = cluster.query("INSERT...",
+                queryOptions().asTransaction(
+                        singleQueryTransactionOptions()
+                                .durabilityLevel(DurabilityLevel.MAJORITY)));
+        // end::single-query-config[]
+    }
+
+    static void configCleanup() {
+        // tag::config-cleanup[]
+        var cluster = Cluster.connect("localhost", ClusterOptions.clusterOptions("username", "password")
+                .environment(env -> env.transactionsConfig(TransactionsConfig
+                                .cleanupConfig(TransactionsCleanupConfig
+                                        .cleanupClientAttempts(true)
+                                        .cleanupLostAttempts(true)
+                                        .cleanupWindow(Duration.ofSeconds(30))))));
+        // end::config-cleanup[]
+    }
+
+    static void log() {
+        try {
+            cluster.transactions().run((ctx) -> {
+                // Your transaction logic.
+            });
+        }
+        catch (TransactionCommitAmbiguousException err) {
+            logger.warning("Transaction possibly committed:");
+            err.logs().forEach(msg -> logger.warning(msg.toString()));
+        }
+        // tag::log[]
+        catch (TransactionFailedException err) {
+            err.logs().forEach(msg -> logger.warning(msg.toString()));
+        }
+        // end::log[]
+    }
+}

--- a/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
+++ b/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
@@ -14,52 +14,18 @@ include::partial$acid-transactions-attributes.adoc[]
 
 include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=intro]
 
-You may also want to start with our https://github.com/couchbaselabs/couchbase-transactions-java-examples[transactions examples repository],
-which features useful downloadable examples of using Distributed Transactions.
-
-Javadocs are available https://docs.couchbase.com/sdk-api/couchbase-transactions-java/index.html?overview-summary.html[online].
+// TODO update when available
+// Javadocs are available https://docs.couchbase.com/sdk-api/couchbase-transactions-java/index.html?overview-summary.html[online].
 
 
 == Requirements
 
 * Couchbase Server 6.6.1 or above.
-* Couchbase Java client 3.1.5 or above.
-It is recommended to follow the transitive dependency for the transactions library from Maven.
 include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=requirements]
 
+Couchbase transactions require no additional components or services to be configured.
 
 == Getting Started
-
-Couchbase transactions require no additional components or services to be configured. 
-Simply add the transactions library into your project.
-The latest version, as of February 2022, is 1.2.3.
-
-With Gradle this can be accomplished by modifying these sections of your build.gradle file like so:
-
-[source,gradle]
-----
-dependencies {
-    compile group: 'com.couchbase.client', name: 'couchbase-transactions', version: '1.2.3'
-}
-----
-
-Or with Maven:
-
-[source,maven]
-----
-<dependency>
-    <groupId>com.couchbase.client</groupId>
-    <artifactId>couchbase-transactions</artifactId>
-    <version>1.2.3</version>
-</dependency>
-----
-
-This will automatically pull in any transitive dependencies of this library, including a compatible version of the Couchbase Java SDK.
-
-A complete simple gradle project is available on our https://github.com/couchbaselabs/couchbase-transactions-java-examples[transactions examples repository].
-
-
-== Initializing Transactions
 
 To make it easy to use any of the following examples, here are all the imports used by them:
 
@@ -68,28 +34,29 @@ To make it easy to use any of the following examples, here are all the imports u
 include::example$TransactionsExample.java[tag=imports,indent=0]
 ----
 
-The starting point is the `Transactions` object.  
-It is very important that the application ensures that only one of these is created, as it performs automated background processes that should not be duplicated.
+Transactions are accessed via a `Cluster`.  A simple transaction that inserts one doc and updates the content of another looks like this (with error handling removed for brevity):
 
 [source,java]
 ----
-include::example$TransactionsExample.java[tag=init,indent=0]
+include::example$TransactionsExample.java[tag=create-simple,indent=0]
 ----
-
-=== Multiple Transactions Objects
-
-Generally an application will need just one `Transactions` object, and in fact the library will usually warn if more are created.
-Each `Transactions` object uses some resources, including a thread-pool.
-
-There is one rare exception where an application may need to create multiple `Transactions` objects, which is covered in <<Custom Metadata Collections>>.
 
 == Configuration
 
-Transactions can optionally be globally configured at the point of creating the `Transactions` object:
+The default configuration should be appropriate for most use-cases.
+If needed, transactions can be globally configured at the point of creating the `Cluster`.
+As usual with `Cluster` configuration, you can either explicitly create and manage the `ClusterEnvironment` yourself:
 
 [source,java]
 ----
 include::example$TransactionsExample.java[tag=config,indent=0]
+----
+
+or alternatively use this lambda syntax, which leads to the `ClusterEnvironment` being owned and managed by the `Cluster`:
+
+[source,java]
+----
+include::example$TransactionsExample.java[tag=config-easy,indent=0]
 ----
 
 include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=config]
@@ -97,7 +64,7 @@ include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=config]
 
 include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=creating]
 
-As with the Couchbase Java Client, you can use the library in either synchronous mode:
+You can create transactions in either synchronous mode:
 
 [source,java]
 ----
@@ -117,6 +84,15 @@ Those new to reactive programming may want to check out https://projectreactor.i
 
 include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=lambda-ctx]
 
+The following helper logging methods will be used throughout the examples.
+Transaction logging is too verbose to be sent to the Java SDK event-bus, so instead it is stored in an in-memory log that can be accessed both from `TransactionResult` and `TransactionFailedException`.
+It is a good practice for the application to log any failed transactions into its own logging system, here represented with a `logger` object:
+[source,java]
+----
+include::example$TransactionsExample.java[tag=logger,indent=0]
+----
+See the <<Logging>> documentation for more detail.
+
 // Examples
 include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=examples-intro]
 
@@ -134,17 +110,18 @@ include::example$TransactionsExample.java[tag=examplesReactive,indent=0]
 ----
 
 
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=mechanics;!integrated-sdk-cleanup-process]
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=mechanics;!library-cleanup-process]
 
 
 == Key-Value Mutations
 
+IMPORTANT: Make sure to use the transactional Key-Value operations inside the lambda, such as `ctx.insert()`, rather than `collection.insert()`.
+Those would be executed as regular non-transactional Key-Value operations, and since the lambda can be executed multiple times, so could those operations.
+
 === Replacing
 
 Replacing a document requires a `ctx.get()` call first.
-This is necessary so that the transactions library can check that the document is not involved in another transaction.
-If it is, then the transactions library will handle this at the `ctx.replace()` point.  
-Generally, this involves rolling back what has been done so far, and retrying the lambda.
+This is necessary so that the SDK can check that the document is not involved in another transaction, and take appropriate action if so.
 
 .With the synchronous API:
 [source,java]
@@ -177,7 +154,7 @@ include::example$TransactionsExample.java[tag=removeReactive,indent=0]
 NOTE: For those using the asynchronous API - some `ctx` methods, notably `ctx.remove()`, return `Mono<Void>`.
 There is a common 'gotcha' with `Mono<Void>` in that it does not trigger a 'next' reactive event - only a 'completion' event.
 This means that some reactive operators chained afterwards - including the common `flatMap` - will not trigger.
-Generally, you will to do `ctx.remove(...).then(...)` rather than `ctx.remove(...).flatMap(...)`.
+Generally, you will need to do `ctx.remove(...).then(...)` rather than `ctx.remove(...).flatMap(...)`.
 
 === Inserting
 
@@ -192,17 +169,19 @@ include::example$TransactionsExample.java[tag=insert,indent=0]
 include::example$TransactionsExample.java[tag=insertReactive,indent=0]
 ----
 
-== Key-Value Reads
-
-There are two ways to get a document with Key-Value, `get` and `getOptional`:
+=== Reads
 
 [source,java]
 ----
 include::example$TransactionsExample.java[tag=get,indent=0]
 ----
 
-`get` will cause the transaction to fail with `TransactionFailed` (after rolling back any changes, of course).
-It is provided as a convenience method so the developer does not have to check the `Optional` if the document must exist for the transaction to succeed.
+If the application needs to ignore or take action on a document not existing, it can catch the exception:
+
+[source,java]
+----
+include::example$TransactionsExample.java[tag=get-catch,indent=0]
+----
 
 Gets will 'read your own writes', e.g. this will succeed:
 
@@ -210,15 +189,17 @@ Gets will 'read your own writes', e.g. this will succeed:
 ----
 include::example$TransactionsExample.java[tag=getReadOwnWrites,indent=0]
 ----
+Of course, no other transaction will be able to read that inserted document, until this transaction reaches the commit point.
 
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=query-intro;!integrated-sdk-begin-transaction]
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=query-intro;!library-begin-transaction]
 
 === Using N1QL
 
-If you already use N1QL from the Java SDK, then its use in transactions is very similar.
-It returns the same `QueryResult` you are used to, and takes most of the same options.
+If you already use N1QL, then its use in transactions is very similar.
+A query returns a `TransactionQueryResult` that is very similar to the `QueryResult` you are used to, and a query takes a `TransactionQueryOptions` that provides the majority of the same options as `QueryOptions`.
 
-You must take care to write `ctx.query()` inside the lambda however, rather than `cluster.query()` or `scope.query()`.
+IMPORTANT: It's important to use the transactional `ctx.query()` inside the lambda, rather than `cluster.query()` or `scope.query()`.
+Those would be executed as regular non-transactional queries, and since the lambda can be executed multiple times, so could the statements.
 
 An example of selecting some rows from the `travel-sample` bucket:
 
@@ -331,27 +312,19 @@ include::example$TransactionsExample.java[tag=querySingleConfigured,indent=0]
 
 == Committing
 
-Committing is automatic: if there is no explicit call to `ctx.commit()` at the end of the transaction logic callback, and no exception is thrown, it will be committed.
+Committing is automatic: at the end of the lambda, if all operations have succeeded and no exception is thrown, committing will commence.
 
-With the asynchronous API, if you leave off the explicit call to `commit` then you may need to call `.then()` on the result of the chain to convert it to the required `Mono<Void>` return type:
+Committing starts with the atomic step of switching the transaction's Active Transaction Record entry to Committed.
+As soon as this is done, all its changes will be atomically visible to reads from other transactions - this is Read Atomicity.
+The individual documents will then be committed so they are visible to non-transactional actors, in an eventually consistent fashion.
 
-[source,java]
-----
-include::example$TransactionsExample.java[tag=commit,indent=0]
-----
-
-As soon as the transaction is committed, all its changes will be atomically visible to reads from other transactions.
-The changes will also be committed (or "unstaged") so they are visible to non-transactional actors, in an eventually consistent fashion.
-
-Commit is final: after the transaction is committed, it cannot be rolled back, and no further operations are allowed on it.
+Commit is final: after the atomic Committed step is reached, the transaction cannot be rolled back, and no further operations are allowed on it.
 
 An asynchronous cleanup process ensures that once the transaction reaches the commit point, it will be fully committed - even if the application crashes.
 
 
 // == A Full Transaction Example
 include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=example]
-
-A complete version of this example is available on our https://github.com/couchbaselabs/couchbase-transactions-java-examples[GitHub transactions examples page].
 
 [source,java]
 ----
@@ -362,7 +335,7 @@ include::example$TransactionsExample.java[tag=full,indent=0]
 // concurrency
 include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=concurrency]
 
-To help detect that this co-operative requirement is fulfilled, the application can subscribe to the client's event logger and check for any `IllegalDocumentState` events, like so:
+To help detect that this co-operative requirement is fulfilled, the application can subscribe to the client's event logger and check for any `IllegalDocumentStateEvent` events, like so:
 
 [source,java]
 ----
@@ -375,11 +348,15 @@ The event contains the key of the document involved, to aid the application with
 
 == Rollback
 
-If an exception is thrown, either by the application from the lambda, or by the transactions library, then that attempt is rolled back.
-The transaction logic may or may not be retried, depending on the exception.
+If an exception is thrown, either by the application from the lambda, or by the transactions logic itself (e.g. on a failed operation), then that attempt is rolled back.
+
+The application's lambda may or may not be retried, depending on the error that occurred.
+The general rule for retrying is whether the transaction is likely to succeed on a retry.
+For example, if this transaction is trying to write a document that is currently involved in another transaction (a write-write conflict), this will lead to a retry as that is likely a transient state.
+But if the transaction is trying to get a document that does not exist, it will not retry.
 //- see link:#error-handling[Error handling and logging].
 
-If the transaction is not retried then it will throw a `TransactionFailed` exception, and its `getCause` method can be used for more details on the failure.
+If the transaction is not retried then it will throw a `TransactionFailedException`, and its `getCause` method can be used for more details on the failure.
 
 The application can use this to signal why it triggered a rollback, as so:
 
@@ -388,22 +365,13 @@ The application can use this to signal why it triggered a rollback, as so:
 include::example$TransactionsExample.java[tag=rollback-cause,indent=0]
 ----
 
-The transaction can also be explicitly rolled back:
-
-[source,java]
-----
-include::example$TransactionsExample.java[tag=rollback,indent=0]
-----
-
-In this case, if `ctx.rollback()` is reached, then the transaction will be regarded as successfully rolled back and no TransactionFailed will be thrown.
-
-After a transaction is rolled back, it cannot be committed, no further operations are allowed on it, and the library will not try to automatically commit it at the end of the code block.
+After a transaction is rolled back, it cannot be committed, no further operations are allowed on it, and the SDK will not try to automatically commit it at the end of the code block.
 
 
 //  Error Handling
 include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=error]
 
-There are three exceptions that Couchbase transactions can raise to the application: `TransactionFailed`, `TransactionExpired` and `TransactionCommitAmbiguous`.
+There are three exceptions that Couchbase transactions can raise to the application: `TransactionFailedException`, `TransactionExpiredException` and `TransactionCommitAmbiguousException`.
 All exceptions derive from `TransactionFailed` for backwards-compatibility purposes.
 
 
@@ -415,9 +383,14 @@ include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=txnfaile
 include::example$TransactionsExample.java[tag=config-expiration,indent=0]
 ----
 
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=txnfailed1]
+Alternatively it can be configured at the per-transaction level:
 
-Similar to `TransactionResult`, `SingleQueryTransactionResult` also has an `unstagingComplete()` method.
+[source,java]
+----
+include::example$TransactionsExample.java[tag=config-expiration-per,indent=0]
+----
+
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=txnfailed1]
 
 === Full Error Handling Example
 
@@ -429,12 +402,19 @@ include::example$TransactionsExample.java[tag=full-error-handling,indent=0]
 ----
 
 // Asynchronous Cleanup
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=cleanup;!integrated-sdk-cleanup-collections]
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tags=cleanup;!library-cleanup-buckets]
 
 [#tuning-cleanup]
 === Configuring Cleanup
 
 The cleanup settings can be configured as so:
+
+[source,java]
+----
+include::example$TransactionsExample.java[tag=config-cleanup,indent=0]
+----
+
+The settings supported by `TransactionsCleanupConfig` are:
 
 [options="header"]
 |===
@@ -442,6 +422,7 @@ The cleanup settings can be configured as so:
 |`cleanupWindow`|60 seconds|This determines how long a cleanup 'run' is; that is, how frequently this client will check its subset of ATR documents.  It is perfectly valid for the application to change this setting, which is at a conservative default.  Decreasing this will cause expiration transactions to be found more swiftly (generally, within this cleanup window), with the tradeoff of increasing the number of reads per second used for the scanning process.
 |`cleanupLostAttempts`|true|This is the thread that takes part in the distributed cleanup process described above, that cleans up expired transactions created by any client.  It is strongly recommended that it is left enabled.
 |`cleanupClientAttempts`|true|This thread is for cleaning up transactions created just by this client.  The client will preferentially aim to send any transactions it creates to this thread, leaving transactions for the distributed cleanup process only when it is forced to (for example, on an application crash).  It is strongly recommended that it is left enabled.
+|`addCollections`|empty|Adds additional collections to the 'cleanup set' - the set of collections being cleaned up.|
 |===
 
 === Monitoring Cleanup
@@ -456,10 +437,10 @@ include::example$TransactionsExample.java[tag=cleanup-events,indent=0]
 `TransactionCleanupEndRunEvent` is raised whenever a current 'run' is finished, and contains statistics from the run.
 (A run is typically around every 60 seconds, with default configuration.)
 
-A `TransactionCleanupAttempt` event is raised when an expired transaction was found by this process, and a cleanup attempt was made.
+A `TransactionCleanupAttemptEvent` event is raised when an expired transaction was found by this process, and a cleanup attempt was made.
 It contains whether that attempt was successful, along with any logs relevant to the attempt.
 
-In addition, if cleanup fails to cleanup a transaction that is more than two hours past expiry, it will raise the `TransactionCleanupAttempt` event at WARN level (rather than the default DEBUG).
+In addition, if cleanup fails to cleanup a transaction that is more than two hours past expiry, it will raise the `TransactionCleanupAttemptEvent` event at WARN level (rather than the default DEBUG).
 With most default configurations of the event-bus (see <<Logging>> below), this will cause that event to be logged somewhere visible to the application.
 If there is not a good reason for the cleanup to be failed (such as a downed node that has not yet been failed-over), then the user is encouraged to report the issue.
 
@@ -479,42 +460,42 @@ or for the asynchronous API:
 include::example$TransactionsExample.java[tag=async_logging,indent=0]
 ----
 
+Those convenience methods are:
+[source,java]
+----
+include::example$TransactionsExample.java[tag=logger,indent=0]
+----
+Of course, the application should replace `logger.warning` with their own logging system.
+
 A failed transaction can involve dozens, even hundreds, of lines of logging, so the application may prefer to write failed transactions into a separate file.
 
-For convenience there is also a config option that will automatically write this programmatic log to the standard Couchbase Java logging configuration inherited from the SDK if a transaction fails.
-This will log all lines of any failed transactions, to `WARN` level:
-[source,java]
-----
-include::example$TransactionsExample.java[tag=config_warn,indent=0]
-----
-
-
-By default the Couchbase Java logging event-bus is setup to look for and use SLF4J/logback, log4j1, and log4j2 on the classpath, and to fallback to java.util.Logging.  
-
-Please see the xref:howtos:collecting-information-and-logging.adoc[Java SDK logging documentation] for details.
-
-Most applications will have their own preferred Java logging solution in-place already.
-For those starting from scratch here is a complete example using the basic `java.util.Logging`:
+In addition a successful transaction can be logged:
 
 [source,java]
 ----
-include::example$TransactionsExample.java[tag=full-logging,indent=0]
+include::example$TransactionsExample.java[tag=logging-success,indent=0]
 ----
-
 
 == Tracing
-
+If configured, detailed telemetry on each transaction can be output that is compatible with various external systems including OpenTelemetry and its predecessor OpenTracing.
 This telemetry is particularly useful for monitoring performance.
 
-If the underlying Couchbase Java SDK is configured for tracing, then no further work is required: transaction spans will be output automatically.
-See the xref:howtos:observability-tracing.adoc[Couchbase Java SDK Request Tracing documentation] for how to configure this.
+See the xref:howtos:observability-tracing.adoc[SDK Request Tracing documentation] for how to configure this.
+
+The tracing should currently be regarded as 'developer preview' functionality, as the spans and attributes output may change over time.
 
 === Parent Spans
 
-While the above is sufficient to use and output transaction spans, the application may wish to indicate that the transaction is part of a larger span -- for instance, a user request.
+The application may wish to indicate that the transaction is part of a larger span -- for instance, a user request.
 It can do this by passing that as a parent span.
 
-If you have an existing OpenTelemetry span you can easily convert it to a Couchbase `RequestSpan` and pass it to the transactions library:
+This can be done using the SDK's `RequestTracer` abstraction as so:
+[source,java]
+----
+include::example$TransactionsExample.java[tag=tracing,indent=0]
+----
+
+Or if you have an existing OpenTelemetry span you can easily convert it to a Couchbase `RequestSpan` and pass it to the SDK:
 
 [source,java]
 ----
@@ -524,9 +505,6 @@ include::example$TransactionsExample.java[tag=tracing-wrapped,indent=0]
 == Concurrent Operations
 The reactive API allows operations to be performed concurrently inside a transaction, which can assist performance.
 
-Any users of the reactive API are very strongly advised to use at minimum the 1.2.3 release of the transactions library.
-Prior to this there were specific rules the application had to follow to get thread-safe results, and these rules can be found in the https://docs.couchbase.com/java-sdk/3.1/howtos/distributed-acid-transactions-from-the-sdk.html#concurrent-operations-with-the-async-api[previous version of this document].
-
 An example of performing parallel operations using the reactive API:
 [source,java]
 ----
@@ -534,57 +512,24 @@ include::example$TransactionsExample.java[tag=concurrentOps,indent=0]
 ----
 
 
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=custom-metadata-1]
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=custom-metadata-1,indent=0]
 
 [source,java]
 ----
 include::example$TransactionsExample.java[tag=custom-metadata,indent=0]
 ----
 
-include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=custom-metadata-2]
-
-=== Multiple Transactions Objects
-
-Generally, an application requires only one `Transactions` object.
-But in some deployments, an application may need to access multiple custom metadata collections, and it is reasonable to create multiple `Transactions` objects as this is the only way to enable this.
-
-The library will not warn about multiple `Transactions` objects being created in this scenario.
-
-== Deferred Commits
-
-NOTE: The deferred commit feature is currently in alpha, and the API may change.
-
-Deferred commits allow a transaction to be paused just before the commit point.
-Optionally, everything required to finish the transaction can then be bundled up into a context that may be serialized into a String or byte array, and deserialized elsewhere (for example, in another process).
-The transaction can then be committed, or rolled back.
-
-The intention behind this feature is to allow multiple transactions, potentially spanning multiple databases, to be brought to just before the commit point, and then all committed together.
-
-Here's an example of deferring the initial commit and serializing the transaction:
+or at an individual transaction level with:
 
 [source,java]
 ----
-include::example$TransactionsExample.java[tag=defer1,indent=0]
+include::example$TransactionsExample.java[tag=custom-metadata-per,indent=0]
 ----
 
-And then committing the transaction later:
-
-[source,java]
-----
-include::example$TransactionsExample.java[tag=defer2,indent=0]
-----
-
-Alternatively the transaction can be rolled back:
-
-[source,java]
-----
-include::example$TransactionsExample.java[tag=defer3,indent=0]
-----
-
-The transaction expiry timer (which is configurable) will begin ticking once the transaction starts, and is not paused while the transaction is in a deferred state.
-
+include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=integrated-sdk-custom-metadata-2,indent=0]
 
 == Further Reading
 
 * There's plenty of explanation about how Transactions work in Couchbase in our xref:{version-server}@server:learn:data/transactions.adoc[Transactions documentation].
-* You can find further code examples on our https://github.com/couchbaselabs/couchbase-transactions-java-examples[transactions examples repository].
+* Couchbase transactions for Java was previously distributed as a separate library, before being integrated into the SDK.
+Users of that library are recommended to follow the xref:distributed-acid-transactions-migration-guide.adoc[migration guide].

--- a/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
+++ b/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
@@ -87,6 +87,7 @@ include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=lambda-c
 The following helper logging methods will be used throughout the examples.
 Transaction logging is too verbose to be sent to the Java SDK event-bus, so instead it is stored in an in-memory log that can be accessed both from `TransactionResult` and `TransactionFailedException`.
 It is a good practice for the application to log any failed transactions into its own logging system, here represented with a `logger` object:
+
 [source,java]
 ----
 include::example$TransactionsExample.java[tag=logger,indent=0]

--- a/modules/howtos/pages/distributed-acid-transactions-migration-guide.adoc
+++ b/modules/howtos/pages/distributed-acid-transactions-migration-guide.adoc
@@ -1,0 +1,185 @@
+= Distributed Transactions Migration Guide
+:description: For those transitioning from using the Couchbase Transactions library for Java.
+:navtitle: ACID Transactions Migration Guide
+:page-partial:
+:page-topic-type: howto
+:page-aliases: acid-transactions-migration-guide
+:page-toclevels: 2
+
+include::project-docs:partial$attributes.adoc[]
+include::partial$acid-transactions-attributes.adoc[]
+
+[abstract]
+{description}
+
+Couchbase transactions for Java were originally introduced as a library separate from the Couchbase Java SDK.
+
+We subsequently chose to integrate transactions directly into the SDKs, to make it easier for users to get started.
+
+This document details the small changes that existing users of the current transactions library need to make, to migrate to the SDK-integrated version.
+
+The existing transactions library will continue to be supported with bugfixes for some time, but new transaction features will only be added to the SDK and it is recommended that all users migrate.
+
+== Accessing transactions
+This is now done via a `Cluster` object.
+There is no longer any need to create a `Transactions` object.
+
+.Before
+[source,java]
+----
+var transactions = Transactions.create(cluster);
+
+transactions.run((ctx) -> {
+    // Your transaction logic.
+});
+----
+
+.After
+[source,java]
+----
+include::example$TransactionsMigration.java[tag=access,indent=0]
+----
+
+== Configuration
+Configuration used to be performed when creating the `Transactions` object, and is now performed when creating the `Cluster` object.
+
+.Before
+[source,java]
+----
+var transactions =
+  Transactions.create(cluster,
+    TransactionConfigBuilder.
+      .durabilityLevel(TransactionDurabilityLevel.MAJORITY)
+      .metadataCollection(collection));
+----
+
+.After
+[source,java]
+----
+include::example$TransactionsMigration.java[tag=config,indent=0]
+----
+
+A few details of configuration change:
+
+* `TransactionsConfig::metadataCollection` takes a `TransactionKeyspace` instead of a `Collection` (since a `Collection` cannot be created at this point).
+* `keyValueTimeout` has been removed from `TransactionsConfig` and `TransactionOptions`.
+* `TransactionDurabilityLevel` has been dropped in favour of using the SDK's `DurabilityLevel`.
+* `TransactionOptions` now allows a `metadataCollection` parameter.
+
+And certain classes have been renamed to be compliant with the Java SDK:
+
+[options="header"]
+|===
+|Before|After|
+|`TransactionConfigBuilder`|`TransactionsConfig`|
+|`TransactionQueryConfigBuilder`|`TransactionsQueryConfig`|
+|`SingleQueryTransactionConfigBuilder`|`SingleQueryTransactionOptions`|
+|`PerTransactionConfigBuilder`|`TransactionOptions`|
+|===
+
+=== Cleanup configuration
+Cleanup configuration options have been encapsulated into their own class:
+
+.Before
+[source,java]
+----
+var transactions =
+  Transactions.create(cluster,
+    TransactionConfigBuilder.create()
+      .cleanupClientAttempts(false)
+      .cleanupLostAttempts(false)
+      .cleanupWindow(Duration.ofSeconds(30)));
+----
+
+.After
+[source,java]
+----
+include::example$TransactionsMigration.java[tag=config-cleanup,indent=0]
+----
+
+== Lambda
+`ctx.commit()` has been removed, as it is redundant: commit automatically happens when the lambda successfully reaches the end.
+
+`ctx.rollback()` has been removed, as it too is redundant: the application can throw any exception from the lambda to trigger a rollback.
+
+`ctx.getOptional()` has been replaced with `ctx.get()` throwing a `DocumentExistsException`.
+This may be caught, allowing the transaction to continue.
+
+== Package changes
+All classes have changed packages to be compatible with the Java SDK conventions.
+
+The simplest way to convert many of the classes to their new locations is to search for `import com.couchbase.transactions.` and replace it with `import com.couchbase.client.java.transactions.`.
+
+Some additional manual conversion after this may be required.
+
+== Single query transactions
+These are now integrated with the existing SDK `QueryOptions`.
+
+.Before
+[source,java]
+----
+SingleQueryTransactionResult sqr = transactions.query("INSERT...");
+----
+
+.After
+[source,java]
+----
+include::example$TransactionsMigration.java[tag=single-query,indent=0]
+----
+
+Or with configuration:
+
+
+.Before
+[source,java]
+----
+SingleQueryTransactionResult sqr = transactions.query("INSERT...",
+  SingleQueryTransactionConfigBuilder.create()
+    .durabilityLevel(TransactionDurabilityLevel.MAJORITY));
+
+QueryResult qr = sqr.queryResult();
+----
+
+.After
+[source,java]
+----
+include::example$TransactionsMigration.java[tag=single-query-config,indent=0]
+----
+
+== Cleanup
+This doesn't impact the API, but it is useful to know that lost cleanup has changed.
+
+Previously, lost cleanup would look for expired transactions on the default collections of all buckets in the cluster.
+Unless a metadata collection was specified, in which case only that collection would be cleaned up.
+
+Now, cleanup is dynamic.
+As transactions are run, the collection where metadata is created for that collection, is added to what we call the 'cleanup set'.
+This is just the set of collections where cleanup, for this application, is looking for expired transactions.
+
+The intent has always been that users without complex requirements should never need to think about or configure transaction cleanup, and this new dynamic cleanup allows us to be closer still to that goal.
+
+== Naming
+All exceptions and events have been renamed to be compliant with the SDK.
+For example, `TransactionFailed` is now `TransactionFailedException`, and `TransactionCleanupAttempt` is now `TransactionCleanupAttemptEvent`.
+
+== Logging
+`TransactionFailedException` now exposes the logs directly, rather than containing a nested `TransactionResult`.
+
+.Before
+[source,java]
+----
+catch (TransactionFailedException err) {
+    err.result().log().logs().forEach(msg -> logger.warning(msg.toString()));
+}
+----
+
+.After
+[source,java]
+----
+include::example$TransactionsMigration.java[tag=log,indent=0]
+----
+
+== Further Reading
+
+* There's plenty of explanation about how Transactions work in Couchbase in our xref:{version-server}@server:learn:data/transactions.adoc[Transactions documentation].
+* The xref:distributed-acid-transactions-from-the-sdk.adoc[Java SDK transactions documentation].

--- a/modules/howtos/partials/acid-transactions-attributes.adoc
+++ b/modules/howtos/partials/acid-transactions-attributes.adoc
@@ -5,7 +5,7 @@
 
 
 // creating
-:lambda-attempt-ctx: pass:q[an `AttemptContext`]
+:lambda-attempt-ctx: pass:q[a `TransactionAttemptContext`]
 :collection-insert: pass:q[`collection.insert()`]
 :ctx-insert: pass:q[`ctx.insert()`]
 
@@ -16,8 +16,8 @@
 
 
 // txnfailed
-:transaction-failed: TransactionFailed
-:transaction-expired: TransactionExpired
-:transaction-config: TransactionConfigBuilder
-:transaction-commit-ambiguous: TransactionCommitAmbiguous
+:transaction-failed: TransactionFailedException
+:transaction-expired: TransactionExpiredException
+:transaction-config: TransactionsConfig
+:transaction-commit-ambiguous: TransactionCommitAmbiguousException
 :txnfailed-unstaging-complete: TransactionResult.unstagingComplete()

--- a/pom.xml
+++ b/pom.xml
@@ -10,12 +10,7 @@
         <dependency>
             <groupId>com.couchbase.client</groupId>
             <artifactId>java-client</artifactId>
-            <version>3.2.6</version>
-        </dependency>
-        <dependency>
-            <groupId>com.couchbase.client</groupId>
-            <artifactId>couchbase-transactions</artifactId>
-            <version>1.2.3</version>
+            <version>3.2.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -152,7 +147,7 @@
     <build>
         <resources>
             <resource>
-                <directory>./resources</directory>
+                <directory>modules/resources</directory>
             </resource>
         </resources>
         <plugins>
@@ -178,13 +173,13 @@
                         </goals>
                         <configuration>
                             <sources>
-                                <source>howtos/examples/</source>
-                                <source>hello-world/examples/</source>
-                                <source>project-docs/examples/</source>
-                                <source>ref/examples/</source>
-                                <source>concept-docs/examples/</source>
-                                <source>devguide/examples/</source>
-                                <source>student/examples/</source>
+                                <source>modules/howtos/examples/</source>
+                                <source>modules/hello-world/examples/</source>
+                                <source>modules/project-docs/examples/</source>
+                                <source>modules/ref/examples/</source>
+                                <source>modules/concept-docs/examples/</source>
+                                <source>modules/devguide/examples/</source>
+                                <source>modules/student/examples/</source>
                             </sources>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Adding a migration guide for existing users of the
transactions library.

Moving pom.xml to the root.  This allows opening the full
project in an IDE, which is a better development workflow.