### PR TITLE
[AV-82442] Update Java release 3.6 docs for Free Tier

### DIFF
--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -34,7 +34,7 @@ Couchbase Capella Sample::
 If you are connecting to https://docs.couchbase.com/cloud/index.html[Couchbase Capella], you'll need to know the endpoint address, as well as a username and password.
 
 This example requires the Travel Sample Bucket.
-The Couchbase Capella free trial version comes with this bucket, and its Query indexes, loaded and ready.
+The Couchbase Capella perpetual free tier version comes with this bucket, and its Query indexes, loaded and ready.
 
 [source,java]
 ----
@@ -108,7 +108,7 @@ Couchbase Capella::
 * You have signed up to https://cloud.couchbase.com/sign-up[Couchbase Capella].
 
 * You have created your own bucket, or loaded the Travel Sample dataset.
-Note, the Travel Sample dataset is installed automatically by the Capella free trial.
+Note, the Travel Sample dataset is installed automatically when deploying a Capella perpetual free tier cluster.
 
 * A user is created with permissions to access the cluster (at least Application Access permissions).
 See the xref:cloud:get-started:cluster-and-data.adoc#credentials[Capella connection page] for more details.

--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -34,7 +34,7 @@ Couchbase Capella Sample::
 If you are connecting to https://docs.couchbase.com/cloud/index.html[Couchbase Capella], you'll need to know the endpoint address, as well as a username and password.
 
 This example requires the Travel Sample Bucket.
-The Couchbase Capella perpetual free tier version comes with this bucket, and its Query indexes, loaded and ready.
+The Couchbase Capella free tier version comes with this bucket, and its Query indexes, loaded and ready.
 
 [source,java]
 ----
@@ -108,7 +108,7 @@ Couchbase Capella::
 * You have signed up to https://cloud.couchbase.com/sign-up[Couchbase Capella].
 
 * You have created your own bucket, or loaded the Travel Sample dataset.
-Note, the Travel Sample dataset is installed automatically when deploying a Capella perpetual free tier cluster.
+Note, the Travel Sample dataset is installed automatically when deploying a Capella free tier cluster.
 
 * A user is created with permissions to access the cluster (at least Application Access permissions).
 See the xref:cloud:get-started:cluster-and-data.adoc#credentials[Capella connection page] for more details.

--- a/modules/howtos/pages/n1ql-queries-with-sdk.adoc
+++ b/modules/howtos/pages/n1ql-queries-with-sdk.adoc
@@ -29,7 +29,7 @@ Couchbase Capella Sample::
 +
 --
 These examples requires the Travel Sample Bucket.
-The Couchbase Capella perpetual free tier version comes with this bucket, and its Query indexes, loaded and ready.
+The Couchbase Capella free tier version comes with this bucket, and its Query indexes, loaded and ready.
 
 [source,java]
 ----

--- a/modules/howtos/pages/n1ql-queries-with-sdk.adoc
+++ b/modules/howtos/pages/n1ql-queries-with-sdk.adoc
@@ -29,7 +29,7 @@ Couchbase Capella Sample::
 +
 --
 These examples requires the Travel Sample Bucket.
-The Couchbase Capella free trial version comes with this bucket, and its Query indexes, loaded and ready.
+The Couchbase Capella perpetual free tier version comes with this bucket, and its Query indexes, loaded and ready.
 
 [source,java]
 ----


### PR DESCRIPTION
Removed mentions of trial in the Java SDK docs. Only locations found were the start-using-sdk.adoc page and the n1ql-queries-with-sdk.adoc. Used git cherry-pick from 3.4 to complete.