### PR TITLE
Clarify which JDKs we test and support

### DIFF
--- a/modules/hello-world/pages/platform-help.adoc
+++ b/modules/hello-world/pages/platform-help.adoc
@@ -34,16 +34,16 @@ To install the JDK we are going to use a JVM-management tool called `sdkman`.
 
 === SDKMAN!
 
-SDKMAN! -- the Software Development Kit Manager -- enables multiple Java versions and runtimes to be installed and managed, without intefering with your system's default JVM.
+SDKMAN! -- the Software Development Kit Manager -- enables multiple Java versions and runtimes to be installed and managed, without interfering with your system's default JVM.
 
 This third party tool is unnecessary in most production environments, but ideal for development machines.
 Installation instructions can be found on the https://sdkman.io/install[SDKMAN! website]. 
 
-Once SDKMAN! is installed, use it to install the latest version of Java:
+Once SDKMAN! is installed, use it to install the latest stable version of Java:
 
 [source,console]
 ----
-$ sdk install java 23.0.2-oracle
+$ sdk install java
 ----
 
 You may be prompted to set that version as a default -- say yes (by pressing *<Enter>*).

--- a/modules/hello-world/pages/start-using-sdk.adoc
+++ b/modules/hello-world/pages/start-using-sdk.adoc
@@ -90,7 +90,7 @@ For the example code below to run, you'll need the username and password of the 
 
 === Prerequisites
 
-* The Java SDK is tested against LTS versions of Oracle JDK and OpenJDK -- 
+* The Java SDK is tested against LTS versions of OpenJDK --
 see the xref:project-docs:compatibility.adoc#jdk-compat[compatibility docs].
 +
 https://adoptium.net/[OpenJDK {java_latest_lts_version} with HotSpot JVM] is recommended.

--- a/modules/project-docs/pages/compatibility.adoc
+++ b/modules/project-docs/pages/compatibility.adoc
@@ -30,7 +30,7 @@ The following OpenJDK releases are supported:
 * https://adoptium.net/[OpenJDK 11 with HotSpot JVM]
 * https://adoptium.net/[OpenJDK 8 with HotSpot JVM]
 
-The following Oracle JDK releases are supported but do not receive the same level of testing due to Oracle license issues:
+The following Oracle JDK releases are also supported but we do not do any testing with them owing to Oracle license issues:
 
 * https://www.oracle.com/java/technologies/downloads/#java17[Oracle JDK 17]
 * https://www.oracle.com/java/technologies/downloads/#java11[Oracle JDK 11]

--- a/modules/project-docs/pages/compatibility.adoc
+++ b/modules/project-docs/pages/compatibility.adoc
@@ -27,7 +27,7 @@ The following OpenJDK releases are supported:
 * https://adoptium.net/[OpenJDK 25 with HotSpot JVM] (recommended)
 * https://adoptium.net/[OpenJDK 21 with HotSpot JVM]
 * https://adoptium.net/[OpenJDK 17 with HotSpot JVM]
-* https://adoptium.net/[OpenJDK 11] (Hotspot recommended)
+* https://adoptium.net/[OpenJDK 11 with HotSpot JVM]
 * https://adoptium.net/[OpenJDK 8 with HotSpot JVM]
 
 The following Oracle JDK releases are supported but do not receive the same level of testing due to Oracle license issues:

--- a/modules/project-docs/pages/compatibility.adoc
+++ b/modules/project-docs/pages/compatibility.adoc
@@ -10,7 +10,7 @@ Plus notes on Cloud, networks, and AWS Lambda.
 {description}
 
 
-The {sdk_dot_minor} SDK requires Java 8 or later to be installed.
+The {sdk_dot_minor} SDK requires Java 8 or later.
 _Java {java_latest_lts_version} is recommended_.
 
 
@@ -20,22 +20,26 @@ _Java {java_latest_lts_version} is recommended_.
 
 === JDK Version Compatibility
 
-The {name-sdk} is tested with Oracle JDK and OpenJDK.
-Other JDK implementations might work but are not tested and are unsupported.
-We recommend running the latest LTS version (i.e. at the time of writing JDK {java_latest_lts_version}) with the highest patch version available.
+We test the {name-sdk} with https://adoptium.net/[Eclipse Temurin] versions 8, 17, 21, and 25.
 
-The following JDK releases are supported:
+The following OpenJDK releases are supported:
 
 * https://adoptium.net/[OpenJDK 25 with HotSpot JVM] (recommended)
 * https://adoptium.net/[OpenJDK 21 with HotSpot JVM]
 * https://adoptium.net/[OpenJDK 17 with HotSpot JVM]
-* https://www.oracle.com/java/technologies/downloads/#jdk17[Oracle JDK 17]
-* https://adoptium.net/[OpenJDK 11] (Hotspot recommended) or https://www.oracle.com/java/technologies/downloads/#jdk11[Oracle JDK 11]
-* https://adoptium.net/[OpenJDK 1.8 with HotSpot JVM]
-* https://www.oracle.com/java/technologies/downloads/#java8[Oracle JDK 1.8]
+* https://adoptium.net/[OpenJDK 11] (Hotspot recommended)
+* https://adoptium.net/[OpenJDK 8 with HotSpot JVM]
 
-Please make sure you run on one of the latest patch releases, since they provide stability improvements and security fixes in general.
+The following Oracle JDK releases are supported but do not receive the same level of testing due to Oracle license issues:
 
+* https://www.oracle.com/java/technologies/downloads/#java17[Oracle JDK 17]
+* https://www.oracle.com/java/technologies/downloads/#java11[Oracle JDK 11]
+* https://www.oracle.com/java/technologies/downloads/#java8[Oracle JDK 8]
+
+Other JDK implementations might work but are untested and unsupported.
+
+[TIP]
+Make sure to stay up to date with JDK patch releases because they provide stability improvements and security fixes.
 
 
 === OS Compatibility

--- a/modules/project-docs/pages/sdk-full-installation.adoc
+++ b/modules/project-docs/pages/sdk-full-installation.adoc
@@ -19,7 +19,7 @@ If you're upgrading your application from Java SDK 2.x, please read our xref:pro
 
 == Prerequisites
 
-The Java SDK is tested against LTS versions of Oracle JDK and OpenJDK -- see our xref:project-docs:compatibility.adoc#jdk-compat[compatibility docs].
+The Java SDK is tested against LTS versions OpenJDK -- see our xref:project-docs:compatibility.adoc#jdk-compat[compatibility docs].
 The underlying OS normally makes no difference, but library incompatibilities in Alpine Linux makes a xref:project-docs:compatibility.adoc#alpine-linux-compatibility[workaround] necessary for this OS.
 
 


### PR DESCRIPTION
Move the Oracle JDKs to a separate list and call out that they receive less testing.

Update the SDKMAN! example so it always installs the latest stable version of Eclipse Temurin instead of an obsolete version of the Oracle JDK.