### PR TITLE
Release 3.6.4.

### DIFF
--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -1039,6 +1039,42 @@ Adds support for base64-encoded vectors in `VectorQuery`.
 
 == Java SDK 3.6 Releases
 
+=== Version 3.6.4 (26 April 2026)
+
+This is a maintenance release.
+
+https://packages.couchbase.com/clients/java/3.6.4/Couchbase-Java-Client-3.6.4.zip[Download] |
+https://docs.couchbase.com/sdk-api/couchbase-java-client-3.6.4/index.html[API Reference] |
+http://docs.couchbase.com/sdk-api/couchbase-core-io-2.6.4/[Core API Reference]
+
+The supported and tested dependencies for this release are:
+
+* io.projectreactor:**reactor-core:3.6.3**
+* org.reactivestreams:**reactive-streams:1.0.4**
+
+Optional artifacts on top of this SDK version are tested for the following compatibilities:
+
+.Optional Artifact Version Compatibility
+[options="header"]
+|=======================
+| Artifact                  | Couchbase Version | Built Against              | API Stability
+| `tracing-opentelemetry`   | 1.4.2             | OpenTelemetry 1.31.0       | Committed
+| `tracing-opentracing`     | 1.4.2             | OpenTracing 0.33.0         | Committed
+| `metrics-opentelemetry`   | 0.6.2             | OpenTelemetry 1.31.0       | Volatile
+| `metrics-micrometer`      | 0.6.2             | Micrometer 1.10.9          | Volatile
+|=======================
+
+==== Improvements
+
+* https://issues.couchbase.com/browse/JVMCBC-1729[JVMCBC-1729]:
+This release allows configuration of a socket option, `TCP_USER_TIMEOUT`, which configures the OS to detect dead TCP connections more quickly than waiting for a global OS-level TCP timeout.
+The default for this option is 20 seconds.
+The default may be overridden to a value between 1 and 120 seconds using the `io.tcpUserTimeout` setting in `ClusterEnvironment`.
+For example, on the ClusterEnvironment.Builder, you would call `.ioConfig(io -> io.tcpUserTimeout(Duration.ofSeconds(30))` to set the timeout to 30 seconds.
+Please note that this setting only propagates to the OS on Linux when the default epoll transport is used.
+On all other platforms, the OS-configured time is used (and you need to tune it there if you want to customize the default behavior).
+This change is a backport of a change originally targeted to the 3.12 release.
+
 === Version 3.6.3 (19 August 2024)
 
 This is a regular maintenance release.

--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -1071,8 +1071,10 @@ This release allows configuration of a socket option, `TCP_USER_TIMEOUT`, which 
 The default for this option is 20 seconds.
 The default may be overridden to a value between 1 and 120 seconds using the `io.tcpUserTimeout` setting in `ClusterEnvironment`.
 For example, on the ClusterEnvironment.Builder, you would call `.ioConfig(io -> io.tcpUserTimeout(Duration.ofSeconds(30))` to set the timeout to 30 seconds.
++
 Please note that this setting only propagates to the OS on Linux when the default epoll transport is used.
 On all other platforms, the OS-configured time is used (and you need to tune it there if you want to customize the default behavior).
++
 This change is a backport of a change originally targeted to the 3.12 release.
 
 === Version 3.6.3 (19 August 2024)

--- a/modules/project-docs/pages/sdk-release-notes.adoc
+++ b/modules/project-docs/pages/sdk-release-notes.adoc
@@ -1070,7 +1070,7 @@ Optional artifacts on top of this SDK version are tested for the following compa
 This release allows configuration of a socket option, `TCP_USER_TIMEOUT`, which configures the OS to detect dead TCP connections more quickly than waiting for a global OS-level TCP timeout.
 The default for this option is 20 seconds.
 The default may be overridden to a value between 1 and 120 seconds using the `io.tcpUserTimeout` setting in `ClusterEnvironment`.
-For example, on the ClusterEnvironment.Builder, you would call `.ioConfig(io -> io.tcpUserTimeout(Duration.ofSeconds(30))` to set the timeout to 30 seconds.
+For example, on the `ClusterEnvironment.Builder`, you would call `.ioConfig(io -> io.tcpUserTimeout(Duration.ofSeconds(30))` to set the timeout to 30 seconds.
 +
 Please note that this setting only propagates to the OS on Linux when the default epoll transport is used.
 On all other platforms, the OS-configured time is used (and you need to tune it there if you want to customize the default behavior).


### PR DESCRIPTION
This release contains a backport of a Linux socket option, `TCP_USER_TIMEOUT` to be more resilient of networks which may allow TCP connections to become stale.