### PR TITLE
Release notes for 3.11.2

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -8,7 +8,7 @@ asciidoc:
   attributes:
     page-nav-header-levels: 2
     server_version: '8.0.0'
-    sdk_current_version: '3.11.1'
+    sdk_current_version: '3.11.2'
     sdk_dot_minor: '3.11'
     sdk_dot_major: '3.x'
     version-server: '8.0'

--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -44,6 +44,39 @@ echo metrics-opentelemetry ; grep '<version>' $src/metrics-opentelemetry/pom.xml
 echo metrics-micrometer ; grep '<version>' $src/metrics-micrometer/pom.xml | head -2 | tail -1 ; grep '<micrometer.version>' $src/pom.xml 
 ////
 
+=== Version 3.11.2 (13 April 2026)
+
+https://packages.couchbase.com/clients/java/3.11.2/Couchbase-Java-Client-3.11.2.zip[Download] |
+https://docs.couchbase.com/sdk-api/couchbase-java-client-3.11.2/index.html[API Reference] |
+https://docs.couchbase.com/sdk-api/couchbase-core-io-3.11.2/[Core API Reference]
+
+This maintenance release upgrades Netty and Jackson to the latest versions.
+
+The supported and tested dependencies for this release are:
+
+* io.projectreactor:**reactor-core:3.6.9**
+* org.reactivestreams:**reactive-streams:1.0.4**
+
+Optional artifacts on top of this SDK version are tested for the following compatibilities:
+
+.Optional Artifact Version Compatibility
+[options="header"]
+|=======================
+| Artifact                  | Built Against              | API Stability
+| `tracing-opentelemetry`   | OpenTelemetry 1.57.0       | Committed
+| `tracing-opentracing`     | OpenTracing 0.33.0         | Committed
+| `metrics-opentelemetry`   | OpenTelemetry 1.57.0       | Volatile
+| `metrics-micrometer`      | Micrometer 1.12.9          | Volatile
+|=======================
+
+==== Improvements
+
+* https://jira.issues.couchbase.com/browse/JVMCBC-1726[JVMCBC-1726]:
+Upgraded Netty from to `4.2.9` to `4.2.12`.
+
+* https://jira.issues.couchbase.com/browse/JVMCBC-1723[JVMCBC-1723]:
+Upgraded Jackson from `2.20.1` to `2.21.2`.
+
 
 === Version 3.11.1 (16 February 2026)
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>com.couchbase.client</groupId>
+                <artifactId>couchbase-client-bom</artifactId>
+                <version>3.11.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-bom</artifactId>
                 <version>1.17.0</version>
@@ -22,7 +29,6 @@
         <dependency>
             <groupId>com.couchbase.client</groupId>
             <artifactId>java-client</artifactId>
-            <version>3.11.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -54,12 +60,10 @@
         <dependency>
             <groupId>com.couchbase.client</groupId>
             <artifactId>metrics-opentelemetry</artifactId>
-            <version>0.8.0</version>
         </dependency>
         <dependency>
             <groupId>com.couchbase.client</groupId>
             <artifactId>tracing-opentelemetry</artifactId>
-            <version>1.6.0</version>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>


### PR DESCRIPTION
and in the example pom.xml, use our BOM to align the metrics and tracing library versions with the SDK version.