### PR TITLE
Fixed DOC-10858

### DIFF
--- a/modules/howtos/examples/ClusterExample.java
+++ b/modules/howtos/examples/ClusterExample.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+Extension of managing_connections
+file: howtos/pages/managing-connections.adoc line: 277
+ */
+
+import java.time.Duration;
+
+import com.couchbase.client.java.Bucket;
+import com.couchbase.client.java.Cluster;
+import com.couchbase.client.java.Collection;
+
+// tag::managing_connections_9[]
+public class ClusterExample {
+    public static void main(String... args) throws Exception {
+      Cluster cluster = Cluster.connect("127.0.0.1", "Administrator", "password");
+      cluster.waitUntilReady(Duration.ofSeconds(10));
+      Bucket bucket = cluster.bucket("travel-sample");
+      Collection collection = bucket.defaultCollection();
+    }
+  }
+// end::managing_connections_9[]

--- a/modules/howtos/examples/managing_connections.java
+++ b/modules/howtos/examples/managing_connections.java
@@ -69,20 +69,10 @@ public class managing_connections {
 		// end::managing_connections_8[]
 	}
 
-	public void managing_connections_9() throws Exception { // file: howtos/pages/managing-connections.adoc line: 252
-		// tag::managing_connections_9[]
-		Cluster cluster = Cluster.connect("127.0.0.1", "Administrator", "password");
-		cluster.waitUntilReady(Duration.ofSeconds(10));
-		Bucket bucket = cluster.bucket("travel-sample");
-		Collection collection = bucket.defaultCollection();
-		// end::managing_connections_9[]
-	}
-
 	public static void main(String[] args) throws Exception {
 		managing_connections obj = new managing_connections();
 		obj.init();
 		obj.managing_connections_5();
 		obj.managing_connections_8();
-		obj.managing_connections_9();
 	}
 }

--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -274,7 +274,7 @@ Or more fully:
 
 [source,java]
 ----
-include::example$managing_connections.java[tag=managing_connections_9,indent=0]
+include::example$ClusterExample.java[tag=managing_connections_9,indent=0]
 ----
 
 If you are working at the _Bucket_ level, then the https://docs.couchbase.com/sdk-api/couchbase-java-client/com/couchbase/client/java/Bucket.html#waitUntilReady-java.time.Duration-[Bucket-level `waitUntilReady`] does the same as the Cluster-level version,

--- a/modules/test/test-howtos.bats
+++ b/modules/test/test-howtos.bats
@@ -22,6 +22,11 @@ load 'test_helper'
     assert_success
 }
 
+@test "[howtos] - ClusterExample.java" {
+    runExample ClusterExample
+    assert_success
+}
+
 @test "[howtos] - CollectingInformationAndLogging.java" {
     runExample CollectingInformationAndLogging
     assert_success


### PR DESCRIPTION
This appears to have broken when the samples were changed to runnable code. The code in ClusterExample has been pulled from the original [here](https://github.com/couchbase/docs-sdk-java/blame/df0d03945d2969f2f844129c71c07e605bb8ba14/modules/howtos/pages/managing-connections.adoc#L250:~:text=public%20class%20ClusterExample%20%7B)