### PR TITLE
Removed timeoutConfig method from .builder()

### DIFF
--- a/modules/project-docs/examples/Migrating.java
+++ b/modules/project-docs/examples/Migrating.java
@@ -66,7 +66,7 @@ public class Migrating {
       // tag::timeoutbuilder[]
       // SDK 3 equivalent
       ClusterEnvironment env = ClusterEnvironment.builder()
-          .timeoutConfig(TimeoutConfig.kvTimeout(Duration.ofSeconds(5))).build();
+          .build();
       // end::timeoutbuilder[]
     }
 


### PR DESCRIPTION
Per [the ticket](https://issues.couchbase.com/browse/DOC-8174), the `timeoutConfig` method doesn't exist under `builder()`. So, this PR is to remove that text from the example code.  

JIRA has this logged against 3.1, so I'd just want to know if we should propagate this to all 3.x versions. If so, should be an easy cherry pick across branches. 