### PR TITLE
Migration guide: add note about subdoc store semantics

### DIFF
--- a/modules/project-docs/examples/MigratingSDKCodeTo3n.java
+++ b/modules/project-docs/examples/MigratingSDKCodeTo3n.java
@@ -81,6 +81,17 @@ public class MigratingSDKCodeTo3n {
     // end::migrating_sdk_code_to_3_n_22[]
   }
 
+  public void migrating_sdk_code_to_3_n_22() throws Exception {
+    // tag::subdoc_mutatein_store_semantics[]
+    collection.mutateIn(
+        "myDocument",
+        singletonList(MutateInSpec.insert("color", "blue")),
+        MutateInOptions.mutateInOptions()
+            .storeSemantics(StoreSemantics.UPSERT)
+    );
+    // end::subdoc_mutatein_store_semantics[]
+  }
+
   public static void main(String[] args) throws Exception {
     MigratingSDKCodeTo3n obj = new MigratingSDKCodeTo3n();
     obj.init();

--- a/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
+++ b/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
@@ -342,11 +342,33 @@ The following table describes the SDK 2 KV APIs and where they are now located i
 |`Bucket.unlock`                 | `Collection.unlock`
 |`Bucket.touch`                  | `Collection.touch`
 |`Bucket.lookupIn`               | `Collection.lookupIn`
-|`Bucket.mutateIn`               | `Collection.mutateIn`
+|`Bucket.mutateIn`               | `Collection.mutateIn` (see <<subdoc-store-semantics,note about store semantics>>)
 |`Bucket.counter`                | `BinaryCollection.increment` and `BinaryCollection.decrement`
 |`Bucket.append`                 | `BinaryCollection.append`
 |`Bucket.prepend`                | `BinaryCollection.prepend`
 |====
+
+[[subdoc-store-semantics]]
+[NOTE]
+====
+To migrate code that called `MutateInBuilder.upsertDocument(true)`, specify the operation's store semantics.
+For example:
+
+.SDK 2
+[source,java]
+----
+bucket.mutateIn("myDocument")
+    .insert("color", "blue")
+    .upsertDocument(true)
+    .execute();
+----
+
+.SDK 3
+[source,java]
+----
+include::example$MigratingSDKCodeTo3n.java[tag=subdoc_mutatein_store_semantics,indent=0]
+----
+====
 
 In addition, the datastructure APIs have been renamed and moved:
 


### PR DESCRIPTION
Answer the common migration question about how to migrate
MutateInBuilder.upsertDocument(true).