### PR TITLE
Change server references to 7.0 for now

### DIFF
--- a/modules/concept-docs/pages/analytics-for-sdk-users.adoc
+++ b/modules/concept-docs/pages/analytics-for-sdk-users.adoc
@@ -21,5 +21,5 @@ For complex and long-running queries, involving large ad hoc join, set, aggregat
 
 == Additional Resources
 
-* Start with our  xref:7.1@server:analytics:primer-beer.adoc[introductory primer].
+* Start with our  xref:7.0@server:analytics:primer-beer.adoc[introductory primer].
 * Read the practical introduction xref:howtos:analytics-using-sdk.adoc[using analytics from the SDK].

--- a/modules/concept-docs/pages/collections.adoc
+++ b/modules/concept-docs/pages/collections.adoc
@@ -8,7 +8,7 @@
 
 The Collections feature in Couchbase Server is fully implemented in the 3.2 API version of the Couchbase SDK.
 
-Information on _Collections_ can be found in the xref:7.1@server:learn:data/scopes-and-collections.adoc[server docs].
+Information on _Collections_ can be found in the xref:7.0@server:learn:data/scopes-and-collections.adoc[server docs].
 
 == Using Collections & Scopes
 

--- a/modules/concept-docs/pages/compression.adoc
+++ b/modules/concept-docs/pages/compression.adoc
@@ -14,7 +14,7 @@ Documents may already be stored compressed with Snappy on the server.
 New documents may be passed from client applications to the server in compressed form, saving around 40% in bandwidth (depending on the document content and size), and also transmission time.
 These operations take place automatically, after the SDK negotiates the capability with the server, and do not require any changes on the client side.
 
-For SDKs with Snappy compression enabled, documents will be automatically compressed if the xref:7.1@server:learn:buckets-memory-and-storage/compression.adoc#compression-modes[Couchbase Server] is not set to `Off` for Compression see xref:#minimum-size[see below].
+For SDKs with Snappy compression enabled, documents will be automatically compressed if the xref:7.0@server:learn:buckets-memory-and-storage/compression.adoc#compression-modes[Couchbase Server] is not set to `Off` for Compression see xref:#minimum-size[see below].
 Instructions to disable compression can be found at xref:#threshold[the bottom of the page].
 
 == Limits

--- a/modules/concept-docs/pages/documents.adoc
+++ b/modules/concept-docs/pages/documents.adoc
@@ -2,7 +2,7 @@
 :description: Couchbase supports CRUD operations, various data structures, and binary documents.
 :nav-title: Documents & Doc Ops
 :page-topic-type: concept
-:page-aliases: ROOT:documents.adoc,ROOT:documents-basics.adoc,ROOT:documents-atomic.adoc,7.1@server:developer-guide:expiry.adoc,7.1@server:developer-guide:creating-documents.adoc,ROOT:core-operations.adoc
+:page-aliases: ROOT:documents.adoc,ROOT:documents-basics.adoc,ROOT:documents-atomic.adoc,7.0@server:developer-guide:expiry.adoc,7.0@server:developer-guide:creating-documents.adoc,ROOT:core-operations.adoc
 
 [abstract]
 {description}
@@ -55,7 +55,7 @@ If you wish to only modify certain parts of a document, you can use xref:subdocu
 include::example$DocumentsExample.java[tag=mutate-in]
 ----
 
-or xref:7.1@server:n1ql:n1ql-language-reference/update.adoc[N1QL UPDATE] to update documents based on specific query criteria:
+or xref:7.0@server:n1ql:n1ql-language-reference/update.adoc[N1QL UPDATE] to update documents based on specific query criteria:
 
 [source,sql]
 ----

--- a/modules/concept-docs/pages/durability-replication-failure-considerations.adoc
+++ b/modules/concept-docs/pages/durability-replication-failure-considerations.adoc
@@ -1,7 +1,7 @@
 = Durability & Failure
 :description: Data durability refers to the fault tolerance and persistence of data in the face of software or hardware failure.
 :page-topic-type: concept
