### PR TITLE
Update GitHub links to point to modern repo

### DIFF
--- a/modules/project-docs/pages/get-involved.adoc
+++ b/modules/project-docs/pages/get-involved.adoc
@@ -4,7 +4,7 @@
 == Contributing
 
 Couchbase welcomes community contributions to the Java SDK.
-The https://github.com/couchbase/couchbase-java-client[Java SDK source code^] is available on GitHub.
-Please see the https://github.com/couchbase/couchbase-java-client/blob/master/CONTRIBUTING.md[CONTRIBUTING^] file for further information.
+The https://github.com/couchbase/couchbase-jvm-clients[Java SDK source code^] is available on GitHub.
+Please see the https://github.com/couchbase/couchbase-jvm-clients/blob/master/CONTRIBUTING.md[CONTRIBUTING^] file for further information.
 
 include::7.0@sdk:shared:partial$contrib.adoc[tag=contrib]


### PR DESCRIPTION
This change might need to be applied to other 3.x branches, too?