### PR TITLE
Update sdk-release-notes.adoc - fix Version 3.7.3 section title

### DIFF
--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -73,7 +73,7 @@ This has now been fixed.
 This has been rewritten to produce only the necessary number of threads are produced for each transaction.
 
 
-=== Version 3.7.4 (23 September 2024)
+=== Version 3.7.3 (23 September 2024)
 
 This is the third maintenance release of the 3.7 series.
 


### PR DESCRIPTION
was accidentally 3.7.4, changed to 3.7.3