-:page-aliases: ROOT:failure-considerations,ROOT:durability,ROOT:enhanced-durability,7.1@server:developer-guide:durability.adoc
+:page-aliases: ROOT:failure-considerations,ROOT:durability,ROOT:enhanced-durability,7.0@server:developer-guide:durability.adoc
 
 
 [abstract]

--- a/modules/concept-docs/pages/n1ql-query.adoc
+++ b/modules/concept-docs/pages/n1ql-query.adoc
@@ -23,10 +23,10 @@ include::example$N1qlQueryExample.java[tag=n1ql_query_1,indent=0]
 
 == Indexes
 
-The Couchbase Query Service makes use of xref:7.1@server:learn:services-and-indexes/indexes/indexes.adoc[_indexes_] in order to do its work.
+The Couchbase Query Service makes use of xref:7.0@server:learn:services-and-indexes/indexes/indexes.adoc[_indexes_] in order to do its work.
 Indexes replicate subsets of documents from data nodes over to index nodes,
 allowing specific data (for example, specific document properties) to be retrieved quickly,
-and to distribute load away from data nodes in xref:7.1@server:learn:services-and-indexes/services/services.adoc[MDS] topologies.
+and to distribute load away from data nodes in xref:7.0@server:learn:services-and-indexes/services/services.adoc[MDS] topologies.
 
 [IMPORTANT]
 In order to make a bucket queryable, it must have at least one index defined.
@@ -59,7 +59,7 @@ Indexes help improve the performance of a query.
 When an index includes the actual values of all the fields specified in the query,
 the index _covers_ the query, and eliminates the need to fetch the actual values from the Data Service.
 An index, in this case, is called a _covering index_, and the query is called a _covered_ query.
-For more information, see xref:7.1@server:n1ql:n1ql-language-reference/covering-indexes.adoc[Covering Indexes].
+For more information, see xref:7.0@server:n1ql:n1ql-language-reference/covering-indexes.adoc[Covering Indexes].
 
 You can also create and define indexes in the SDK using:
 
@@ -100,7 +100,7 @@ include::7.1@sdk:shared:partial$n1ql-queries.adoc[tag=index-consistency]
 
 The following options are available:
 
-include::7.1@server:learn:page$services-and-indexes/indexes/index-replication.adoc[tag=scan_consistency]
+include::7.0@server:learn:page$services-and-indexes/indexes/index-replication.adoc[tag=scan_consistency]
 
 Consider the following snippet:
 
@@ -124,7 +124,7 @@ and allows optimization on a case-by-case basis.
 
 == Collections and Scopes, and the Query Context
 
-From Couchbase Server release 7.0 the xref:7.1@server:learn:data/scopes-and-collections.adoc[Collections] feature lets you logically group similar documents into Collections.
+From Couchbase Server release 7.0 the xref:7.0@server:learn:data/scopes-and-collections.adoc[Collections] feature lets you logically group similar documents into Collections.
 
 You can query collections in N1QL, by referring to a fully qualified keyspace.
 For example, to list the documents in the `airline` collection in the `inventory` scope:
