### PR TITLE
aliases.adoc & !topic-type

### DIFF
--- a/modules/concept-docs/pages/analytics-for-sdk-users.adoc
+++ b/modules/concept-docs/pages/analytics-for-sdk-users.adoc
@@ -2,7 +2,7 @@
 :description: Parallel data management for complex queries over many records, using a familiar SQL-like syntax.
 :nav-title: Analytics for SDK Users
 :page-topic-type: concept
-:page-aliases: analytics,
+:page-aliases: analytics.adoc
 
 [abstract]
 {description}

--- a/modules/concept-docs/pages/buckets-and-clusters.adoc
+++ b/modules/concept-docs/pages/buckets-and-clusters.adoc
@@ -2,7 +2,7 @@
 :description: The Couchbase Java SDK provides an API for managing a Couchbase cluster programmatically.
 :navtitle: Buckets & Clusters
 :page-topic-type: concept
-:page-aliases: managing-clusters
+:page-aliases: managing-clusters.adoc
 
 include::project-docs:partial$attributes.adoc[]
 

--- a/modules/concept-docs/pages/compression.adoc
+++ b/modules/concept-docs/pages/compression.adoc
@@ -2,7 +2,7 @@
 :description: In response to increasing volumes of data being sent over the wire, Couchbase Data Platform provides data compression between the SDK and Couchbase Server.
 :page-topic-type: concept
 :page-edition: Enterprise Edition
-:page-aliases:../../ROOT/pages/compression-intro.adoc
+:page-aliases:ROOT:compression-intro.adoc
 include::project-docs:partial$attributes.adoc[]
 
 [abstract]

--- a/modules/concept-docs/pages/data-model.adoc
+++ b/modules/concept-docs/pages/data-model.adoc
@@ -2,7 +2,7 @@
 :description: Couchbase's use of JSON as a storage format allows powerful search and query over documents.
 :nav-title: Data Model
 :page-toclevels: 2
-:page-aliases: ROOT:datastructures
+:page-aliases: ROOT:datastructures.adoc
 
 include::project-docs:partial$attributes.adoc[]
 

--- a/modules/concept-docs/pages/n1ql-query.adoc
+++ b/modules/concept-docs/pages/n1ql-query.adoc
@@ -1,7 +1,6 @@
 = Query
 :description: Parallel data management for complex queries over many records, using a familiar SQL-like syntax.
-:page-topic-type: concept
-:page-aliases: ROOT:n1ql-query,ROOT:prepared-statements,ROOT:querying
+:page-aliases: ROOT:n1ql-query.adoc,ROOT:prepared-statements.adoc,ROOT:querying.adoc
 
 include::project-docs:partial$attributes.adoc[]
 

--- a/modules/concept-docs/pages/nonjson.adoc
+++ b/modules/concept-docs/pages/nonjson.adoc
@@ -1,8 +1,7 @@
 = Non-JSON Documents
 :description: Binary formats & Transcoders.
 :nav-title: Non-JSON
-:page-aliases: ROOT:nonjson
-:page-topic-type: concept
+:page-aliases: ROOT:nonjson.adoc
 
 include::project-docs:partial$attributes.adoc[]
 

--- a/modules/concept-docs/pages/xattr.adoc
+++ b/modules/concept-docs/pages/xattr.adoc
@@ -1,8 +1,7 @@
 = XATTR and Virtual XATTR
 :description: Extended Attributes (XATTR) are metadata that can be provided on a per-application basis.
 :nav-title: XATTR
-:page-topic-type: concept
-:page-aliases: sdk-xattr-overview,ROOT:sdk-xattr-overview
+:page-aliases: sdk-xattr-overview.adoc,ROOT:sdk-xattr-overview.adoc
 
 include::project-docs:partial$attributes.adoc[]
 

--- a/modules/hello-world/pages/sample-application.adoc
+++ b/modules/hello-world/pages/sample-application.adoc
@@ -1,7 +1,7 @@
 = Quickstart in Couchbase with Spring Boot and Java
 :page-toclevels: 2
 :description: Quickstart app to build a REST API using Couchbase Capella in Java using Spring Boot
-:page-aliases: ROOT:sample-application,ROOT:tutorial4,ROOT:sample-app-backend
+:page-aliases: ROOT:sample-application.adoc,ROOT:tutorial4.adoc,ROOT:sample-app-backend.adoc
 
 
 

--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -1,5 +1,5 @@
 = Hello World
