### PR TITLE
Release notes for 3.6.1 (copyedited and moved from release branch to temp branch)

### DIFF
--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -38,6 +38,57 @@ echo metrics-open-telemetry ; grep '<version>' $src/tracing-opentracing/pom.xml 
 echo metrics-micrometergrep '<version>' $src/metrics-micrometer/pom.xml | head -2 | tail -1 ; grep '<micrometer.version>' $src/metrics-micrometer/pom.xml 
 ////
 
+=== Version 3.6.1 (2 April 2024)
+
+This is a regular maintenance release.
+
+https://packages.couchbase.com/clients/java/3.6.1/Couchbase-Java-Client-3.6.1.zip[Download] |
+https://docs.couchbase.com/sdk-api/couchbase-java-client-3.6.1/index.html[API Reference] |
+http://docs.couchbase.com/sdk-api/couchbase-core-io-2.6.1/[Core API Reference]
+
+The supported and tested dependencies for this release are:
+
+* io.projectreactor:**reactor-core:3.6.3**
+* org.reactivestreams:**reactive-streams:1.0.4**
+
+Optional artifacts on top of this SDK version are tested for the following compatibilities:
+
+.Optional Artifact Version Compatibility
+[options="header"]
+|=======================
+| Artifact                  | Couchbase Version | Built Against              | API Stability
+| `tracing-opentelemetry`   | 1.4.1             | OpenTelemetry 1.31.0       | Committed
+| `tracing-opentracing`     | 1.4.1             | OpenTracing 0.33.0         | Committed
+| `metrics-opentelemetry`   | 0.6.1             | OpenTelemetry 1.31.0       | Volatile
+| `metrics-micrometer`      | 0.6.1             | Micrometer 1.10.9          | Volatile
+|=======================
+
+==== Improvements
+
+* https://issues.couchbase.com/browse/JVMCBC-1477[JVMCBC-1477]
+Reduced the rate at which messages appear in the server’s `http_access.log` when invalid credentials are provided resulting in 401 errors.  
+Issues resulting in 403 errors will be handled in a future release.
+* https://issues.couchbase.com/browse/JVMCBC-1498[JVMCBC-1498]
+The fields of a `SearchRow` from a Full-Text Search result are now included in the output of `SearchRow.toString()`.
+* https://issues.couchbase.com/browse/JVMCBC-1499[JVMCBC-1499]
+Disabled DNS SRV caching. The SDK now responds quicker to DNS changes in dynamic environments like Kubernetes.
+* https://issues.couchbase.com/browse/JVMCBC-1500[JVMCBC-1500]
+Added `EventingFunctionLanguageCompatibility.VERSION_7_2_0`.
+* https://issues.couchbase.com/browse/JVMCBC-1504[JVMCBC-1504]
+Deprecated static methods that return new config builders, like `TimeoutConfig.builder()` and `TimeoutConfig.kvTimeout(Duration)`.
+See the following example for the recommended way to configure client settings:
+[source,java]
+----
+Cluster cluster = Cluster.connect(
+  connectionString,
+  ClusterOptions.clusterOptions(username, password)
+    .environment(env -> env
+      .timeoutConfig(timeout -> timeout
+        .kvTimeout(Duration.ofSeconds(3))
+      )
+    )
+);
+----
 
 === Version 3.6.0 (11 March 2024)
 


### PR DESCRIPTION
Accidentally merged Michael's branch into release/3.6. Moving the 3.6.1 release note content to the temp branch, and doing a bit of copywriting to the content.