@@ -134,7 +134,7 @@ For example, to list the documents in the `airline` collection in the `inventory
 SELECT * FROM `travel-sample`.inventory.airline;
 ----
 
-As a convenience, you can also query a partial keyspace from the xref:7.1@server:n1ql:n1ql-intro:sysinfo.adoc#query-context[Query Context] of a specific Scope. 
+As a convenience, you can also query a partial keyspace from the xref:7.0@server:n1ql:n1ql-intro:sysinfo.adoc#query-context[Query Context] of a specific Scope. 
 For example, from the context of `{backtick}travel-sample{backtick}.inventory`, you could abbreviate the previous query to:
 
 [source,n1ql]
@@ -142,5 +142,5 @@ For example, from the context of `{backtick}travel-sample{backtick}.inventory`, 
 SELECT * FROM airline;
 ----
 
-To do this, you can xref:7.1@server:tools:query-workbench.adoc#query-context[Set a Query Context] in the Query Workbench
+To do this, you can xref:7.0@server:tools:query-workbench.adoc#query-context[Set a Query Context] in the Query Workbench
 or xref:howtos:n1ql-queries-with-sdk.adoc#querying-at-scope-level[query at scope level] using the SDK.

--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -34,8 +34,8 @@ include::example$StartUsing.java[tags=start-using,indent=0]
 ----
 
 As well as the Java SDK (see below), and a running instance of Couchbase Server, you will need to load up the Travel Sample Bucket
-using either the xref:{version-server}@server:manage:manage-settings/install-sample-buckets.adoc#install-sample-buckets-with-the-ui[Web interface]
-or the xref:{version-server}@server:manage:manage-settings/install-sample-buckets.adoc#install-sample-buckets-with-the-cli[command line].
+using either the xref:7.0@server:manage:manage-settings/install-sample-buckets.adoc#install-sample-buckets-with-the-ui[Web interface]
+or the xref:7.0@server:manage:manage-settings/install-sample-buckets.adoc#install-sample-buckets-with-the-cli[command line].
 --
 ====
 
@@ -108,7 +108,7 @@ include::example$StartUsing.java[tags=connect,indent=0]
 --
 ====
 
-Couchbase uses xref:{version-server}@server:learn:security/roles.adoc[Role Based Access Control (RBAC)] to control access to resources.
+Couchbase uses xref:7.0@server:learn:security/roles.adoc[Role Based Access Control (RBAC)] to control access to resources.
 Here we suggest using the _Full Admin_ role created during setup of   Couchbase Capella, or a local Couchbase Server cluster.
 
 For production client code, you will want to use more appropriate, restrictive settings -- but here we want to get you up and running quickly.

--- a/modules/howtos/pages/analytics-using-sdk.adoc
+++ b/modules/howtos/pages/analytics-using-sdk.adoc
@@ -12,13 +12,13 @@
 [abstract]
 {description}
 
-For complex and long-running queries, involving large ad hoc join, set, aggregation, and grouping operations, the Couchbase Data Platform offers the xref:7.1@server:analytics:introduction.adoc[Couchbase Analytics Service (CBAS)].
+For complex and long-running queries, involving large ad hoc join, set, aggregation, and grouping operations, the Couchbase Data Platform offers the xref:7.0@server:analytics:introduction.adoc[Couchbase Analytics Service (CBAS)].
 This is the analytic counterpart to our xref:n1ql-queries-with-sdk.adoc[operational data focussed Query Service].
 The analytics service is available in Couchbase Data Platform 6.0 and later.
 
 == Getting Started
 
-After familiarizing yourself with our xref:7.1@server:analytics:primer-beer.adoc[introductory primer],
+After familiarizing yourself with our xref:7.0@server:analytics:primer-beer.adoc[introductory primer],
 in particular creating a dataset and linking it to a bucket, try Couchbase Analytics using the Java SDK.
 Intentionally, the API for analytics is nearly identical to that of the query service.
 

--- a/modules/howtos/pages/collecting-information-and-logging.adoc
+++ b/modules/howtos/pages/collecting-information-and-logging.adoc
@@ -184,6 +184,6 @@ include::example$CollectingInformationAndLogging.java[tag=collecting_information
 Different redaction levels are supported -- please see the `RedactionLevel` enum description for more information.
 
 Note that you need to run this command before any of the SDK code is initialized so all of the logs are captured properly. 
-Once the SDK writes the logs with the tags to a file, you can then use the xref:7.1@server:cli:cbcli/cblogredaction.adoc[`cblogredaction` tool] to obfuscate the log.
+Once the SDK writes the logs with the tags to a file, you can then use the xref:7.0@server:cli:cbcli/cblogredaction.adoc[`cblogredaction` tool] to obfuscate the log.
 
-* You may wish to read more on Log Redaction xref:7.1@server:manage:manage-logging/manage-logging.adoc#understanding_redaction[in the Server docs].
+* You may wish to read more on Log Redaction xref:7.0@server:manage:manage-logging/manage-logging.adoc#understanding_redaction[in the Server docs].

--- a/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
+++ b/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
@@ -538,4 +538,4 @@ include::{version-server}@sdk:shared:partial$acid-transactions.adoc[tag=integrat
 
 == Further Reading
 
-* There's plenty of explanation about how Transactions work in Couchbase in our xref:{version-server}@server:learn:data/transactions.adoc[Transactions documentation].
+* There's plenty of explanation about how Transactions work in Couchbase in our xref:7.0@server:learn:data/transactions.adoc[Transactions documentation].

--- a/modules/howtos/pages/json.adoc
+++ b/modules/howtos/pages/json.adoc
@@ -223,10 +223,10 @@ JSON has no built-in representation of dates, so commonly they are represented a
 * a string-formatted https://www.w3.org/TR/NOTE-datetime[ISO-8601^] date 
 * an offset in seconds or milliseconds from the Unix epoch 1 January 1970 UTC
 
-While it doesn't matter which you choose (as long as you serialize and deserialize your Date object consistently!) it may make sense to store the dates in Couchbase in a format that can be easily manipulated using the xref:{version-server}@server:n1ql:n1ql-language-reference/datefun.adoc[date functions in N1QL].
+While it doesn't matter which you choose (as long as you serialize and deserialize your Date object consistently!) it may make sense to store the dates in Couchbase in a format that can be easily manipulated using the xref:7.0@server:n1ql:n1ql-language-reference/datefun.adoc[date functions in N1QL].
 
 Handily, as we can see on the same page, the
-xref:{version-server}@server:n1ql:n1ql-language-reference$datefun.adoc#date-formats[supported date formats] are the usual convention in JSON.
+xref:7.0@server:n1ql:n1ql-language-reference$datefun.adoc#date-formats[supported date formats] are the usual convention in JSON.
 
 Let's look at a brief example of how we might implement this, to serialize a new Event class:
 
@@ -309,4 +309,4 @@ include::example$Json.java[tags=identify,indent=0]
 
 == Additional Resources
 
-* Read more about the xref:{version-server}@server:learn:data/data.adoc[Couchbase Data Model].
+* Read more about the xref:7.0@server:learn:data/data.adoc[Couchbase Data Model].

--- a/modules/howtos/pages/kv-operations.adoc
+++ b/modules/howtos/pages/kv-operations.adoc
@@ -285,7 +285,7 @@ NOTE: Increment & Decrement are considered part of the ‘binary’ API and as s
 
 == Scoped KV Operations
 
-It is possible to perform scoped key-value operations on named xref:7.1@server:learn:data/scopes-and-collections.adoc[`Collections`] _with Couchbase Server release 7.x_.
+It is possible to perform scoped key-value operations on named xref:7.0@server:learn:data/scopes-and-collections.adoc[`Collections`] _with Couchbase Server release 7.x_.
 See the https://docs.couchbase.com/sdk-api/couchbase-java-client/com/couchbase/client/java/Collection.html[API docs] for more information.
 
 Here is an example showing an upsert in the `users` collection, which lives in the `travel-sample.tenant_agent_00` keyspace:

--- a/modules/howtos/pages/n1ql-queries-with-sdk.adoc
+++ b/modules/howtos/pages/n1ql-queries-with-sdk.adoc
@@ -252,7 +252,7 @@ NOTE: N1QL is not the only query option in Couchbase.
 Be sure to check that xref:concept-docs:data-services.adoc[your use case fits your selection of query service].
 
 * For a deeper dive into N1QL from the SDK, refer to our xref:concept-docs:n1ql-query.adoc[N1QL SDK concept doc].
-* The xref:{version-server}@server:n1ql:n1ql-language-reference/index.adoc[Server doc N1QL intro] introduces a complete guide to the N1QL language, including all of the latest additions.
+* The xref:7.0@server:n1ql:n1ql-language-reference/index.adoc[Server doc N1QL intro] introduces a complete guide to the N1QL language, including all of the latest additions.
 * The http://query.pub.couchbase.com/tutorial/#1[N1QL interactive tutorial] is a good introduction to the basics of N1QL use.
-* For scaling up queries, be sure to xref:{version-server}@server:learn:services-and-indexes/indexes/index-replication.adoc[read up on Indexes].
+* For scaling up queries, be sure to xref:7.0@server:learn:services-and-indexes/indexes/index-replication.adoc[read up on Indexes].
 * N1QL is for operational queries; for analytical workloads, read more on xref:concept-docs:http-services.adoc#long-running-queries-big-data[when to choose Analytics], our implementation of SQL++ available in the Enterprise Edition.

--- a/modules/howtos/pages/sdk-authentication.adoc
+++ b/modules/howtos/pages/sdk-authentication.adoc
@@ -43,7 +43,7 @@ include::7.1@sdk:shared:partial$auth-overview.adoc[tag=cert-auth]
 
 == Authenticating the Java Client by Certificate
 
-For sample procedures whereby certificates can be generated and deployed, see xref:7.1@server:manage:manage-security/manage-certificates.adoc[Manage Certificates].
+For sample procedures whereby certificates can be generated and deployed, see xref:7.0@server:manage:manage-security/manage-certificates.adoc[Manage Certificates].
 The rest of this document assumes that the processes there, or something similar, have been followed.
 That is, a cluster certificate has been created and installed on the server, a client certificate has been created, and it is stored in a JVM keystore along with the cluster's certificate.
 

--- a/modules/project-docs/pages/compatibility.adoc
+++ b/modules/project-docs/pages/compatibility.adoc
@@ -74,7 +74,7 @@ Please make sure you run on one of the latest patch releases, since they provide
 == OS Compatibility
 
 In general, the JVM eliminates concerns about underlying OS compatibility, 
-and Couchbase JVM SDKs can be expected to run on all of the Operating Systems supported by xref:{version-server}@server:install:install-platforms.adoc[Couchbase Server].
+and Couchbase JVM SDKs can be expected to run on all of the Operating Systems supported by xref:7.0@server:install:install-platforms.adoc[Couchbase Server].
 
 Specifically, the 3.3 SDK is tested with the following OSs and platforms:
 

--- a/modules/project-docs/pages/distributed-acid-transactions-migration-guide.adoc
+++ b/modules/project-docs/pages/distributed-acid-transactions-migration-guide.adoc
@@ -185,5 +185,5 @@ include::example$TransactionsMigration.java[tag=log,indent=0]
 
 == Further Reading
 
-* There's plenty of explanation about how Transactions work in Couchbase in our xref:{version-server}@server:learn:data/transactions.adoc[Transactions documentation].
+* There's plenty of explanation about how Transactions work in Couchbase in our xref:7.0@server:learn:data/transactions.adoc[Transactions documentation].
 * The xref:howtos:distributed-acid-transactions-from-the-sdk.adoc[Java SDK transactions documentation].


### PR DESCRIPTION
It looks like we have a lot of broken links for server xrefs in production, and this is because we haven't published 7.1 yet.

In *theory* docs-sdk-common (which will be the only thing referenced for 7.1 after this PR) should work, but I need to test this in staging and see how it all comes together.

There is also the matter that a few partials in sdk-common reference server 7.1, I may need to change that as well after this. 
But one step at a time.