-:page-aliases: ROOT:getting-started.adoc,ROOT:start-using.adoc,ROOT:hello-couchbase.adoc,ROOT:start-using-sdk.adoc,ROOT:java-intro,ROOT:tutorial
+:page-aliases: ROOT:getting-started.adoc,ROOT:start-using.adoc,ROOT:hello-couchbase.adoc,ROOT:start-using-sdk.adoc,ROOT:java-intro.adoc,ROOT:tutorial.adoc
 :page-toclevels: 3
 :description: Install, connect, try. A quick start guide to get you up and running with Couchbase and the {name-sdk}.
 :forum-link: https://www.couchbase.com/forums/c/java-sdk/5
@@ -29,7 +29,8 @@ but first let's look at those data operations, and installing the {name-sdk}.
 
 // remember to add a nomenclature note to the next version of this page for LCB.
 
-.Upsert with Replication set to Majority Durablity
+.Upsert with Replication set to xref:concept-docs:data-durability-acid-transactions.adoc#durable-writes[Majority Durablity]:
+
 [source,java]
 ----
 include::devguide:example$java/Overview.java[tag=overview,indent=0]

--- a/modules/howtos/pages/analytics-using-sdk.adoc
+++ b/modules/howtos/pages/analytics-using-sdk.adoc
@@ -1,12 +1,7 @@
 = Analytics
 :description: Parallel data management for complex queries over many records, using a familiar SQL-like syntax.
-:page-topic-type: howto
-:page-aliases: analytics-query
+:page-aliases: analytics-query.adoc
 :page-edition: Enterprise Edition
-:lang: Java
-:version: 3.2.1
-:example-source: 3.2@java-sdk:howtos:example$Analytics.java
-:example-source-lang: java
 
 [abstract]
 {description}

--- a/modules/howtos/pages/concurrent-async-apis.adoc
+++ b/modules/howtos/pages/concurrent-async-apis.adoc
@@ -1,7 +1,6 @@
 = Async and Reactive APIs
 :description: The Java SDK offers efficient, non-blocking alternatives to the regular blocking API.
-:page-topic-type: howto
-:page-aliases: ROOT:async-programming,ROOT:batching-operations,multiple-apis,ROOT:documents-bulk,ROOT:observables
+:page-aliases: ROOT:async-programming.adoc,ROOT:batching-operations.adoc,multiple-apis.adoc,ROOT:documents-bulk.adoc,ROOT:observables.adoc
 
 [abstract]
 {description} This page outlines the different options with their drawbacks and benefits.

--- a/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
+++ b/modules/howtos/pages/distributed-acid-transactions-from-the-sdk.adoc
@@ -2,7 +2,7 @@
 :reftext: Distributed ACID Transactions from the Java SDK
 :description: A practical guide on using Couchbase Distributed ACID transactions, via the Java SDK.
 :page-partial:
-:page-aliases: acid-transactions
+:page-aliases: acid-transactions.adoc
 :page-toclevels: 2
 :page-pagination: next
 

--- a/modules/howtos/pages/encrypting-using-sdk.adoc
+++ b/modules/howtos/pages/encrypting-using-sdk.adoc
@@ -1,6 +1,5 @@
 = Encrypting Your Data
 :description: A practical guide for getting started with Field-Level Encryption, showing how to encrypt and decrypt JSON fields using the Java SDK.
-:page-topic-type: howto
 :page-edition: Enterprise Edition
 :page-aliases: ROOT:encrypting-using-sdk.adoc
 

--- a/modules/howtos/pages/error-handling.adoc
+++ b/modules/howtos/pages/error-handling.adoc
@@ -1,10 +1,7 @@
 = Handling Errors
 :description: Errors are inevitable. That's why the SDK has very extensive error handling and retry capabilties
 :navtitle: Handling Errors
-:page-topic-type: howto
-:page-aliases: ROOT:handling-error-conditions,handling-error-conditions,errors,handling-errors
-:source-language: java
-:lang: java
+:page-aliases: ROOT:handling-error-conditions.adoc,handling-error-conditions.adoc,errors.adoc,handling-errors.adoc
 
 [abstract]
 {description} which are focussed on one goal:

--- a/modules/howtos/pages/full-text-searching-with-sdk.adoc
+++ b/modules/howtos/pages/full-text-searching-with-sdk.adoc
@@ -1,7 +1,7 @@
 = Search
 :description: You can use the Full Text Search service (FTS) to create queryable full-text indexes in Couchbase Server.
 :page-toclevels: 2
-:page-aliases: ROOT:search-query, ROOT:full-text-searching-with-sdk.adoc
+:page-aliases: ROOT:search-query.adoc, ROOT:full-text-searching-with-sdk.adoc
 
 [abstract]
 {description}

--- a/modules/howtos/pages/json.adoc
+++ b/modules/howtos/pages/json.adoc
@@ -1,8 +1,6 @@
 = JSON Modelling
 :description: The Java SDK supports multiple options for working with JSON.
 :navtitle: JSON Modelling
