### PR TITLE
Fix otel.yaml config file in otel metrics exaple

### DIFF
--- a/modules/howtos/pages/observability-metrics.adoc
+++ b/modules/howtos/pages/observability-metrics.adoc
@@ -148,7 +148,9 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: '0.0.0.0:4317'
       http:
+        endpoint: '0.0.0.0:4318'
 
 exporters:
   logging:


### PR DESCRIPTION
By default the receivers listen to `localhost`, so an SDK outside the docker container is unable to reach it. For this example to work we should specify `0.0.0.0`. Judging from the docs, this sounds like a recent change: https://opentelemetry.io/docs/collector/configuration/#basics