### PR TITLE
DOC-13089 fix broken link by correcting attribute

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -4,12 +4,6 @@ title: Java SDK
 start_page: hello-world:overview.adoc
 nav:
 - modules/ROOT/nav.adoc
-ext:
-  preview:
-    HEAD:
-      sources:
-        docs-sdk-common:
-          branches: release/7.7
 asciidoc:
   attributes:
     page-nav-header-levels: 1

--- a/modules/howtos/pages/managing-connections.adoc
+++ b/modules/howtos/pages/managing-connections.adoc
@@ -266,7 +266,7 @@ The protocol implements a gRPC-style interface between the SDK and Couchbase Ser
 
 The underlying protocol will not work with certain legacy features: MapReduce Views (a deprecated Service -- 
 use xref:howtos:n1ql-queries-with-sdk.adoc[Query] instead) and 
-Memcached buckets (superseded by the improved xref:{server_version}@server:learn:buckets-memory-and-storage/buckets.adoc#bucket-types[Ephemeral Buckets]).
+Memcached buckets (superseded by the improved xref:{version-server}@server:learn:buckets-memory-and-storage/buckets.adoc#bucket-types[Ephemeral Buckets]).
 
 The following are not currently implemented over the `couchbase2://` protocol:
 

--- a/modules/howtos/pages/sdk-authentication.adoc
+++ b/modules/howtos/pages/sdk-authentication.adoc
@@ -44,7 +44,7 @@ include::{version-common}@sdk:shared:partial$auth-overview.adoc[tag=cert-auth]
 
 == Authenticating the Java Client by Certificate
 
-To learn how to generate and deploy certificates, see xref:{server_version}@server:manage:manage-security/manage-certificates.adoc[Manage Certificates].
+To learn how to generate and deploy certificates, see xref:{version-server}@server:manage:manage-security/manage-certificates.adoc[Manage Certificates].
 The rest of this section assumes you followed those processes, or did something similar.
 
 For the following example, you will need a client certificate and the associated private key.

--- a/preview/DOC-13089-fix-broken-link.yml
+++ b/preview/DOC-13089-fix-broken-link.yml
@@ -1,0 +1,5 @@
+sources:
+  docs-sdk-common:
+    branches: release/7.7
+  docs-server:
+    branches: release/7.6

--- a/preview/HEAD.yml
+++ b/preview/HEAD.yml
@@ -1,0 +1,3 @@
+sources:
+  docs-sdk-common:
+    branches: release/7.7


### PR DESCRIPTION
Preview URL:
https://preview.docs-test.couchbase.com/docs-sdk-java-DOC-13089-fix-broken-link/java-sdk/current/howtos/sdk-authentication.html#authenticating-the-java-client-by-certificate

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

![image](https://github.com/user-attachments/assets/6f20cc9f-d1e9-40a0-a928-4c97230eabbb)


Looks like the wrong attribute `{server_version}` was used, breaking the link.

NOTE: there is one other example of this in the source, which we'll fix shortly.