-:page-topic-type: howto
-:lang: Java
 :page-toclevels: 2
 
 include::project-docs:partial$attributes.adoc[]

--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -1,8 +1,7 @@
 = Managing Connections
 :description: This section describes how to connect the Java SDK to a Couchbase cluster.
 :navtitle: Managing Connections
-:page-topic-type: howto
-:page-aliases: ROOT:managing-connections,howtos:multi-network,ROOT:connecting,ROOT:connection-advanced
+:page-aliases: ROOT:managing-connections.adoc,howtos:multi-network.adoc,ROOT:connecting.adoc,ROOT:connection-advanced.adoc
 :page-toclevels: 2
 
 include::project-docs:partial$attributes.adoc[]

--- a/modules/howtos/pages/observability-orphan-logger.adoc
+++ b/modules/howtos/pages/observability-orphan-logger.adoc
@@ -1,6 +1,5 @@
 = Orphaned Requests Logging
 :description: In addition to request tracing and metrics reporting, logging orphaned requests provides additional insight into why an operation might have timed out (or got cancelled for a different reason).
-:page-topic-type: howto
 
 [abstract]
 {description}

--- a/modules/howtos/pages/sdk-authentication.adoc
+++ b/modules/howtos/pages/sdk-authentication.adoc
@@ -1,8 +1,7 @@
 = Authentication
 :description: As well as Role-Based Access Control (RBAC), Couchbase offers connection with Certificate Authentication, and works transparently with LDAP.
-:page-topic-type: howto
 :page-edition: Enterprise Edition
-:page-aliases: ROOT:sdk-authentication-overview
+:page-aliases: ROOT:sdk-authentication-overview.adoc
 
 include::project-docs:partial$attributes.adoc[]
 

--- a/modules/howtos/pages/subdocument-operations.adoc
+++ b/modules/howtos/pages/subdocument-operations.adoc
@@ -1,12 +1,7 @@
 = Sub-Document Operations
 :description: Sub-Document operations can be used to efficiently access and change parts of documents.
-:page-topic-type: howto
-include::project-docs:partial$attributes.adoc[]
-:lang: Java
-:version: 3.2.1
 :page-aliases: ROOT:sdk-xattr-example.adoc
 
-include::project-docs:partial$attributes.adoc[]
 
 [abstract]
 {description}

--- a/modules/howtos/pages/transactions-single-query.adoc
+++ b/modules/howtos/pages/transactions-single-query.adoc
@@ -1,7 +1,6 @@
 = Single Query Transactions
 :description: Learn how to perform bulk-loading transactions with the SDK.
 :page-partial:
-:page-topic-type: howto
 :page-pagination: full
 
 include::project-docs:partial$attributes.adoc[]

--- a/modules/howtos/pages/transactions-tracing.adoc
+++ b/modules/howtos/pages/transactions-tracing.adoc
@@ -1,7 +1,6 @@
 = Tracing
 :description: Tracing Couchbase Distributed ACID transactions.
 :page-partial:
-:page-topic-type: howto
 :page-pagination: full
 
 [abstract]

--- a/modules/howtos/pages/transcoders-nonjson.adoc
+++ b/modules/howtos/pages/transcoders-nonjson.adoc
@@ -1,7 +1,6 @@
 = Transcoders and Non-JSON Documents
 :description: The Java SDK supports common JSON document requirements out-of-the-box.
 :nav-title: Using Transcoders
-:page-topic-type: howtos
 
 [abstract]
 {description}

--- a/modules/howtos/pages/view-queries-with-sdk.adoc
+++ b/modules/howtos/pages/view-queries-with-sdk.adoc
@@ -1,10 +1,8 @@
 = MapReduce Views
 :description: Our legacy MapReduce Views Service is best replaced by the scalable Query Service.
 :navtitle: MapReduce Views
-:page-topic-type: howto
-:page-aliases: ROOT:view-queries-with-sdk,ROOT:geo-spatial-views
+:page-aliases: ROOT:view-queries-with-sdk.adoc,ROOT:geo-spatial-views.adoc
 
-include::project-docs:partial$attributes.adoc[]
 
 [abstract]
 {description}

--- a/modules/project-docs/pages/3.0-pre-release-notes.adoc
+++ b/modules/project-docs/pages/3.0-pre-release-notes.adoc
@@ -1,7 +1,6 @@
 = Pre-release Archive Release Notes
 :description: Release notes for the 3.0 Alpha & Beta Releases
 :navtitle: α & β Release Notes
-:page-topic-type: project-doc
 :page-aliases: 3.0αλφα-sdk-release-notes
 
 [abstract] 

--- a/modules/project-docs/pages/compatibility.adoc
+++ b/modules/project-docs/pages/compatibility.adoc
@@ -1,7 +1,7 @@
 = Compatibility
 :description: Platform compatibility, and features available in different SDK versions, and compatibility between Server and SDK. \
 Plus notes on Cloud, networks, and AWS Lambda.
