### PR TITLE
Update client setting examples to use config callback.

### DIFF
--- a/modules/howtos/examples/ManagingConnections.java
+++ b/modules/howtos/examples/ManagingConnections.java
@@ -14,24 +14,29 @@
  * limitations under the License.
  */
 
+import com.couchbase.client.core.env.IoConfig;
+import com.couchbase.client.core.env.SecurityConfig;
+import com.couchbase.client.java.*;
+import com.couchbase.client.java.codec.JsonSerializer;
+import com.couchbase.client.java.env.ClusterEnvironment;
+
 import java.nio.file.Paths;
 import java.time.Duration;
 
-import com.couchbase.client.core.env.IoConfig;
-import com.couchbase.client.core.env.SecurityConfig;
-import com.couchbase.client.core.env.TimeoutConfig;
-import com.couchbase.client.java.AsyncBucket;
-import com.couchbase.client.java.AsyncCluster;
-import com.couchbase.client.java.Bucket;
-import com.couchbase.client.java.Cluster;
-import com.couchbase.client.java.ClusterOptions;
-import com.couchbase.client.java.Collection;
-import com.couchbase.client.java.ReactiveBucket;
-import com.couchbase.client.java.ReactiveCluster;
-import com.couchbase.client.java.Scope;
-import com.couchbase.client.java.env.ClusterEnvironment;
-
 public class ManagingConnections {
+
+  private static class MyCustomJsonSerializer implements JsonSerializer {
+    @Override
+    public byte[] serialize(Object o) {
+      throw new UnsupportedOperationException("just an example");
+    }
+
+    @Override
+    public <T> T deserialize(Class<T> aClass, byte[] bytes) {
+      throw new UnsupportedOperationException("just an example");
+    }
+  }
+
   public static void main(String... args) {
 
     {
@@ -61,31 +66,46 @@ public class ManagingConnections {
 
     {
       // tag::customenv[]
-      ClusterEnvironment env = ClusterEnvironment.builder()
-          // Customize client settings by calling methods on the builder
-          .build();
+      // Connect to a cluster using custom client settings.
+      Cluster cluster = Cluster.connect(
+          "127.0.0.1",
+          ClusterOptions.clusterOptions("username", "password")
+              .environment(env -> {
+                // "env" is a `ClusterEnvironment.Builder`. Customize
+                // client settings by calling builder methods.
 
-      // Create a cluster using the environment's custom client settings.
-      Cluster cluster = Cluster.connect("127.0.0.1",
-          ClusterOptions.clusterOptions("username", "password").environment(env));
+                // For example, set the default JSON serializer.
+                env.jsonSerializer(new MyCustomJsonSerializer());
 
-      // Shut down gracefully. Shut down the environment
-      // after all associated clusters are disconnected.
+                // For example, set the default SQL++ query timeout to 30 seconds.
+                env.timeoutConfig(timeout -> timeout.queryTimeout(Duration.ofSeconds(30)));
+
+                // Don't call env.build()! The SDK takes care of that.
+              })
+      );
+
+      // Shut down gracefully.
       cluster.disconnect();
-      env.shutdown();
       // end::customenv[]
     }
 
     {
       // tag::shareclusterenvironment[]
-      ClusterEnvironment env = ClusterEnvironment.builder()
-          .timeoutConfig(TimeoutConfig.kvTimeout(Duration.ofSeconds(5))).build();
+      ClusterEnvironment sharedEnvironment = ClusterEnvironment.builder()
+          .timeoutConfig(timeout -> timeout.kvTimeout(Duration.ofSeconds(5)))
+          .build();
 
-      Cluster clusterA = Cluster.connect("clusterA.example.com",
-          ClusterOptions.clusterOptions("username", "password").environment(env));
+      Cluster clusterA = Cluster.connect(
+          "clusterA.example.com",
+          ClusterOptions.clusterOptions("username", "password")
+              .environment(sharedEnvironment)
+      );
 
-      Cluster clusterB = Cluster.connect("clusterB.example.com",
-          ClusterOptions.clusterOptions("username", "password").environment(env));
+      Cluster clusterB = Cluster.connect(
+          "clusterB.example.com",
+          ClusterOptions.clusterOptions("username", "password")
+              .environment(sharedEnvironment)
+      );
 
       // ...
 
@@ -93,7 +113,7 @@ public class ManagingConnections {
       // AND shut down the custom environment when then program ends.
       clusterA.disconnect();
       clusterB.disconnect();
-      env.shutdown();
+      sharedEnvironment.shutdown();
       // end::shareclusterenvironment[]
     }
 

--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -42,15 +42,15 @@ The client fetches the full address list from the first node it is able to conta
 
 A `ClusterEnvironment` manages shared resources like thread pools, timers, and schedulers.
 It also holds the client settings.
-One way to customize the client's behavior is to build your own `ClusterEnvironment` with custom settings:
+You can customize the client's behavior by providing a callback that modifies a `ClusterEnvironment.Builder`:
 
 [source,java]
 ----
 include::example$ManagingConnections.java[tag=customenv,indent=0]
 ----
 
-TIP: If you create a `Cluster` without specifying a custom environment, the client creates a default environment used exclusively by that `Cluster`.
-This default `ClusterEnvironment` is managed completely by the Java SDK, and is automatically shut down when the associated `Cluster` is disconnected.
+TIP: When you customize the environment using a callback like in the above example, the client creates an environment that is managed completely by the Java SDK.
+This environment is automatically shut down when the associated `Cluster` is disconnected.
 
 [#connection-strings]
 == Connection Strings
@@ -95,18 +95,25 @@ If you created any `ClusterEnvironment` instances, call their `shutdown()` metho
 [#multiple-clusters]
 == Connecting to Multiple Clusters
 
-If a single application needs to connect to multiple Couchbase Server clusters, we recommend creating a single `ClusterEnvironment` and sharing it between the `Clusters`:
+If a single application needs to connect to multiple Couchbase Server clusters, it is possible to reduce the SDK's resource consumption by creating a single `ClusterEnvironment` and sharing it between the `Clusters`:
 
 [source,java]
 ----
 include::example$ManagingConnections.java[tag=shareclusterenvironment,indent=0]
 ----
 
-When you manually create a `ClusterEnvironment` like this, the SDK will not shut it down when you call `Cluster.disconnect()`.
-Instead you are responsible for shutting it down after disconnecting all clusters that share the environment.
+[WARNING]
+====
+If you manually create a `ClusterEnvironment`, be aware of these limitations:
 
-TIP: If you create a `Cluster` without specifying a custom environment, the client creates a default environment used exclusively by that `Cluster`.
-This default `ClusterEnvironment` is managed completely by the Java SDK, and is automatically shut down when the associated `Cluster` is disconnected.
+* A manually created `ClusterEnvironment` cannot be further customized by connection string parameters or Java system properties.
+
+* When you manually create a `ClusterEnvironment`, the SDK will not shut it down when you call `Cluster.disconnect()`.
+Instead, you are responsible for shutting it down after disconnecting all clusters that share the environment.
+====
+
+TIP: When connecting to a single cluster, it's usually better to customize the `ClusterEnvironment` by <<cluster-environment,providing a configuration callback>>.
+That way, the SDK automatically shuts down the environment for you, and you can customize the environment with connection string parameters and Java system properties.
 
 [#alternate-addresses]
 == Alternate Addresses and Custom Ports

--- a/modules/ref/examples/ClientSettingsExample.java
+++ b/modules/ref/examples/ClientSettingsExample.java
@@ -54,41 +54,48 @@ public class ClientSettingsExample {
 
   public void client_settings_1() throws Exception {
     // tag::client_settings_1[]
-    ClusterEnvironment env = ClusterEnvironment.builder()
-        // [Customize client settings here]
-        .build();
+    Cluster cluster = Cluster.connect(
+        connectionString,
+        ClusterOptions.clusterOptions(username, password)
+            .environment(env -> {
+              // "env" is a `ClusterEnvironment.Builder`. Customize
+              // client settings by calling builder methods.
 
-    // Create a cluster using the custom client settings.
-    Cluster cluster = Cluster.connect(connectionString, ClusterOptions
-        .clusterOptions(username, password)
-        .environment(env));
-
-    // [Your code to interact with the cluster]
-
-    // Shut down gracefully.
-    cluster.disconnect();
-    env.shutdown();
-    // end::client_settings_1[]
+              // Don't call env.build()! The SDK takes care of that.
+            })
+    );    // end::client_settings_1[]
   }
 
   public void client_settings_2() throws Exception {
     // tag::client_settings_2[]
-    ClusterEnvironment env = ClusterEnvironment.builder()
-        .timeoutConfig(TimeoutConfig
-            .kvTimeout(Duration.ofSeconds(5))
-            .queryTimeout(Duration.ofSeconds(10)))
-        .build();
+    Cluster cluster = Cluster.connect(
+        connectionString,
+        ClusterOptions.clusterOptions(username, password)
+            .environment(env -> env // ClusterEnvironment.Builder
+                .timeoutConfig(timeout -> timeout // TimeoutConfig.Builder
+                    .kvTimeout(Duration.ofSeconds(5))
+                    .queryTimeout(Duration.ofSeconds(10))
+                )
+                .ioConfig(io -> io // IoConfig.Builder
+                    .maxHttpConnections(64)
+                )
+            )
+    );
     // end::client_settings_2[]
   }
 
-  public void client_settings_3() throws Exception {
-    // tag::client_settings_3[]
-    ClusterEnvironment.Builder envBuilder = ClusterEnvironment.builder();
-    envBuilder.timeoutConfig() // returns a TimeoutConfig.Builder
-        .kvTimeout(Duration.ofSeconds(5))
-        .queryTimeout(Duration.ofSeconds(10));
-    ClusterEnvironment env = envBuilder.build();
-    // end::client_settings_3[]
+  public void client_settings_connection_string() throws Exception {
+    // tag::client_settings_connection_string[]
+    Cluster cluster = Cluster.connect(
+        "couchbase://127.0.0.1?timeout.kvTimeout=10s&timeout.queryTimeout=15s", // <1>
+        ClusterOptions.clusterOptions(username, password)
+            .environment(env -> env
+                .timeoutConfig(timeout -> timeout
+                    .kvTimeout(Duration.ofSeconds(5)) // <2>
+                )
+            )
+    );
+    // end::client_settings_connection_string[]
   }
 
   public void client_settings_4() throws Exception {
@@ -96,75 +103,104 @@ public class ClientSettingsExample {
     System.setProperty("com.couchbase.env.timeout.kvTimeout", "10s"); // <1>
     System.setProperty("com.couchbase.env.timeout.queryTimeout", "15s");
 
-    ClusterEnvironment environment = ClusterEnvironment.builder()
-        .timeoutConfig(TimeoutConfig.kvTimeout(Duration.ofSeconds(5))) // <2>
-        .build();
+    Cluster cluster = Cluster.connect(
+        "couchbase://127.0.0.1?timeout.queryTimeout=30s", // <2>
+        ClusterOptions.clusterOptions(username, password)
+            .environment(env -> env
+                .timeoutConfig(timeout -> timeout
+                    .kvTimeout(Duration.ofSeconds(5)) // <2>
+                )
+            )
+    );
     // end::client_settings_4[]
   }
 
   public void client_settings_5() throws Exception {
-    try {
-      // tag::client_settings_5[]
-      ClusterEnvironment env = ClusterEnvironment.builder()
-          .securityConfig(SecurityConfig
-              .enableTls(true)
-          )
-          .build();
-      // end::client_settings_5[]
-    } catch (InvalidArgumentException e) {
-      System.err.println(e);
-    }
+    // tag::client_settings_5[]
+    Cluster cluster = Cluster.connect(
+        connectionString,
+        ClusterOptions.clusterOptions(username, password)
+            .environment(env -> env
+                .securityConfig(security -> security
+                    .enableTls(true)
+                )
+            )
+    );
+    // end::client_settings_5[]
+    cluster.disconnect();
   }
 
   public void client_settings_6() throws Exception {
     // tag::client_settings_6[]
-    ClusterEnvironment env = ClusterEnvironment.builder()
-        .ioConfig(IoConfig
-            .networkResolution(NetworkResolution.AUTO)
-        )
-        .build();
+    Cluster cluster = Cluster.connect(
+        connectionString,
+        ClusterOptions.clusterOptions(username, password)
+            .environment(env -> env
+                .ioConfig(io -> io
+                    .networkResolution(NetworkResolution.AUTO)
+                )
+            )
+    );
     // end::client_settings_6[]
   }
 
   public void client_settings_7() throws Exception {
     // tag::client_settings_7[]
-    ClusterEnvironment env = ClusterEnvironment.builder()
-        .ioConfig(IoConfig.
-            kvCircuitBreakerConfig(CircuitBreakerConfig.builder()
-                .enabled(true)
-                .volumeThreshold(45)
-                .errorThresholdPercentage(25)
-                .sleepWindow(Duration.ofSeconds(1))
-                .rollingWindow(Duration.ofMinutes(2))
-            ))
-        .build();
+    Cluster cluster = Cluster.connect(
+        connectionString,
+        ClusterOptions.clusterOptions(username, password)
+            .environment(env -> env
+                .ioConfig(io -> io.
+                    kvCircuitBreakerConfig(kvBreaker -> kvBreaker
+                        .enabled(true)
+                        .volumeThreshold(45)
+                        .errorThresholdPercentage(25)
+                        .sleepWindow(Duration.ofSeconds(1))
+                        .rollingWindow(Duration.ofMinutes(2))
+                    )
+                )
+            )
+    );
     // end::client_settings_7[]
   }
 
   public void client_settings_8() throws Exception {
     // tag::client_settings_8[]
-    ClusterEnvironment env = ClusterEnvironment.builder()
-        .timeoutConfig(TimeoutConfig
-            .kvTimeout(Duration.ofMillis(2500))
-        )
-        .build();
+    Cluster cluster = Cluster.connect(
+        connectionString,
+        ClusterOptions.clusterOptions(username, password)
+            .environment(env -> env
+                .timeoutConfig(timeout -> timeout
+                    .kvTimeout(Duration.ofMillis(2500))
+                )
+            )
+    );
     // end::client_settings_8[]
   }
 
   public void client_settings_9() throws Exception {
     // tag::client_settings_9[]
-    ClusterEnvironment env = ClusterEnvironment.builder()
-        .compressionConfig(CompressionConfig.create().enable(true))
-        .build();
+    Cluster cluster = Cluster.connect(
+        connectionString,
+        ClusterOptions.clusterOptions(username, password)
+            .environment(env -> env
+                .compressionConfig(compression -> compression
+                    .minSize(32)
+                )
+            )
+    );
     // end::client_settings_9[]
   }
 
   public void client_settings_10() throws Exception {
     // tag::client_settings_10[]
-    ClusterEnvironment env = ClusterEnvironment.builder()
-        .retryStrategy(BestEffortRetryStrategy.INSTANCE)
-
-        .build();
+    Cluster cluster = Cluster.connect(
+        connectionString,
+        ClusterOptions.clusterOptions(username, password)
+            .environment(env -> env
+                .retryStrategy(BestEffortRetryStrategy.INSTANCE)
+            )
+    );
     // end::client_settings_10[]
   }
 
@@ -173,7 +209,6 @@ public class ClientSettingsExample {
     obj.init();
     obj.client_settings_1();
     obj.client_settings_2();
-    obj.client_settings_3();
     obj.client_settings_4();
     obj.client_settings_5();
     obj.client_settings_6();

--- a/modules/ref/pages/client-settings.adoc
+++ b/modules/ref/pages/client-settings.adoc
@@ -23,39 +23,52 @@ It is designed to apply the builder arguments in a fluent fashion and then creat
 include::example$ClientSettingsExample.java[tag=client_settings_1,indent=0]
 ----
 
-== Config Builders
+[#config-builders]
+== Nested Config Builders
 
-Environment settings are grouped into categories, with one builder class per category.
-These builders all work in the same way, which we'll illustrate by using timeout settings as an example.
+Client settings are grouped into categories, with one builder class per category.
+These builders all work in the same way, which we'll illustrate by using timeout and I/O settings as an example.
 
 Timeout settings are configured using an instance of `TimeoutConfig.Builder`.
-The usual way to create an instance is to call a static factory method on the `TimeoutConfig` class.
-The method `TimeoutConfig.builder()` returns a builder with default settings.
-There are also static factory methods that create a builder and set a configuration value in one step.
-For example, instead of `TimeoutConfig.builder().kvTimeout(...)` you can write simply `TimeoutConfig.kvTimeout(...)`.
+The usual way to get an instance is to call a configuration callback method on the `ClusterEnvironment.Builder` class.
 
-.Creating a new timeout config builder
+There's a similar class for I/O settings, called `IoConfig.Builder`.
+
+Each category of client settings has its own builder class.
+
+.Configuring client settings for timeouts and I/O
 [source,java]
 ----
 include::example$ClientSettingsExample.java[tag=client_settings_2,indent=0]
 ----
 
-Another way to obtain an instance of a config builder is to borrow it from the cluster environment builder.
-This technique may be useful if you're configuring the environment in stages and wish to preserve values set by a previous stage.
+The name of the `ClusterEnvironment.Builder` method for configuring a nested builder matches the name of the nested config class.
+For example, the `TimeoutConfig.Builder` is configured using the environment builder's `timeoutConfig` method, the `IoConfig.Builder` is configured using the `ioConfig` method, and so on.
 
-.Borrowing the existing timeout config builder
+[#connection-string-params]
+== Connection String Parameters
+
+Many client settings may also be configured by specifying a parameter in the connection string.
+
+NOTE: A connection string parameter takes precedence over the corresponding <<config-builders,builder method>>.
+
+[#duration-values]
+.Configuration via connection string parameters
 [source,java]
 ----
-include::example$ClientSettingsExample.java[tag=client_settings_3,indent=0]
+include::example$ClientSettingsExample.java[tag=client_settings_connection_string,indent=0]
 ----
+<1> When specifying durations, `s` stands for seconds.
+Other valid qualifiers are `ns` for nanoseconds, `us` for microseconds, `ms` for milliseconds, and `m` for minutes.
+<2> The `kvTimeout` value specified via `TimeoutConfig.Builder` is overridden by the `timeout.kvTimeout` connection string parameter.
+In this example, the actual `kvTimeout` is 10 seconds, and the `queryTimeout` is 15 seconds.
 
-The name of the cluster environment builder method for getting and setting each config builder always matches the name of the config class.
-For example, `TimeoutConfig` is set via the environment builder's `timeoutConfig` method, `IoConfig` is set via the `ioConfig` method, and so on.
 
 == System Properties
 
-Many client settings may also be configured by setting a Java system property.
-If a system property is set, it always takes precedence over the builder setting.
+Any client setting that can be specified as a connection string parameter may also be specified as a Java system property.
+
+NOTE: A system property takes precedence over the corresponding <<connection-string-params,connection string parameter>> or <<config-builders,builder method>>.
 
 [#duration-values]
 .Configuration via system property
@@ -65,11 +78,10 @@ include::example$ClientSettingsExample.java[tag=client_settings_4,indent=0]
 ----
 <1> When specifying durations, `s` stands for seconds.
 Other valid qualifiers are `ns` for nanoseconds, `us` for microseconds, `ms` for milliseconds, and `m` for minutes.
-<2> The `kvTimeout` value specified via `TimeoutConfig.Builder` is overridden by the system property.
+<2> The client setting specified here is overridden by the system property.
 In this example the actual `kvTimeout` is 10 seconds, and the `queryTimeout` is 15 seconds.
 
-TIP: System property names starting with `com.couchbase.env` are paths in a Java object graph rooted at the environment builder.
-Setting the property `com.couchbase.env.timeout.kvTimeout` tells the SDK to invoke `envBuilder.timeoutConfig().kvTimeout(...)` using reflection.
+TIP: The system property name for a client setting is always `com.couchbase.env.` plus the connection string parameter name.
 
 == Configuration Options
 
@@ -82,6 +94,7 @@ They are categorized into groups for
 <<compression-options,compression>>, and 
 <<general-options,general>> options.
 
+[#security-options]
 === Security Options
 
 By default the client will connect to Couchbase Server using an unencrypted connection.
@@ -93,62 +106,90 @@ If you are using the Enterprise Edition, it's possible to secure the connection 
 include::example$ClientSettingsExample.java[tag=client_settings_5,indent=0]
 ----
 
-NOTE: Unless you set `enableTls` to `true`, none of the other security settings in this section have any effect.
-
+[[security.enableTls]]
 Name: *Enabling Secure Connections*::
-Builder Method: `SecurityConfig.enableTls(boolean)`
 +
-Default:  `false`
-+
-System Property: `com.couchbase.env.security.enableTls`
+[cols="h,~"]
+|===
+| Connection{nbsp}String | `security.enableTls`
+| System{nbsp}Property   | `com.couchbase.env.security.enableTls`
+| Builder                | `env.securityConfig(it \-> it.enableTls(boolean))`
+| Default Value          | `false`
+|===
 +
 Set this to `true` to encrypt all communication between the client and server using TLS.
-This feature requires the Enterprise Edition of Couchbase Server 3.0 or later.
-If TLS is enabled you must also specify the trusted certificates by calling exactly one of `trustCertificate`, `trustCertificates`, or `trustManagerFactory`.
+This feature requires the Enterprise Edition of Couchbase Server.
++
+[TIP]
+====
+The recommended way to enable TLS is to specify a connection string that starts with the `couchbases://` (note the final "s") scheme.
+This forces a secure connection, regardless of whether `security.enableTls` is true or false.
+
+Specifying `security.enableTls` is only required when building a xref:howtos:managing-connections.adoc#multiple-clusters[shared cluster environment] for use with secure connections.
+====
++
+When TLS is enabled, you might also need to specify the trusted certificates by calling exactly one of `trustCertificate`, `trustCertificates`, or `trustManagerFactory`.
 Please see the xref:howtos:managing-connections.adoc[Managing Connections] section for more details on how to set it up properly.
 
+[[security.enableNativeTls]]
 Name: *Disabling Native TLS Provider*::
-Builder Method: `SecurityConfig.enableNativeTls(boolean)`
 +
-Default:  `true`
-+
-System Property: `com.couchbase.env.security.enableNativeTls`
+[cols="h,~"]
+|===
+| Connection{nbsp}String | `security.enableNativeTls`
+| System{nbsp}Property   | `com.couchbase.env.security.enableNativeTls`
+| Builder                | `env.securityConfig(it \-> it.enableNativeTls(boolean))`
+| Default Value          | `true`
+|===
 +
 When TLS is enabled, the client will by default use an optimized native TLS provider if one is available.
 If for some reason you need to disable the native provider and use the JDK's portable provider instead, set this to `false`.
-If `enableTls` is  `false` then `enableNativeTls` has no effect.
+If TLS is not enabled, then `security.enableNativeTls` has no effect.
 
+[[security.trustCertificate]]
 Name: *TLS Certificate Location*::
-Builder Method: `SecurityConfig.trustCertificate(Path)`
 +
-Default:  N/A
-+
-System Property: `com.couchbase.env.security.trustCertificate`
+[cols="h,~"]
+|===
+| Connection{nbsp}String | `security.trustCertificate` (or `certpath`)
+| System{nbsp}Property   | `com.couchbase.env.security.trustCertificate`
+| Builder                | `env.securityConfig(it \-> it.trustCertificate(Path))`
+| Default Value          | N/A
+|===
 +
 Path to a file containing a single X.509 certificate to trust as a Certificate Authority when establishing secure connections.
 See the xref:howtos:managing-connections.adoc#ssl[Connection Management] section for more details on how to set it up properly.
 
+[[security.trustCertificates]]
 Name: *TLS Certificates*::
-Builder Method: `SecurityConfig.trustCertificates(List<X509Certificate>)`
 +
-Default:  N/A
-+
-System Property: N/A
+[cols="h,~"]
+|===
+| Connection{nbsp}String | N/A
+| System{nbsp}Property   | N/A
+| Builder                | `env.securityConfig(it \-> it.trustCertificates(List<X509Certificate>))`
+| Default Value          | N/A
+|===
 +
 If you wish to trust more than one certificate, or prefer to load the certificate yourself, then call this method to specify the certificates to trust as Certificate Authorities when establishing secure connections.
 See the xref:howtos:managing-connections.adoc#ssl[Connection Management] section for more details on how to set it up properly.
 
+[[security.trustManagerFactory]]
 Name: *Custom TLS Trust Manager Factory*::
-Builder Method: `SecurityConfig.trustManagerFactory(TrustManagerFactory)`
 +
-Default:  N/A
-+
-System Property: N/A
+[cols="h,~"]
+|===
+| Connection{nbsp}String | N/A
+| System{nbsp}Property   | N/A
+| Builder                | `env.securityConfig(it \-> it.trustManagerFactory(TrustManagerFactory))`
+| Default Value          | N/A
+|===
 +
 As an alternative to specifying the certificates to trust, you can specify a custom `TrustManagerFactory` to use when establishing secure connections.
 See the xref:howtos:managing-connections.adoc#ssl[Connection Management] section for more details on how to set it up properly.
 
 
+[#io-options]
 === I/O Options
 
 I/O settings are represented by the Java class `IoConfig`.
@@ -160,34 +201,46 @@ The associated `ClusterEnvironment.Builder` method is called `ioConfig`.
 include::example$ClientSettingsExample.java[tag=client_settings_6,indent=0]
 ----
 
+[[io.enableDnsSrv]]
 Name: *DNS SRV Enabled*::
-Builder Method: `IoConfig.enableDnsSrv(boolean)`
 +
-Default:  `true`
-+
-System Property: `com.couchbase.env.io.enableDnsSrv`
+[cols="h,~"]
+|===
+| Connection{nbsp}String | `io.enableDnsSrv`
+| System{nbsp}Property   | `com.couchbase.env.io.enableDnsSrv`
+| Builder                | `env.ioConfig(it \-> it.enableDnsSrv(boolean))`
+| Default Value          | `true`
+|===
 +
 Gets the bootstrap node list from a DNS SRV record.
 See the xref:howtos:managing-connections.adoc#using-dns-srv-records[Connection Management] section for more information on how to use it properly.
 
+[[io.mutationTokensEnabled]]
 Name: *Mutation Tokens Enabled*::
-Builder Method: `IoConfig.mutationTokensEnabled(boolean)`
 +
-Default:  `true`
-+
-System Property: `com.couchbase.env.io.mutationTokensEnabled`
+[cols="h,~"]
+|===
+| Connection{nbsp}String | `io.mutationTokensEnabled`
+| System{nbsp}Property   | `com.couchbase.env.io.mutationTokensEnabled`
+| Builder                | `env.ioConfig(it \-> it.mutationTokensEnabled(boolean))`
+| Default Value          | `true`
+|===
 +
 Mutation tokens allow enhanced durability requirements as well as advanced {sqlpp_url}[{sqlpp} (formerly N1QL)] querying capabilities.
 Set this to `false` if you do not require these features and wish to avoid the associated overhead.
 
+[[io.networkResolution]]
 Name: *Network Resolution*::
-Builder Method: `IoConfig.networkResolution(NetworkResolution)`
 +
-Default:  `auto`
+[cols="h,~"]
+|===
+| Connection{nbsp}String | `io.networkResolution` (or `network`)
+| System{nbsp}Property   | `com.couchbase.env.io.networkResolution`
+| Builder                | `env.ioConfig(it \-> it.networkResolution(boolean))`
+| Default Value          | `auto`
+|===
 +
-System Property: `com.couchbase.env.io.networkResolution`
-+
-NOTE: The system property value should be one of `auto`, `default`, or `external` (lower case).
+NOTE: The value for the connection string parameter or system property should be one of `auto`, `default`, or `external` (lower case).
 +
 Each node in the Couchbase Server cluster might have multiple addresses associated with it.
 For example, a node might have one address that should be used when connecting from inside the same virtual network environment where the server is running, and a second address for connecting from outside the server's network environment.
@@ -196,47 +249,66 @@ By default the client will use a simple matching heuristic to determine which se
 +
 If you wish to override the heuristic, you can set this value to `default` if the client is running in the same network as the server, or `external` if the client is running in a different network.
 
+[[io.captureTraffic]]
 Name: *Capture Traffic*::
-Builder Method: `IoConfig.captureTraffic(ServiceType...)`
 +
-Default:  capture is disabled
+[cols="h,~"]
+|===
+| Connection{nbsp}String | `io.captureTraffic`
+| System{nbsp}Property   | `com.couchbase.env.io.captureTraffic`
+| Builder                | `env.ioConfig(it \-> it.captureTraffic(ServiceType...))`
+| Default Value          | traffic capture is disabled
+|===
 +
-System Property: `com.couchbase.env.io.captureTraffic`
-+
-TIP: Multiple services may be specified in the system property value using a comma-delimited list such as `KV,QUERY`.
-To enable capture for all services, set the value of the system property to an empty string.
+TIP: Multiple services may be specified in the connection string parameter or system property value using a comma-delimited list such as `KV,QUERY`.
+To enable capture for all services, set the value to an empty string.
 +
 Call this method to log all traffic to the specified services.
 If no services are specified, traffic to all services is captured.
++
+Captured traffic is logged to the `com.couchbase.io` category at `TRACE` level.
+To see the traffic, you may need to configure your logging framework to include these messages.
 
+[[io.enableTcpKeepAlives]]
 Name: *Socket Keepalive*::
-Builder Method: `IoConfig.enableTcpKeepAlives(boolean)`
 +
-Default:  `true`
-+
-System Property: `com.couchbase.env.io.enableTcpKeepAlives`
+[cols="h,~"]
+|===
+| Connection{nbsp}String | `io.enableTcpKeepAlives`
+| System{nbsp}Property   | `com.couchbase.env.io.enableTcpKeepAlives`
+| Builder                | `env.ioConfig(it \-> it.enableTcpKeepAlives(boolean))`
+| Default Value          | `true`
+|===
 +
 If enabled, the client periodically sends a TCP keepalive to the server to prevent firewalls and other network equipment from dropping idle TCP connections.
 
+[[io.tcpKeepAliveTime]]
 Name: *Socket Keepalive Interval*::
-Builder Method: `IoConfig.tcpKeepAliveTime(Duration)`
 +
-Default:  `60s`
-+
-System Property: `com.couchbase.env.io.tcpKeepAliveTime`
+[cols="h,~"]
+|===
+| Connection{nbsp}String | `io.tcpKeepAliveTime`
+| System{nbsp}Property   | `com.couchbase.env.io.tcpKeepAliveTime`
+| Builder                | `env.ioConfig(it \-> it.tcpKeepAliveTime(Duration))`
+| Default Value          | `60s`
+|===
 +
 The idle time after which a TCP keepalive gets fired.
-(This setting has no effect if `enableTcpKeepAlives` is `false`.)
+(This setting has no effect if `io.enableTcpKeepAlives` is `false`.)
 +
 NOTE: This setting only propagates to the OS on Linux when the epoll transport is used.
 On all other platforms, the OS-configured time is used (and you need to tune it there if you want to override the default interval).
 
+[[io.numKvConnections]]
 Name: *Key/Value Endpoints per Node*::
-Builder Method: `IoConfig.numKvConnections(int)`
 +
-Default:  `1`
-+
-System Property: `com.couchbase.env.io.numKvConnections`
+[cols="h,~"]
+|===
+| Connection{nbsp}String | `io.numKvConnections`
+| System{nbsp}Property   | `com.couchbase.env.io.numKvConnections`
+| Builder                | `env.ioConfig(it \-> it.numKvConnections(int))`
+| Default Value          | `1`
+|===
 +
 The number of actual endpoints (sockets) to open per node in the cluster against the Key/Value service.
 By default, for every node in the cluster one socket is opened where all traffic is pushed through.
@@ -247,35 +319,48 @@ The recommendation is keeping it at 1 unless there is other evidence.
 +
 NOTE: xref:concept-docs:durability-replication-failure-considerations.adoc#synchronous-writes[Durable Write] operations with Couchbase Server 6.5 and above require up to 16 kvEndpoints per node, for most efficient operation, unless the environment dictates something a little lower.
 
+[[io.maxHttpConnections]]
 Name: *Max HTTP Endpoints per Service per Node*::
-Builder Method: `IoConfig.maxHttpConnections(int)`
 +
-Default:  `12`
-+
-System Property: `com.couchbase.env.io.maxHttpConnections`
+[cols="h,~"]
+|===
+| Connection{nbsp}String | `io.maxHttpConnections`
+| System{nbsp}Property   | `com.couchbase.env.io.maxHttpConnections`
+| Builder                | `env.ioConfig(it \-> it.maxHttpConnections(int))`
+| Default Value          | `12`
+|===
 +
 Each service (except the Key/Value service) has a separate dynamically sized pool of HTTP connections for issuing requests.
 This setting puts an upper bound on the number of HTTP connections in each pool.
 
+[[io.idleHttpConnectionTimeout]]
 Name: *Idle HTTP Connection Timeout*::
-Builder Method: `IoConfig.idleHttpConnectionTimeout(Duration)`
 +
-Default:  `4.5s`
-+
-System Property: `com.couchbase.env.io.idleHttpConnectionTimeout`
+[cols="h,~"]
+|===
+| Connection{nbsp}String | `io.idleHttpConnectionTimeout`
+| System{nbsp}Property   | `com.couchbase.env.io.idleHttpConnectionTimeout`
+| Builder                | `env.ioConfig(it \-> it.idleHttpConnectionTimeout(Duration))`
+| Default Value          | `1s`
+|===
 +
 The length of time an HTTP connection may remain idle before it is closed and removed from the pool.
-Durations longer than 50 seconds are not recommended, since some services have a 1 minute server side idle timeout.
+Durations longer than 1 second are not recommended, since Couchbase Server aggressively drops idle connections.
 
+[[io.configPollInterval]]
 Name: *Config Poll Interval*::
-Builder Method: `IoConfig.configPollInterval(Duration)`
 +
-Default:  `2.5s`
-+
-System Property: `com.couchbase.env.io.configPollInterval`
+[cols="h,~"]
+|===
+| Connection{nbsp}String | `io.configPollInterval`
+| System{nbsp}Property   | `com.couchbase.env.io.configPollInterval`
+| Builder                | `env.ioConfig(it \-> it.configPollInterval(Duration))`
+| Default Value          | `2.5s`
+|===
 +
 The interval at which the client fetches cluster topology information in order to proactively detect changes.
 
+[#circuit-breaker-options]
 === Circuit Breaker Options
 
 Circuit breakers are a tool for preventing cascading failures.
@@ -284,7 +369,8 @@ When a circuit is closed, requests are sent to the server as normal.
 If too many requests fail within a certain time window, the breaker opens the circuit, preventing requests from going through.
 
 When a circuit is open, any requests to the service immediately fail without the client even talking to the server.
-After a "sleep delay" elapses, the next request is allowed to go through the to the server. This trial request is called a "canary."
+After a "sleep delay" elapses, the next request is allowed to go through the to the server.
+This trial request is called a "canary."
 
 Each service has an associated circuit breaker which may be configured independently of the others.
 The `IoConfig` builder has methods for configuring the circuit breakers of each service.
@@ -341,12 +427,13 @@ How long the window is in which the number of failed ops are tracked in a rollin
 [TIP]
 .Cloud Native Gateway
 ====
-If using the `couchbase2://` connection protocol with xref:howtos:managing-connections.adoc#cloud-native-gateway[Cloud Native Gateway], 
+If using the `couchbase2://` connection protocol with xref:howtos:managing-connections.adoc#cloud-native-gateway[Cloud Native Gateway],
 note that circuit breaker options are not available when using this protocol.
 The connection protocol uses a separate queue per node, and thus avoids the main cause of possible cascading failure.
 ====
 
 
+[#timeout-options]
 === Timeout Options
 
 The default timeout values are suitable for most environments, and should be adjusted only after profiling the expected latencies in your deployment environment.
@@ -356,33 +443,38 @@ Most timeouts can be overridden on a per-operation basis (for example, by passin
 The values set here are used as the defaults when no per-operation timeout is specified.
 See <<duration-values, setting duration values>> under xref:#system-properties[System Properties].
 
-Timeout settings are represented by the Java class `TimeoutConfig`.
-The associated `ClusterEnvironment.Builder` method is called `timeoutConfig`.
-
 .Template for configuring timeouts
 [source,java]
 ----
 include::example$ClientSettingsExample.java[tag=client_settings_8,indent=0]
 ----
 
+[[timeout.kvTimeout]]
 Name: *Key-Value Timeout*::
-Builder Method: `TimeoutConfig.kvTimeout(Duration)`
 +
-Default: `2.5s` -- _but see TIP, below_
-+
-System Property: `com.couchbase.env.timeout.kvTimeout`
+[cols="h,~"]
+|===
+| Connection{nbsp}String | `timeout.kvTimeout`
+| System{nbsp}Property   | `com.couchbase.env.timeout.kvTimeout`
+| Builder                | `env.timeoutConfig(it \-> it.kvTimeout(Duration))`
+| Default Value          | `2.5s` -- _but see TIP, below_
+|===
 +
 The Key/Value default timeout is used on operations which are performed on a specific key if not overridden by a custom timeout.
 This includes all commands like get(), getFromReplica() and all mutation commands, but does not include operations that are performed with enhanced durability requirements.
 +
 TIP: xref:concept-docs:durability-replication-failure-considerations.adoc#synchronous-writes[Durable Write operations] have their own timeout setting, `kvDurableTimeout`, see below.
 
+[[timeout.kvDurableTimeout]]
 Name: *Key-Value Durable Operation Timeout*::
-Builder Method: `TimeoutConfig.kvDurableTimeout(Duration)`
 +
-Default: `10s`
-+
-System Property: `com.couchbase.env.timeout.kvDurableTimeout`
+[cols="h,~"]
+|===
+| Connection{nbsp}String | `timeout.kvDurableTimeout`
+| System{nbsp}Property   | `com.couchbase.env.timeout.kvDurableTimeout`
+| Builder                | `env.timeoutConfig(it \-> it.kvDurableTimeout(Duration))`
+| Default Value          | `10s`
+|===
 +
 Key/Value operations with enhanced durability requirements may take longer to complete, so they have a separate default timeout.
 +
@@ -394,85 +486,111 @@ WARNING: The `kvDurableTimeout` property is not part of the stable API and may c
 // When there's a timeout, does it stop the sync write?
 // Does it result in an ambiguous state?
 
+[[timeout.viewTimeout]]
 Name: *View Timeout*::
-Builder Method: `TimeoutConfig.viewTimeout(Duration)`
 +
-Default: `75s`
-+
-System Property: `com.couchbase.env.timeout.viewTimeout`
+[cols="h,~"]
+|===
+| Connection{nbsp}String | `timeout.viewTimeout`
+| System{nbsp}Property   | `com.couchbase.env.timeout.viewTimeout`
+| Builder                | `env.timeoutConfig(it \-> it.viewTimeout(Duration))`
+| Default Value          | `75s`
+|===
 +
 The View timeout is used on view operations if not overridden by a custom timeout.
 Note that it is set to such a high timeout compared to key/value since it can affect hundreds or thousands of rows.
 Also, if there is a node failure during the request the internal cluster timeout is set to 60 seconds.
 
+[[timeout.queryTimeout]]
 Name: *Query Timeout*::
-Builder Method: `TimeoutConfig.queryTimeout(Duration)`
 +
-Default: `75s`
-+
-System Property: `com.couchbase.env.timeout.queryTimeout`
+[cols="h,~"]
+|===
+| Connection{nbsp}String | `timeout.queryTimeout`
+| System{nbsp}Property   | `com.couchbase.env.timeout.queryTimeout`
+| Builder                | `env.timeoutConfig(it \-> it.queryTimeout(Duration))`
+| Default Value          | `75s`
+|===
 +
 The Query timeout is used on all {sqlpp} query operations if not overridden by a custom timeout.
 Note that it is set to such a high timeout compared to key/value since it can affect hundreds or thousands of rows.
 
+[[timeout.searchTimeout]]
 Name: *Search Timeout*::
-Builder Method: `TimeoutConfig.searchTimeout(Duration)`
 +
-Default: `75s`
-+
-System Property: `com.couchbase.env.timeout.searchTimeout`
+[cols="h,~"]
+|===
+| Connection{nbsp}String | `timeout.searchTimeout`
+| System{nbsp}Property   | `com.couchbase.env.timeout.searchTimeout`
+| Builder                | `env.timeoutConfig(it \-> it.searchTimeout(Duration))`
+| Default Value          | `75s`
+|===
 +
 The Search timeout is used on all FTS operations if not overridden by a custom timeout.
 Note that it is set to such a high timeout compared to key/value since it can affect hundreds or thousands of rows.
 
+[[timeout.analyticsTimeout]]
 Name: *Analytics Timeout*::
-Builder Method: `TimeoutConfig.analyticsTimeout(Duration)`
 +
-Default: `75s`
-+
-System Property: `com.couchbase.env.timeout.analyticsTimeout`
+[cols="h,~"]
+|===
+| Connection{nbsp}String | `timeout.analyticsTimeout`
+| System{nbsp}Property   | `com.couchbase.env.timeout.analyticsTimeout`
+| Builder                | `env.timeoutConfig(it \-> it.analyticsTimeout(Duration))`
+| Default Value          | `75s`
+|===
 +
 The Analytics timeout is used on all Analytics query operations if not overridden by a custom timeout.
 Note that it is set to such a high timeout compared to key/value since it can affect hundreds or thousands of rows.
 
+[[timeout.connectTimeout]]
 Name: *Connect Timeout*::
-Builder Method: `TimeoutConfig.connectTimeout(Duration)`
 +
-Default: `10s`
-+
-System Property: `com.couchbase.env.timeout.connectTimeout`
+[cols="h,~"]
+|===
+| Connection{nbsp}String | `timeout.connectTimeout`
+| System{nbsp}Property   | `com.couchbase.env.timeout.connectTimeout`
+| Builder                | `env.timeoutConfig(it \-> it.connectTimeout(Duration))`
+| Default Value          | `10s`
+|===
 +
 The connect timeout is used when a Bucket is opened and if not overridden by a custom timeout.
 If you feel the urge to change this value to something higher, there is a good chance that your network is not properly set up.
 Connecting to the server should in practice not take longer than a second on a reasonably fast network.
 
+[[timeout.disconnectTimeout]]
 Name: *Disconnect Timeout*::
-Builder Method: `TimeoutConfig.disconnectTimeout(Duration)`
 +
-Default: `10s`
-+
-System Property: `com.couchbase.env.timeout.disconnectTimeout`
+[cols="h,~"]
+|===
+| Connection{nbsp}String | `timeout.disconnectTimeout`
+| System{nbsp}Property   | `com.couchbase.env.timeout.disconnectTimeout`
+| Builder                | `env.timeoutConfig(it \-> it.disconnectTimeout(Duration))`
+| Default{nbsp}Value     | `10s`
+|===
 +
 The disconnect timeout is used when a Cluster is disconnected and if not overridden by a custom timeout.
 A timeout is applied here always to make sure that your code does not get stuck at shutdown.
 The default should provide enough time to drain all outstanding operations properly, but make sure to adapt this timeout to fit your application requirements.
 
+[[timeout.managementTimeout]]
 Name: *Management Timeout*::
-Builder Method: `TimeoutConfig.managementTimeout(Duration)`
 +
-Default: `75s`
-+
-System Property: `com.couchbase.env.timeout.managementTimeout`
+[cols="h,~"]
+|===
+| Connection{nbsp}String | `timeout.managementTimeout`
+| System{nbsp}Property   | `com.couchbase.env.timeout.managementTimeout`
+| Builder                | `env.timeoutConfig(it \-> it.managementTimeout(Duration))`
+| Default Value          | `75s`
+|===
 +
 The management timeout is used on all cluster management APIs (BucketManager, UserManager, CollectionManager, QueryIndexManager, etc.) if not overridden by a custom timeout.
 The default is quite high because some operations (such as flushing a bucket, for example) might take a long time.
 
+[#compression-options]
 === Compression Options
 
 The client can optionally compress documents before sending them to Couchbase Server.
-
-Compression settings are represented by the Java class `CompressionConfig`.
-The associated `ClusterEnvironment.Builder` method is called `compressionConfig`.
 
 .Template for configuring CompressionExample settings
 [source,java]
@@ -480,32 +598,44 @@ The associated `ClusterEnvironment.Builder` method is called `compressionConfig`
 include::example$ClientSettingsExample.java[tag=client_settings_9,indent=0]
 ----
 
+[[compression.enable]]
 Name: *Enabling Compression*::
-Builder Method: `CompressionConfig.enabled`
 +
-Default: `true`
-+
-System Property: `com.couchbase.env.compression.enable(boolean)`
+[cols="h,~"]
+|===
+| Connection{nbsp}String | `compression.enable`
+| System{nbsp}Property   | `com.couchbase.env.compression.enable`
+| Builder                | `env.compressionConfig(it \-> it.enable(boolean))`
+| Default Value          | `true`
+|===
 +
 If enabled, the client will compress documents before they are sent to Couchbase Server.
-If this is set to `false`, the other CompressionExample settings have no effect.
+If this is set to `false`, the other compression settings have no effect.
 
+[[compression.minSize]]
 Name: *Document Minimum Size*::
-Builder Method: `CompressionConfig.minSize(int)`
 +
-Default: `32`
-+
-System Property: `com.couchbase.env.compression.minSize`
+[cols="h,~"]
+|===
+| Connection{nbsp}String | `compression.minSize`
+| System{nbsp}Property   | `com.couchbase.env.compression.minSize`
+| Builder                | `env.compressionConfig(it \-> it.minSize(int))`
+| Default Value          | `32`
+|===
 +
 Size in bytes.
 Documents smaller than this size are never compressed.
 
+[[compression.minRatio]]
 Name: *Document Minimum Compressibility*::
-Builder Method: `CompressionConfig.minRatio(double)`
 +
-Default: `0.83`
-+
-System Property: `com.couchbase.env.compression.minRatio`
+[cols="h,~"]
+|===
+| Connection{nbsp}String | `compression.minRatio`
+| System{nbsp}Property   | `com.couchbase.env.compression.minRatio`
+| Builder                | `env.compressionConfig(it \-> it.minRatio(int))`
+| Default Value          | `0.83`
+|===
 +
 A floating point value between 0 and 1.
 Specifies how "compressible" a document must be in order for the compressed form to be sent to the server.
@@ -516,6 +646,7 @@ If the compressed document size divided by the uncompressed document size is gre
 +
 For example, with a `minRatio` of `0.83`, CompressionExample will only be used if the size of the compressed document is less than 83% of the uncompressed document size.
 
+[#general-options]
 === General Options
 
 The settings in this category apply to the client in general.
@@ -527,12 +658,16 @@ They are configured directly on the `ClusterEnvironment.Builder`.
 include::example$ClientSettingsExample.java[tag=client_settings_10,indent=0]
 ----
 
+[[retryStrategy]]
 Name: *Retry Strategy*::
-Builder Method: `retryStrategy(RetryStrategy)`
 +
-Default:  `BestEffortRetryStrategy.INSTANCE`
-+
-System Property: N/A
+[cols="h,~"]
+|===
+| Connection{nbsp}String | N/A
+| System{nbsp}Property   | N/A
+| Builder                | `env.retryStrategy(RetryStrategy)`
+| Default Value          | `BestEffortRetryStrategy.INSTANCE`
+|===
 +
 The client's default retry strategy.
 +
@@ -548,11 +683,14 @@ See the advanced section in the documentation on more specific information on re
 
 [#unordered-executions]
 Name: *Unordered Execution*::
-Builder Method: `unorderedExecutionEnabled(boolean)`
 +
-Default:  `true`
-+
-System Property: `com.couchbase.unorderedExecutionEnabled`
+[cols="h,~"]
+|===
+| Connection{nbsp}String | N/A
+| System{nbsp}Property   | com.couchbase.unorderedExecutionEnabled
+| Builder                | N/A
+| Default Value          | `true`
+|===
 +
 From Couchbase 7.0, Out-of-Order execution allows the server to concurrently handle multiple requests on the same connection, potentially improving performance for durable writes and multi-document ACID transactions.
 This means that tuning the number of connections (KV endpoints) is no longer necessary as a workaround where data not available in the cache is causing timeouts.
@@ -561,12 +699,16 @@ This is set to `true` by default.
 // Server will handle any operations that are not safe to be executed out of order, and setting this to `false` is unlikely to ever be necessary.
 Note, changing the setting will only affect Server versions 7.0 onwards.
 
+[[jsonSerializer]]
 Name: *JSON Serializer*::
-Builder Method: `jsonSerializer(JsonSerializer)`
 +
-Default:  _see below_
-+
-System Property: N/A
+[cols="h,~"]
+|===
+| Connection{nbsp}String | N/A
+| System{nbsp}Property   | N/A
+| Builder                | `env.jsonSerializer(JsonSerializer)`
+| Default Value          | _see description below_
+|===
 +
 The JSON serializer handles the conversion between JSON and Java objects.
 +
@@ -577,12 +719,16 @@ TIP: To create a serializer backed by a custom `ObjectMapper`, call `JacksonJson
 If Jackson is not present, the client will fall back to using an unspecified default serializer.
 (Actually, it will use a repackaged version of Jackson, but this is an implementation detail you should not depend on.)
 
+[[transcoder]]
 Name: *Transcoder*::
-Builder Method: `transcoder(Transcoder)`
 +
-Default: `JsonTranscoder`
-+
-System Property: N/A
+[cols="h,~"]
+|===
+| Connection{nbsp}String | N/A
+| System{nbsp}Property   | N/A
+| Builder                | `env.transcoder(Transcoder)`
+| Default Value          | `JsonTranscoder`
+|===
 +
 The transcoder is responsible for converting KV binary packages to and from Java objects.
 +
@@ -592,12 +738,16 @@ When writing documents it sets the appropriate flags to indicate the document co
 +
 The transcoder configured here is just the default; it can be overridden on a per-operation basis.
 
+[[requestTracer]]
 Name: *Request Tracer*::
-Builder Method: `requestTracer(RequestTracer)`
 +
-Default:  `ThresholdRequestTracer`
-+
-System Property: N/A
+[cols="h,~"]
+|===
+| Connection{nbsp}String | N/A
+| System{nbsp}Property   | N/A
+| Builder                | `env.requestTracer(RequestTracer)`
+| Default Value          | `ThresholdRequestTracer`
+|===
 +
 The default tracer logs the slowest requests per service.
 +
@@ -606,12 +756,16 @@ It is recommended to use those modules and not write your own tracer unless abso
 +
 NOTE: When using a non-default tracer, you are responsible for starting and stopping it.
 
+[[scheduler]]
 Name: *Computation Scheduler*::
-Builder Method: `scheduler(Scheduler)`
 +
-Default: _see below_
-+
-System Property: N/A
+[cols="h,~"]
+|===
+| Connection{nbsp}String | N/A
+| System{nbsp}Property   | N/A
+| Builder                | `env.scheduler(Scheduler)`
+| Default Value          | _see below_
+|===
 +
 This is an advanced setting that should not be modified without good reason.
 +
@@ -622,12 +776,16 @@ Extra care should be used when changing the scheduler, since many internal compo
 NOTE: Shutting down the cluster environment will not dispose of a custom scheduler.
 You are responsible for disposing of it after it is no longer needed.
 
+[[eventBus]]
 Name: *Event Bus*::
-Builder Method: `eventBus(EventBus)`
 +
-Default:  `DefaultEventBus`
-+
-System Property: N/A
+[cols="h,~"]
+|===
+| Connection{nbsp}String | N/A
+| System{nbsp}Property   | N/A
+| Builder                | `eventBus(EventBus)`
+| Default Value          | `DefaultEventBus`
+|===
 +
 This is an advanced setting that should not be modified without good reason.
 +
@@ -644,7 +802,16 @@ You are responsible for stopping it after it is no longer needed.
 
 include::{version-common}@sdk:shared:partial$client-settings-wide-network.adoc[]
 
+
 == Configuration Profiles
+
+[cols="h,~"]
+|===
+| Connection{nbsp}String | applyProfile
+| System{nbsp}Property   | com.couchbase.env.applyProfile
+| Builder                | `applyProfile(String)`
+| Default Value          | no profile
+|===
 
 Configuration Profiles provide predefined client settings that allow you to quickly configure an environment for common use-cases.
 When using a configuration profile, the current client settings are overridden with the values provided in the profile.
@@ -654,9 +821,9 @@ CAUTION: The Configuration Profiles feature is currently a xref:java-sdk:project
 
 === WAN Development
 
-*Builder Method:* `applyProfile("wan-development")`
+*Builder Method:* `env.applyProfile("wan-development")`
 
-A `wan-development` configuration profile can be used to modify client settings for development or high-latency environments.
+The `wan-development` configuration profile can be used to modify client settings for development or high-latency environments.
 This profile changes the default timeouts.
 
 


### PR DESCRIPTION
Motivation
----------
Config callback has advantages over manually creating your own ClusterEnvironment:

* Enables using connection string parameters and Java system properties to configure client settings.

* It's harder for the user to accidentally clobber client settings set by other parts of their code.

* The SDK automatically shuts down the environment for you, eliminating a potential resource leak.

Modifications
-------------
Update code snippets to use config callback.

Add an anchor for each client setting.

Use tables to structure client setting info.

Document connection string parameter names.

Fix `io.idleHttpConnectionTimeout` default value (a while ago it was reduced from 4.5s to 1s)

Warn that manually-created ClusterEnvironments are incompatible with connection string parameters and Java system properties.

Document that `couchbases://` overrides the `security.enableTls` setting.