-:page-aliases: ROOT:overview,ROOT:compatibility-versions-features,compatibility-versions-features
+:page-aliases: ROOT:overview.adoc,ROOT:compatibility-versions-features.adoc,compatibility-versions-features.adoc
 :page-toclevels: 3
 :table-caption!:
 

--- a/modules/project-docs/pages/distributed-acid-transactions-migration-guide.adoc
+++ b/modules/project-docs/pages/distributed-acid-transactions-migration-guide.adoc
@@ -2,7 +2,6 @@
 :description: For those transitioning from using the Couchbase Transactions library for Java.
 :page-toclevels: 2
 
-include::project-docs:partial$attributes.adoc[]
 
 [abstract]
 {description}

--- a/modules/project-docs/pages/get-involved.adoc
+++ b/modules/project-docs/pages/get-involved.adoc
@@ -1,7 +1,6 @@
 = Get Involved
 :navtitle: Get Involved
 
-include::project-docs:partial$attributes.adoc[]
 
 == Contributing
 

--- a/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
+++ b/modules/project-docs/pages/migrating-sdk-code-to-3.n.adoc
@@ -3,7 +3,7 @@
 Collections and Scopes are introduced.
 :page-toclevels: 2
 :nav-title: Migrating to Java SDK 3.x API
-:page-aliases: ROOT:migrate
+:page-aliases: ROOT:migrate.adoc
 
 
 [abstract]

--- a/modules/project-docs/pages/sdk-full-installation.adoc
+++ b/modules/project-docs/pages/sdk-full-installation.adoc
@@ -1,7 +1,6 @@
 = Full Installation
 :description: Installation instructions for the Couchbase Java Client.
 :page-partial:
-:page-topic-type: project-doc
 
 [abstract]
 {description}

--- a/modules/project-docs/pages/sdk-licenses.adoc
+++ b/modules/project-docs/pages/sdk-licenses.adoc
@@ -1,6 +1,5 @@
 = Licenses
 :description: Couchbase SDKs' source code is licensed under the Apache Licence 2.0.
-:page-topic-type: project-doc
 :page-aliases: ROOT:sdk-licenses.adoc
 
 [abstract]

--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -1,10 +1,9 @@
 = SDK Release Notes
 :description: Release notes, installation instructions, and download archive for the Couchbase Java Client.
 :navtitle: Release Notes
-:page-topic-type: project-doc
 :page-toclevels: 2
 :page-partial:
-:page-aliases: relnotes-java-sdk,ROOT:sdk-release-notes,ROOT:relnotes-java-sdk,ROOT:release-notes,ROOT:download-links,server:sdks:java-2.2/download-links
+:page-aliases: relnotes-java-sdk.adoc,ROOT:sdk-release-notes.adoc,ROOT:relnotes-java-sdk.adoc,ROOT:release-notes.adoc,ROOT:download-links.adoc,server:sdks:java-2.2/download-links.adoc
 
 [abstract]
 {description}

--- a/modules/project-docs/pages/third-party-integrations.adoc
+++ b/modules/project-docs/pages/third-party-integrations.adoc
@@ -1,8 +1,6 @@
 = 3^rd^ Party Integrations
 :description: The Couchbase Java SDK is often used with unofficial and third party tools and applications to integrate into broader language and platform ecosystems, and across data lakes in heterogeneous environments.
-:page-topic-type: project-doc
 
-include::project-docs:partial$attributes.adoc[]
 
 [abstract]
 

--- a/modules/ref/pages/client-settings.adoc
+++ b/modules/ref/pages/client-settings.adoc
@@ -1,8 +1,7 @@
 = Client Settings
 :description: pass:q[The `ClusterEnvironment` class enables you to configure Java SDK options for security, timeouts, reliability, and performance.]
 :nav-title: Client Settings
-:page-topic-type: reference
-:page-aliases: ROOT:client-settings, ROOT:env-config
+:page-aliases: ROOT:client-settings.adoc, ROOT:env-config.adoc
 :page-toclevels: 2
 
 include::project-docs:partial$attributes.adoc[]

--- a/modules/ref/pages/error-codes.adoc
+++ b/modules/ref/pages/error-codes.adoc
@@ -1,9 +1,7 @@
 = Error Messages
 :description: The standardized error codes returned by the Couchbase Java SDK, from cloud connection to sub-document.
 :nav-title: Error Codes
-:page-topic-type: ref
 
-include::project-docs:partial$attributes.adoc[]
 
 [abstract]
 {description}


### PR DESCRIPTION
Adding .adoc to page-aliases - avoids Antora warning, and ready for deprecation